### PR TITLE
Fix alert route condition `one_of` operation breaking every apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Fix `Provider produced inconsistent result after apply` on `incident_alert_route` when a condition uses `operation = "one_of"` (or `not_one_of`) on a String alert attribute. The API accepts that value but stores and returns the substring-matching equivalent (`contains_one_of` / `not_contains_one_of`), so the read-back disagreed with the plan and every apply failed, tainting the route so it never converged. The provider now preserves the planned operation when the API returns exactly that known normalisation. A genuine operation change, or any other divergence, is still surfaced. Applies to both the v2 and v3 alert route schemas.
+
 ## v6.1.0
 
 - Add optional `retry_config` to `incident_escalation_path` levels, allowing you

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- Fix `Provider produced inconsistent result after apply` on `incident_alert_route` when a condition uses `operation = "one_of"` (or `not_one_of`) on a String alert attribute. The API accepts that value but stores and returns the substring-matching equivalent (`contains_one_of` / `not_contains_one_of`), so the read-back disagreed with the plan and every apply failed, tainting the route so it never converged. The provider now preserves the planned operation when the API returns exactly that known normalisation. A genuine operation change, or any other divergence, is still surfaced. Applies to both the v2 and v3 alert route schemas.
+- Fix `Provider produced inconsistent result after apply` when a condition uses an operation alias that the API renames on read. `operation = "one_of"` on a String alert attribute reads back as `contains_one_of`. `operation = "contains"` on a catalog entry reads back as `name_contains`. The state then disagreed with the plan, so every apply failed and left the resource tainted. The provider now keeps the planned operation when the API returns exactly the canonical name of the alias it sent. It still reports a real operation change, or any other difference. This covers `incident_alert_route` (v2 and v3 schemas), `incident_workflow` and `incident_maintenance_window`.
 
 ## v6.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 ## Unreleased
 
-- Fix `Provider produced inconsistent result after apply` when a condition uses an operation alias that the API renames on read. `operation = "one_of"` on a String alert attribute reads back as `contains_one_of`. `operation = "contains"` on a catalog entry reads back as `name_contains`. The state then disagreed with the plan, so every apply failed and left the resource tainted. The provider now keeps the planned operation when the API returns exactly the canonical name of the alias it sent. It still reports a real operation change, or any other difference. This covers `incident_alert_route` (v2 and v3 schemas), `incident_workflow` and `incident_maintenance_window`.
-
 ## v6.1.0
 
 - Add optional `retry_config` to `incident_escalation_path` levels, allowing you

--- a/internal/provider/incident_alert_route_operation_alias_test.go
+++ b/internal/provider/incident_alert_route_operation_alias_test.go
@@ -1,0 +1,89 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+)
+
+// TestAccIncidentAlertRouteOperationAlias reproduces ONC-12602 against the real
+// API: `one_of` on a String alert attribute is an alias the API returns as
+// `contains_one_of`. Before the fix the create step failed with "Provider
+// produced inconsistent result after apply". The second step re-applies the same
+// config to prove the refresh path holds the alias too, rather than showing a
+// permanent diff.
+func TestAccIncidentAlertRouteOperationAlias(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIncidentAlertRouteOperationAliasConfig("one_of"),
+				Check: resource.TestCheckResourceAttr(
+					"incident_alert_route.alias", "condition_groups.0.conditions.0.operation", "one_of"),
+			},
+			{
+				Config: testAccIncidentAlertRouteOperationAliasConfig("one_of"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+			},
+			// The canonical name must still round-trip: we only ever swap back to
+			// what the config asked for.
+			{
+				Config: testAccIncidentAlertRouteOperationAliasConfig("contains_one_of"),
+				Check: resource.TestCheckResourceAttr(
+					"incident_alert_route.alias", "condition_groups.0.conditions.0.operation", "contains_one_of"),
+			},
+		},
+	})
+}
+
+func testAccIncidentAlertRouteOperationAliasConfig(operation string) string {
+	return fmt.Sprintf(`
+resource "incident_alert_attribute" "alias" {
+  name  = %[1]q
+  type  = "String"
+  array = false
+}
+
+resource "incident_alert_route" "alias" {
+  name       = %[2]q
+  enabled    = true
+  is_private = false
+
+  alert_sources = []
+  expressions   = []
+
+  condition_groups = [{
+    conditions = [{
+      subject        = "alert.attributes.${incident_alert_attribute.alias.id}"
+      operation      = %[3]q
+      param_bindings = [{ array_value = [{ literal = "org/repo" }] }]
+    }]
+  }]
+
+  grouping_config = {
+    default = {
+      enabled = false
+    }
+  }
+
+  message_config = {
+    destinations = []
+  }
+
+  escalation_config = {
+    auto_cancel_escalations = true
+    escalation_targets      = []
+  }
+
+  incident_config = {
+    enabled          = false
+    condition_groups = []
+  }
+}
+`, StableSuffix("alias-attr"), StableSuffix("alias-route"), operation)
+}

--- a/internal/provider/incident_maintenance_window_resource.go
+++ b/internal/provider/incident_maintenance_window_resource.go
@@ -237,7 +237,7 @@ func (r *IncidentMaintenanceWindowResource) Create(ctx context.Context, req reso
 	}
 
 	tflog.Trace(ctx, fmt.Sprintf("created a maintenance window resource with id=%s", result.JSON201.MaintenanceWindow.Id))
-	data = r.buildModel(result.JSON201.MaintenanceWindow)
+	data = r.buildModel(result.JSON201.MaintenanceWindow, data)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -260,7 +260,7 @@ func (r *IncidentMaintenanceWindowResource) Read(ctx context.Context, req resour
 		return
 	}
 
-	data = r.buildModel(result.JSON200.MaintenanceWindow)
+	data = r.buildModel(result.JSON200.MaintenanceWindow, data)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -298,7 +298,7 @@ func (r *IncidentMaintenanceWindowResource) Update(ctx context.Context, req reso
 		return
 	}
 
-	data = r.buildModel(result.JSON200.MaintenanceWindow)
+	data = r.buildModel(result.JSON200.MaintenanceWindow, data)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -410,7 +410,9 @@ func (r *IncidentMaintenanceWindowResource) buildPayload(data *MaintenanceWindow
 	return payload, nil
 }
 
-func (r *IncidentMaintenanceWindowResource) buildModel(mw client.MaintenanceWindowV1) *MaintenanceWindowResourceModel {
+// buildModel converts from the response type to the terraform model/schema type.
+// prior is the plan (create/update) or prior state (read).
+func (r *IncidentMaintenanceWindowResource) buildModel(mw client.MaintenanceWindowV1, prior *MaintenanceWindowResourceModel) *MaintenanceWindowResourceModel {
 	model := &MaintenanceWindowResourceModel{
 		ID:                   types.StringValue(mw.Id),
 		Name:                 types.StringValue(mw.Name),
@@ -465,6 +467,10 @@ func (r *IncidentMaintenanceWindowResource) buildModel(mw client.MaintenanceWind
 	// Nullable strings
 	model.NotificationMessage = types.StringPointerValue(mw.NotificationMessage)
 	model.IncidentID = types.StringPointerValue(mw.IncidentId)
+
+	if prior != nil {
+		model.AlertConditionGroups.ReconcileOperations(prior.AlertConditionGroups)
+	}
 
 	return model
 }

--- a/internal/provider/incident_maintenance_window_resource_test.go
+++ b/internal/provider/incident_maintenance_window_resource_test.go
@@ -9,9 +9,13 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/incident-io/terraform-provider-incident/internal/client"
+	"github.com/incident-io/terraform-provider-incident/internal/provider/models"
 )
 
 func testAccMaintenanceWindowLeadUserID(t *testing.T) string {
@@ -297,4 +301,46 @@ func testAccMaintenanceWindowResourceConfigWithOptionalFields(model maintenanceW
 	}
 
 	return buf.String()
+}
+
+// TestMaintenanceWindowBuildModelReconcilesConditionOperation covers ONC-12602 for
+// maintenance windows, which carry alert condition groups just like alert routes do.
+func TestMaintenanceWindowBuildModelReconcilesConditionOperation(t *testing.T) {
+	mw := client.MaintenanceWindowV1{
+		Id:   "01ABC",
+		Name: "window",
+		AlertConditionGroups: []client.ConditionGroupV2{
+			{
+				Conditions: []client.ConditionV2{
+					{
+						Subject:   client.ConditionSubjectV2{Reference: "alert.attributes.01GH"},
+						Operation: client.ConditionOperationV2{Value: "contains_one_of"},
+					},
+				},
+			},
+		},
+	}
+
+	prior := &MaintenanceWindowResourceModel{
+		AlertConditionGroups: models.IncidentEngineConditionGroups{
+			{
+				Conditions: models.IncidentEngineConditions{
+					{
+						Subject:   types.StringValue("alert.attributes.01GH"),
+						Operation: types.StringValue("one_of"),
+					},
+				},
+			},
+		},
+	}
+
+	r := &IncidentMaintenanceWindowResource{}
+
+	withPrior := r.buildModel(mw, prior)
+	assert.Equal(t, "one_of", withPrior.AlertConditionGroups[0].Conditions[0].Operation.ValueString(),
+		"with a plan the operation should be reconciled")
+
+	noPrior := r.buildModel(mw, nil)
+	assert.Equal(t, "contains_one_of", noPrior.AlertConditionGroups[0].Conditions[0].Operation.ValueString(),
+		"with no plan the operation should stay verbatim")
 }

--- a/internal/provider/models/alert_route_v2_model.go
+++ b/internal/provider/models/alert_route_v2_model.go
@@ -650,6 +650,28 @@ func (AlertRouteResourceModel) FromAPIV2WithPlan(apiModel client.AlertRouteV2, p
 		result.MessageTemplate = &binding
 	}
 
+	// Preserve the planned operation for any condition the API normalised to a
+	// semantically-equivalent value (e.g. `one_of` -> `contains_one_of` for a
+	// String subject), which would otherwise make the read-back disagree with the
+	// plan and fail apply. See IncidentEngineConditionGroups.ReconcileOperations.
+	if plan != nil {
+		result.ConditionGroups.ReconcileOperations(plan.ConditionGroups)
+		for i := range result.AlertSources {
+			if i < len(plan.AlertSources) {
+				result.AlertSources[i].ConditionGroups.ReconcileOperations(plan.AlertSources[i].ConditionGroups)
+			}
+		}
+		for i := range result.ChannelConfig {
+			if i < len(plan.ChannelConfig) {
+				result.ChannelConfig[i].ConditionGroups.ReconcileOperations(plan.ChannelConfig[i].ConditionGroups)
+			}
+		}
+		if result.IncidentConfig != nil && plan.IncidentConfig != nil {
+			result.IncidentConfig.ConditionGroups.ReconcileOperations(plan.IncidentConfig.ConditionGroups)
+		}
+		result.Expressions.ReconcileOperations(plan.Expressions)
+	}
+
 	return result
 }
 

--- a/internal/provider/models/alert_route_v2_model.go
+++ b/internal/provider/models/alert_route_v2_model.go
@@ -55,10 +55,34 @@ type AlertRouteAlertSourceModel struct {
 	ConditionGroups IncidentEngineConditionGroups `tfsdk:"condition_groups"`
 }
 
+// reconcileAlertSourceOperations correlates by ID, not position: alert_sources is a set.
+func reconcileAlertSourceOperations(applied, plan []AlertRouteAlertSourceModel) {
+	planByAlertSourceID := map[string]AlertRouteAlertSourceModel{}
+	for _, source := range plan {
+		planByAlertSourceID[source.AlertSourceID.ValueString()] = source
+	}
+
+	for i := range applied {
+		if planned, ok := planByAlertSourceID[applied[i].AlertSourceID.ValueString()]; ok {
+			applied[i].ConditionGroups.ReconcileOperations(planned.ConditionGroups)
+		}
+	}
+}
+
 type AlertRouteChannelConfigModel struct {
 	ConditionGroups IncidentEngineConditionGroups `tfsdk:"condition_groups"`
 	MsTeamsTargets  *AlertRouteChannelTargetModel `tfsdk:"ms_teams_targets"`
 	SlackTargets    *AlertRouteChannelTargetModel `tfsdk:"slack_targets"`
+}
+
+// reconcileChannelConfigOperations falls back to position: channel configs are a
+// set with no ID to key on.
+func reconcileChannelConfigOperations(applied, plan []AlertRouteChannelConfigModel) {
+	for i := range applied {
+		if i < len(plan) {
+			applied[i].ConditionGroups.ReconcileOperations(plan[i].ConditionGroups)
+		}
+	}
 }
 
 type AlertRouteChannelTargetModel struct {
@@ -650,22 +674,10 @@ func (AlertRouteResourceModel) FromAPIV2WithPlan(apiModel client.AlertRouteV2, p
 		result.MessageTemplate = &binding
 	}
 
-	// Preserve the planned operation for any condition the API normalised to a
-	// semantically-equivalent value (e.g. `one_of` -> `contains_one_of` for a
-	// String subject), which would otherwise make the read-back disagree with the
-	// plan and fail apply. See IncidentEngineConditionGroups.ReconcileOperations.
 	if plan != nil {
 		result.ConditionGroups.ReconcileOperations(plan.ConditionGroups)
-		for i := range result.AlertSources {
-			if i < len(plan.AlertSources) {
-				result.AlertSources[i].ConditionGroups.ReconcileOperations(plan.AlertSources[i].ConditionGroups)
-			}
-		}
-		for i := range result.ChannelConfig {
-			if i < len(plan.ChannelConfig) {
-				result.ChannelConfig[i].ConditionGroups.ReconcileOperations(plan.ChannelConfig[i].ConditionGroups)
-			}
-		}
+		reconcileAlertSourceOperations(result.AlertSources, plan.AlertSources)
+		reconcileChannelConfigOperations(result.ChannelConfig, plan.ChannelConfig)
 		if result.IncidentConfig != nil && plan.IncidentConfig != nil {
 			result.IncidentConfig.ConditionGroups.ReconcileOperations(plan.IncidentConfig.ConditionGroups)
 		}

--- a/internal/provider/models/alert_route_v2_model_test.go
+++ b/internal/provider/models/alert_route_v2_model_test.go
@@ -140,11 +140,9 @@ func TestAlertRouteV2EscalationPathTargetIgnoresDuplicateUsers(t *testing.T) {
 	}
 }
 
-// TestAlertRouteV2ReconcilesConditionOperation covers ONC-12602 end-to-end for
-// the v2 mapping: the API accepts `one_of` on a String subject but stores and
-// returns `contains_one_of`. FromAPIV2WithPlan must restore the planned `one_of`
-// so the read-back matches the plan and apply converges. On an import/read with
-// no plan the API value is kept verbatim.
+// TestAlertRouteV2ReconcilesConditionOperation covers ONC-12602 end-to-end: the
+// planned `one_of` survives a `contains_one_of` read-back, and an import with no
+// plan keeps the API value.
 func TestAlertRouteV2ReconcilesConditionOperation(t *testing.T) {
 	api := client.AlertRouteV2{
 		Id:            "01ABC",
@@ -192,6 +190,55 @@ func TestAlertRouteV2ReconcilesConditionOperation(t *testing.T) {
 	if got := noPlan.ConditionGroups[0].Conditions[0].Operation.ValueString(); got != "contains_one_of" {
 		t.Errorf("no plan: operation should stay verbatim %q, got %q", "contains_one_of", got)
 	}
+}
+
+// TestReconcileAlertSourceOperationsCorrelatesByID asserts alert source conditions
+// still reconcile when the API returns the sources in a different order to the
+// plan, and that we do not reconcile against the wrong source.
+func TestReconcileAlertSourceOperationsCorrelatesByID(t *testing.T) {
+	source := func(id, operation string) AlertRouteAlertSourceModel {
+		return AlertRouteAlertSourceModel{
+			AlertSourceID: types.StringValue(id),
+			ConditionGroups: IncidentEngineConditionGroups{
+				{Conditions: IncidentEngineConditions{
+					{
+						Subject:   types.StringValue("alert.attributes.01GH"),
+						Operation: types.StringValue(operation),
+					},
+				}},
+			},
+		}
+	}
+	operationOf := func(s AlertRouteAlertSourceModel) string {
+		return s.ConditionGroups[0].Conditions[0].Operation.ValueString()
+	}
+
+	applied := []AlertRouteAlertSourceModel{
+		source("01SOURCEA", "contains_one_of"),
+		source("01SOURCEB", "contains_one_of"),
+	}
+	// Same sources in the opposite order, and only source B planned `one_of`.
+	plan := []AlertRouteAlertSourceModel{
+		source("01SOURCEB", "one_of"),
+		source("01SOURCEA", "contains_one_of"),
+	}
+
+	reconcileAlertSourceOperations(applied, plan)
+
+	if got := operationOf(applied[0]); got != "contains_one_of" {
+		t.Errorf("source A planned contains_one_of, should be left alone, got %q", got)
+	}
+	if got := operationOf(applied[1]); got != "one_of" {
+		t.Errorf("source B planned one_of, should be reconciled, got %q", got)
+	}
+
+	// An unplanned source is left alone, and a nil plan must not panic.
+	unplanned := []AlertRouteAlertSourceModel{source("01SOURCEC", "contains_one_of")}
+	reconcileAlertSourceOperations(unplanned, plan)
+	if got := operationOf(unplanned[0]); got != "contains_one_of" {
+		t.Errorf("unplanned source should be left alone, got %q", got)
+	}
+	reconcileAlertSourceOperations(unplanned, nil)
 }
 
 // TestAlertRouteV2UserTargetKeepsUsers confirms the sibling case: a genuine user

--- a/internal/provider/models/alert_route_v2_model_test.go
+++ b/internal/provider/models/alert_route_v2_model_test.go
@@ -3,6 +3,8 @@ package models
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/incident-io/terraform-provider-incident/internal/client"
 	"github.com/samber/lo"
 )
@@ -135,6 +137,60 @@ func TestAlertRouteV2EscalationPathTargetIgnoresDuplicateUsers(t *testing.T) {
 	}
 	if target.Users != nil {
 		t.Error("users should be nil for an escalation-path target (API duplicate must be dropped)")
+	}
+}
+
+// TestAlertRouteV2ReconcilesConditionOperation covers ONC-12602 end-to-end for
+// the v2 mapping: the API accepts `one_of` on a String subject but stores and
+// returns `contains_one_of`. FromAPIV2WithPlan must restore the planned `one_of`
+// so the read-back matches the plan and apply converges. On an import/read with
+// no plan the API value is kept verbatim.
+func TestAlertRouteV2ReconcilesConditionOperation(t *testing.T) {
+	api := client.AlertRouteV2{
+		Id:            "01ABC",
+		Name:          "route",
+		Version:       2,
+		AlertSources:  []client.AlertRouteAlertSourceV2{},
+		ChannelConfig: []client.AlertRouteChannelConfigV2{},
+		ConditionGroups: []client.ConditionGroupV2{
+			{
+				Conditions: []client.ConditionV2{
+					{
+						Subject:   client.ConditionSubjectV2{Reference: "alert.attributes.01GH"},
+						Operation: client.ConditionOperationV2{Value: "contains_one_of"},
+					},
+				},
+			},
+		},
+		Expressions: []client.ExpressionV2{},
+		EscalationConfig: client.AlertRouteEscalationConfigV2{
+			EscalationTargets: []client.AlertRouteEscalationTargetV2{},
+		},
+		IncidentConfig:   client.AlertRouteIncidentConfigV2{GroupingKeys: []client.GroupingKeyV2{}},
+		IncidentTemplate: client.AlertRouteIncidentTemplateV2{},
+	}
+
+	plan := &AlertRouteResourceModel{
+		ConditionGroups: IncidentEngineConditionGroups{
+			{
+				Conditions: IncidentEngineConditions{
+					{
+						Subject:   types.StringValue("alert.attributes.01GH"),
+						Operation: types.StringValue("one_of"),
+					},
+				},
+			},
+		},
+	}
+
+	withPlan := AlertRouteResourceModel{}.FromAPIV2WithPlan(api, plan)
+	if got := withPlan.ConditionGroups[0].Conditions[0].Operation.ValueString(); got != "one_of" {
+		t.Errorf("with plan: operation should be reconciled to %q, got %q", "one_of", got)
+	}
+
+	noPlan := AlertRouteResourceModel{}.FromAPIV2(api)
+	if got := noPlan.ConditionGroups[0].Conditions[0].Operation.ValueString(); got != "contains_one_of" {
+		t.Errorf("no plan: operation should stay verbatim %q, got %q", "contains_one_of", got)
 	}
 }
 

--- a/internal/provider/models/alert_route_v2_model_test.go
+++ b/internal/provider/models/alert_route_v2_model_test.go
@@ -192,6 +192,101 @@ func TestAlertRouteV2ReconcilesConditionOperation(t *testing.T) {
 	}
 }
 
+// TestAlertRouteV2ReconcilesEveryConditionGroupLocation guards the wiring rather
+// than the reconciliation itself: a condition group missed in FromAPIV2WithPlan
+// still fails apply, and every other test here only covers the top-level one.
+func TestAlertRouteV2ReconcilesEveryConditionGroupLocation(t *testing.T) {
+	const subject = "alert.attributes.01GH"
+
+	apiGroups := func() []client.ConditionGroupV2 {
+		return []client.ConditionGroupV2{
+			{Conditions: []client.ConditionV2{
+				{
+					Subject:   client.ConditionSubjectV2{Reference: subject},
+					Operation: client.ConditionOperationV2{Value: "contains_one_of"},
+				},
+			}},
+		}
+	}
+	planGroups := func() IncidentEngineConditionGroups {
+		return IncidentEngineConditionGroups{
+			{Conditions: IncidentEngineConditions{
+				{Subject: types.StringValue(subject), Operation: types.StringValue("one_of")},
+			}},
+		}
+	}
+
+	api := client.AlertRouteV2{
+		Id:              "01ABC",
+		Name:            "route",
+		Version:         2,
+		ConditionGroups: apiGroups(),
+		AlertSources: []client.AlertRouteAlertSourceV2{
+			{AlertSourceId: "01SOURCE", ConditionGroups: apiGroups()},
+		},
+		ChannelConfig: []client.AlertRouteChannelConfigV2{
+			{ConditionGroups: apiGroups()},
+		},
+		Expressions: []client.ExpressionV2{
+			{
+				Reference: "expr",
+				Label:     "expr",
+				Operations: []client.ExpressionOperationV2{
+					{
+						OperationType: "filter",
+						Filter:        &client.ExpressionFilterOptsV2{ConditionGroups: apiGroups()},
+					},
+				},
+			},
+		},
+		EscalationConfig: client.AlertRouteEscalationConfigV2{
+			EscalationTargets: []client.AlertRouteEscalationTargetV2{},
+		},
+		IncidentConfig: client.AlertRouteIncidentConfigV2{
+			GroupingKeys:    []client.GroupingKeyV2{},
+			ConditionGroups: apiGroups(),
+		},
+		IncidentTemplate: client.AlertRouteIncidentTemplateV2{},
+	}
+
+	plan := &AlertRouteResourceModel{
+		ConditionGroups: planGroups(),
+		AlertSources: []AlertRouteAlertSourceModel{
+			{AlertSourceID: types.StringValue("01SOURCE"), ConditionGroups: planGroups()},
+		},
+		ChannelConfig: []AlertRouteChannelConfigModel{
+			{ConditionGroups: planGroups()},
+		},
+		Expressions: IncidentEngineExpressions{
+			{
+				Reference: types.StringValue("expr"),
+				Operations: IncidentEngineExpressionOperations{
+					{
+						OperationType: types.StringValue("filter"),
+						Filter:        &IncidentEngineExpressionFilterOpts{ConditionGroups: planGroups()},
+					},
+				},
+			},
+		},
+		IncidentConfig: &AlertRouteIncidentConfigModel{ConditionGroups: planGroups()},
+	}
+
+	result := AlertRouteResourceModel{}.FromAPIV2WithPlan(api, plan)
+
+	locations := map[string]IncidentEngineConditionGroups{
+		"condition_groups":              result.ConditionGroups,
+		"alert_sources":                 result.AlertSources[0].ConditionGroups,
+		"channel_config":                result.ChannelConfig[0].ConditionGroups,
+		"incident_config":               result.IncidentConfig.ConditionGroups,
+		"expressions.operations.filter": result.Expressions[0].Operations[0].Filter.ConditionGroups,
+	}
+	for location, groups := range locations {
+		if got := groups[0].Conditions[0].Operation.ValueString(); got != "one_of" {
+			t.Errorf("%s: operation should be reconciled to %q, got %q", location, "one_of", got)
+		}
+	}
+}
+
 // TestReconcileAlertSourceOperationsCorrelatesByID asserts alert source conditions
 // still reconcile when the API returns the sources in a different order to the
 // plan, and that we do not reconcile against the wrong source.

--- a/internal/provider/models/alert_route_v3_model.go
+++ b/internal/provider/models/alert_route_v3_model.go
@@ -389,6 +389,30 @@ func (AlertRouteResourceModel) FromAPIV3WithPlan(apiModel client.AlertRouteV3, p
 		result.IncidentConfig.Template = incidentTemplateFromAPIV3(apiModel.IncidentConfig.Template, planTemplate)
 	}
 
+	// Preserve the planned operation for any condition the API normalised to a
+	// semantically-equivalent value (e.g. `one_of` -> `contains_one_of` for a
+	// String subject), which would otherwise make the read-back disagree with the
+	// plan and fail apply. See IncidentEngineConditionGroups.ReconcileOperations.
+	if plan != nil {
+		result.ConditionGroups.ReconcileOperations(plan.ConditionGroups)
+		for i := range result.AlertSources {
+			if i < len(plan.AlertSources) {
+				result.AlertSources[i].ConditionGroups.ReconcileOperations(plan.AlertSources[i].ConditionGroups)
+			}
+		}
+		if plan.MessageConfig != nil {
+			for i := range result.MessageConfig.Destinations {
+				if i < len(plan.MessageConfig.Destinations) {
+					result.MessageConfig.Destinations[i].ConditionGroups.ReconcileOperations(plan.MessageConfig.Destinations[i].ConditionGroups)
+				}
+			}
+		}
+		if result.IncidentConfig != nil && plan.IncidentConfig != nil {
+			result.IncidentConfig.ConditionGroups.ReconcileOperations(plan.IncidentConfig.ConditionGroups)
+		}
+		result.Expressions.ReconcileOperations(plan.Expressions)
+	}
+
 	return result
 }
 

--- a/internal/provider/models/alert_route_v3_model.go
+++ b/internal/provider/models/alert_route_v3_model.go
@@ -118,6 +118,15 @@ type AlertRouteV3ChannelConfigModel struct {
 	SlackTargets    *AlertRouteV3ChannelTargetModel `tfsdk:"slack_targets"`
 }
 
+// reconcileDestinationOperations is reconcileChannelConfigOperations for v3 destinations.
+func reconcileDestinationOperations(applied, plan []AlertRouteV3ChannelConfigModel) {
+	for i := range applied {
+		if i < len(plan) {
+			applied[i].ConditionGroups.ReconcileOperations(plan[i].ConditionGroups)
+		}
+	}
+}
+
 type AlertRouteV3ChannelTargetModel struct {
 	Binding            *IncidentEngineParamBinding `tfsdk:"binding"`
 	ChannelVisibility  types.String                `tfsdk:"channel_visibility"`
@@ -389,23 +398,11 @@ func (AlertRouteResourceModel) FromAPIV3WithPlan(apiModel client.AlertRouteV3, p
 		result.IncidentConfig.Template = incidentTemplateFromAPIV3(apiModel.IncidentConfig.Template, planTemplate)
 	}
 
-	// Preserve the planned operation for any condition the API normalised to a
-	// semantically-equivalent value (e.g. `one_of` -> `contains_one_of` for a
-	// String subject), which would otherwise make the read-back disagree with the
-	// plan and fail apply. See IncidentEngineConditionGroups.ReconcileOperations.
 	if plan != nil {
 		result.ConditionGroups.ReconcileOperations(plan.ConditionGroups)
-		for i := range result.AlertSources {
-			if i < len(plan.AlertSources) {
-				result.AlertSources[i].ConditionGroups.ReconcileOperations(plan.AlertSources[i].ConditionGroups)
-			}
-		}
+		reconcileAlertSourceOperations(result.AlertSources, plan.AlertSources)
 		if plan.MessageConfig != nil {
-			for i := range result.MessageConfig.Destinations {
-				if i < len(plan.MessageConfig.Destinations) {
-					result.MessageConfig.Destinations[i].ConditionGroups.ReconcileOperations(plan.MessageConfig.Destinations[i].ConditionGroups)
-				}
-			}
+			reconcileDestinationOperations(result.MessageConfig.Destinations, plan.MessageConfig.Destinations)
 		}
 		if result.IncidentConfig != nil && plan.IncidentConfig != nil {
 			result.IncidentConfig.ConditionGroups.ReconcileOperations(plan.IncidentConfig.ConditionGroups)

--- a/internal/provider/models/alert_route_v3_model_test.go
+++ b/internal/provider/models/alert_route_v3_model_test.go
@@ -473,6 +473,110 @@ func TestAlertRouteV3ReconcilesConditionOperation(t *testing.T) {
 	}
 }
 
+// TestAlertRouteV3ReconcilesEveryConditionGroupLocation guards the wiring rather
+// than the reconciliation itself: a condition group missed in FromAPIV3WithPlan
+// still fails apply, and every other test here only covers the top-level one.
+func TestAlertRouteV3ReconcilesEveryConditionGroupLocation(t *testing.T) {
+	const subject = "alert.attributes.01GH"
+
+	apiGroups := func() []client.ConditionGroupV3 {
+		return []client.ConditionGroupV3{
+			{Conditions: []client.ConditionV3{
+				{
+					Subject:       client.ConditionSubjectV3{Reference: subject},
+					Operation:     client.ConditionOperationV3{Value: "contains_one_of"},
+					ParamBindings: []client.EngineParamBindingV3{},
+				},
+			}},
+		}
+	}
+	planGroups := func() IncidentEngineConditionGroups {
+		return IncidentEngineConditionGroups{
+			{Conditions: IncidentEngineConditions{
+				{Subject: types.StringValue(subject), Operation: types.StringValue("one_of")},
+			}},
+		}
+	}
+
+	api := client.AlertRouteV3{
+		Id:              "01ABC",
+		Name:            "route",
+		ConditionGroups: apiGroups(),
+		AlertSources: []client.AlertRouteAlertSourceV3{
+			{AlertSourceId: "01SOURCE", ConditionGroups: apiGroups()},
+		},
+		Expressions: []client.ExpressionV3{
+			{
+				Reference: "expr",
+				Label:     "expr",
+				Operations: []client.ExpressionOperationV3{
+					{
+						OperationType: "filter",
+						Filter:        &client.ExpressionFilterOptsV3{ConditionGroups: apiGroups()},
+					},
+				},
+			},
+		},
+		GroupingConfig: client.AlertGroupingConfigV3{
+			Default: client.GroupingSettingsV3{Enabled: false},
+		},
+		MessageConfig: client.AlertMessageConfigV3{
+			Destinations: []client.AlertMessageDestinationV3{
+				{ConditionGroups: apiGroups()},
+			},
+		},
+		EscalationConfig: client.AlertRouteEscalationConfigV3{
+			EscalationTargets: []client.AlertRouteEscalationTargetV3{},
+		},
+		IncidentConfig: client.AlertRouteIncidentConfigV3{
+			Enabled:         true,
+			ConditionGroups: lo.ToPtr(apiGroups()),
+		},
+	}
+
+	plan := &AlertRouteResourceModel{
+		GroupingConfig: &AlertRouteV3GroupingConfigModel{
+			Default: &AlertRouteV3GroupingSettingsModel{},
+		},
+		ConditionGroups: planGroups(),
+		AlertSources: []AlertRouteAlertSourceModel{
+			{AlertSourceID: types.StringValue("01SOURCE"), ConditionGroups: planGroups()},
+		},
+		Expressions: IncidentEngineExpressions{
+			{
+				Reference: types.StringValue("expr"),
+				Operations: IncidentEngineExpressionOperations{
+					{
+						OperationType: types.StringValue("filter"),
+						Filter:        &IncidentEngineExpressionFilterOpts{ConditionGroups: planGroups()},
+					},
+				},
+			},
+		},
+		MessageConfig: &AlertRouteV3MessageConfigModel{
+			Destinations: []AlertRouteV3ChannelConfigModel{
+				{ConditionGroups: planGroups()},
+			},
+		},
+		IncidentConfig: &AlertRouteIncidentConfigModel{ConditionGroups: planGroups()},
+	}
+
+	result := AlertRouteResourceModel{}.FromAPIV3WithPlan(api, plan)
+
+	locations := map[string]IncidentEngineConditionGroups{
+		"condition_groups":              result.ConditionGroups,
+		"alert_sources":                 result.AlertSources[0].ConditionGroups,
+		"message_config.destinations":   result.MessageConfig.Destinations[0].ConditionGroups,
+		"incident_config":               result.IncidentConfig.ConditionGroups,
+		"expressions.operations.filter": result.Expressions[0].Operations[0].Filter.ConditionGroups,
+	}
+	for location, groups := range locations {
+		if got := groups[0].Conditions[0].Operation.ValueString(); got != "one_of" {
+			t.Errorf("%s: operation should be reconciled to %q, got %q", location, "one_of", got)
+		}
+	}
+}
+
 // TestWhenAlertJoinsGroupFromAPIGracePeriodByMode covers the mapping of
 // grace_period_seconds out of the API. The grace period is only a real,
 // configurable field when mode is on_each_new_alert. For on_priority_increase

--- a/internal/provider/models/alert_route_v3_model_test.go
+++ b/internal/provider/models/alert_route_v3_model_test.go
@@ -416,11 +416,8 @@ func TestAlertRouteV3CustomFieldsNullVsEmpty(t *testing.T) {
 	}
 }
 
-// TestAlertRouteV3ReconcilesConditionOperation covers ONC-12602 for the v3
-// mapping: the API accepts `one_of` on a String subject but stores and returns
-// `contains_one_of`. FromAPIV3WithPlan must restore the planned `one_of` so the
-// read-back matches the plan and apply converges; with no plan (import/read)
-// the API value is kept verbatim.
+// TestAlertRouteV3ReconcilesConditionOperation is
+// TestAlertRouteV2ReconcilesConditionOperation for the v3 mapping.
 func TestAlertRouteV3ReconcilesConditionOperation(t *testing.T) {
 	api := client.AlertRouteV3{
 		Id:   "01ABC",

--- a/internal/provider/models/alert_route_v3_model_test.go
+++ b/internal/provider/models/alert_route_v3_model_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/samber/lo"
 
@@ -412,6 +413,66 @@ func TestAlertRouteV3CustomFieldsNullVsEmpty(t *testing.T) {
 	}
 	if len(gotEmpty.IncidentConfig.Template.CustomFields) != 0 {
 		t.Errorf("custom_fields: expected length 0, got %d", len(gotEmpty.IncidentConfig.Template.CustomFields))
+	}
+}
+
+// TestAlertRouteV3ReconcilesConditionOperation covers ONC-12602 for the v3
+// mapping: the API accepts `one_of` on a String subject but stores and returns
+// `contains_one_of`. FromAPIV3WithPlan must restore the planned `one_of` so the
+// read-back matches the plan and apply converges; with no plan (import/read)
+// the API value is kept verbatim.
+func TestAlertRouteV3ReconcilesConditionOperation(t *testing.T) {
+	api := client.AlertRouteV3{
+		Id:   "01ABC",
+		Name: "route",
+		ConditionGroups: []client.ConditionGroupV3{
+			{
+				Conditions: []client.ConditionV3{
+					{
+						Subject:       client.ConditionSubjectV3{Reference: "alert.attributes.01GH"},
+						Operation:     client.ConditionOperationV3{Value: "contains_one_of"},
+						ParamBindings: []client.EngineParamBindingV3{},
+					},
+				},
+			},
+		},
+		Expressions: []client.ExpressionV3{},
+		GroupingConfig: client.AlertGroupingConfigV3{
+			Default: client.GroupingSettingsV3{Enabled: false},
+		},
+		MessageConfig: client.AlertMessageConfigV3{
+			Destinations: []client.AlertMessageDestinationV3{},
+		},
+		EscalationConfig: client.AlertRouteEscalationConfigV3{
+			EscalationTargets: []client.AlertRouteEscalationTargetV3{},
+		},
+		IncidentConfig: client.AlertRouteIncidentConfigV3{Enabled: false},
+	}
+
+	plan := &AlertRouteResourceModel{
+		GroupingConfig: &AlertRouteV3GroupingConfigModel{
+			Default: &AlertRouteV3GroupingSettingsModel{},
+		},
+		ConditionGroups: IncidentEngineConditionGroups{
+			{
+				Conditions: IncidentEngineConditions{
+					{
+						Subject:   types.StringValue("alert.attributes.01GH"),
+						Operation: types.StringValue("one_of"),
+					},
+				},
+			},
+		},
+	}
+
+	withPlan := AlertRouteResourceModel{}.FromAPIV3WithPlan(api, plan)
+	if got := withPlan.ConditionGroups[0].Conditions[0].Operation.ValueString(); got != "one_of" {
+		t.Errorf("with plan: operation should be reconciled to %q, got %q", "one_of", got)
+	}
+
+	noPlan := AlertRouteResourceModel{}.FromAPIV3(api)
+	if got := noPlan.ConditionGroups[0].Conditions[0].Operation.ValueString(); got != "contains_one_of" {
+		t.Errorf("no plan: operation should stay verbatim %q, got %q", "contains_one_of", got)
 	}
 }
 

--- a/internal/provider/models/engine.go
+++ b/internal/provider/models/engine.go
@@ -61,31 +61,17 @@ type IncidentEngineConditionGroup struct {
 	Conditions IncidentEngineConditions `tfsdk:"conditions"`
 }
 
-// serverOperationNormalisations maps the condition operations the API accepts on
-// input to the canonical form it stores and returns. For a String (rather than
-// CatalogEntry) subject the API silently rewrites the set-membership operators
-// to their substring-matching equivalents: `one_of` becomes `contains_one_of`
-// and `not_one_of` becomes `not_contains_one_of`. `one_of` is the value used in
-// the provider docs and the API reference example, so it is a natural thing to
-// write, but because operation is stored verbatim from the read-back the plan
-// (`one_of`) then disagrees with the applied state (`contains_one_of`) and
-// Terraform aborts with "Provider produced inconsistent result after apply",
-// tainting the route so it never converges (ONC-12602).
-//
-// We only ever preserve the planned value when the API's value is exactly the
-// known normalisation of it, so any other divergence (a genuine change, or an
-// unrelated out-of-band edit) is still surfaced rather than masked.
+// serverOperationNormalisations maps operation aliases the API accepts to the
+// canonical name it returns for them. Each is canonical on other subject types,
+// so we match the API value exactly rather than rewriting on the alias alone.
 var serverOperationNormalisations = map[string]string{
-	"one_of":     "contains_one_of",
-	"not_one_of": "not_contains_one_of",
+	"one_of":   "contains_one_of", // String, Link and TemplatedText subjects
+	"contains": "name_contains",   // CatalogEntry subjects
 }
 
-// ReconcileOperations restores planned condition operations onto this read-back
-// set wherever the API normalised the operation to a semantically-equivalent
-// value it accepts but rewrites (see serverOperationNormalisations). Condition
-// groups and the conditions within them are ordered lists, so we correlate
-// positionally against the plan and additionally require the subject to match,
-// which keeps a genuine operation change (or a mismatched correlation) surfaced.
+// ReconcileOperations restores the planned operation wherever the API returned
+// the canonical form of an alias we sent (ONC-12602). Condition groups are lists,
+// so we correlate positionally and require the subject to match.
 func (groups IncidentEngineConditionGroups) ReconcileOperations(plan IncidentEngineConditionGroups) {
 	for gi := range groups {
 		if gi >= len(plan) {
@@ -205,22 +191,27 @@ func (IncidentEngineParamBindingValue) FromAPI(pbv client.EngineParamBindingValu
 
 type IncidentEngineExpressions []IncidentEngineExpression
 
-// ReconcileOperations restores planned condition operations onto the condition
-// groups nested inside expression operations (filter and branch conditions),
-// mirroring IncidentEngineConditionGroups.ReconcileOperations. We correlate
-// expressions, operations and branches positionally against the plan.
+// ReconcileOperations does the same for filter and branch conditions. Expressions
+// are a set, so we correlate by reference rather than position.
 func (expressions IncidentEngineExpressions) ReconcileOperations(plan IncidentEngineExpressions) {
+	planByReference := map[string]IncidentEngineExpression{}
+	for _, expression := range plan {
+		planByReference[expression.Reference.ValueString()] = expression
+	}
+
 	for ei := range expressions {
-		if ei >= len(plan) {
-			break
+		planExpression, ok := planByReference[expressions[ei].Reference.ValueString()]
+		if !ok {
+			continue
 		}
+
 		for oi := range expressions[ei].Operations {
-			if oi >= len(plan[ei].Operations) {
+			if oi >= len(planExpression.Operations) {
 				break
 			}
 
 			op := expressions[ei].Operations[oi]
-			planOp := plan[ei].Operations[oi]
+			planOp := planExpression.Operations[oi]
 
 			if op.Filter != nil && planOp.Filter != nil {
 				op.Filter.ConditionGroups.ReconcileOperations(planOp.Filter.ConditionGroups)

--- a/internal/provider/models/engine.go
+++ b/internal/provider/models/engine.go
@@ -61,6 +61,51 @@ type IncidentEngineConditionGroup struct {
 	Conditions IncidentEngineConditions `tfsdk:"conditions"`
 }
 
+// serverOperationNormalisations maps the condition operations the API accepts on
+// input to the canonical form it stores and returns. For a String (rather than
+// CatalogEntry) subject the API silently rewrites the set-membership operators
+// to their substring-matching equivalents: `one_of` becomes `contains_one_of`
+// and `not_one_of` becomes `not_contains_one_of`. `one_of` is the value used in
+// the provider docs and the API reference example, so it is a natural thing to
+// write, but because operation is stored verbatim from the read-back the plan
+// (`one_of`) then disagrees with the applied state (`contains_one_of`) and
+// Terraform aborts with "Provider produced inconsistent result after apply",
+// tainting the route so it never converges (ONC-12602).
+//
+// We only ever preserve the planned value when the API's value is exactly the
+// known normalisation of it, so any other divergence (a genuine change, or an
+// unrelated out-of-band edit) is still surfaced rather than masked.
+var serverOperationNormalisations = map[string]string{
+	"one_of":     "contains_one_of",
+	"not_one_of": "not_contains_one_of",
+}
+
+// ReconcileOperations restores planned condition operations onto this read-back
+// set wherever the API normalised the operation to a semantically-equivalent
+// value it accepts but rewrites (see serverOperationNormalisations). Condition
+// groups and the conditions within them are ordered lists, so we correlate
+// positionally against the plan and additionally require the subject to match,
+// which keeps a genuine operation change (or a mismatched correlation) surfaced.
+func (groups IncidentEngineConditionGroups) ReconcileOperations(plan IncidentEngineConditionGroups) {
+	for gi := range groups {
+		if gi >= len(plan) {
+			break
+		}
+		for ci := range groups[gi].Conditions {
+			if ci >= len(plan[gi].Conditions) {
+				break
+			}
+
+			planned := plan[gi].Conditions[ci]
+			applied := groups[gi].Conditions[ci]
+			if applied.Subject.Equal(planned.Subject) &&
+				serverOperationNormalisations[planned.Operation.ValueString()] == applied.Operation.ValueString() {
+				groups[gi].Conditions[ci].Operation = planned.Operation
+			}
+		}
+	}
+}
+
 type IncidentEngineConditions []IncidentEngineCondition
 
 func (IncidentEngineConditions) FromAPI(conditions []client.ConditionV2) IncidentEngineConditions {
@@ -159,6 +204,39 @@ func (IncidentEngineParamBindingValue) FromAPI(pbv client.EngineParamBindingValu
 }
 
 type IncidentEngineExpressions []IncidentEngineExpression
+
+// ReconcileOperations restores planned condition operations onto the condition
+// groups nested inside expression operations (filter and branch conditions),
+// mirroring IncidentEngineConditionGroups.ReconcileOperations. We correlate
+// expressions, operations and branches positionally against the plan.
+func (expressions IncidentEngineExpressions) ReconcileOperations(plan IncidentEngineExpressions) {
+	for ei := range expressions {
+		if ei >= len(plan) {
+			break
+		}
+		for oi := range expressions[ei].Operations {
+			if oi >= len(plan[ei].Operations) {
+				break
+			}
+
+			op := expressions[ei].Operations[oi]
+			planOp := plan[ei].Operations[oi]
+
+			if op.Filter != nil && planOp.Filter != nil {
+				op.Filter.ConditionGroups.ReconcileOperations(planOp.Filter.ConditionGroups)
+			}
+
+			if op.Branches != nil && planOp.Branches != nil {
+				for bi := range op.Branches.Branches {
+					if bi >= len(planOp.Branches.Branches) {
+						break
+					}
+					op.Branches.Branches[bi].ConditionGroups.ReconcileOperations(planOp.Branches.Branches[bi].ConditionGroups)
+				}
+			}
+		}
+	}
+}
 
 func (IncidentEngineExpressions) FromAPI(expressions []client.ExpressionV2) IncidentEngineExpressions {
 	out := IncidentEngineExpressions{}

--- a/internal/provider/models/engine_test.go
+++ b/internal/provider/models/engine_test.go
@@ -145,12 +145,8 @@ func TestIncidentEngineParamBindings_TrimAppendedEmpty(t *testing.T) {
 	}
 }
 
-// TestIncidentEngineConditionGroups_ReconcileOperations covers ONC-12602: the
-// alert-route API accepts `one_of` on a String subject but stores and returns
-// `contains_one_of`. Without reconciliation the read-back operation disagrees
-// with the plan and apply fails with "Provider produced inconsistent result
-// after apply". ReconcileOperations must restore the planned value for that
-// known normalisation while leaving genuine changes and unrelated values alone.
+// TestIncidentEngineConditionGroups_ReconcileOperations covers ONC-12602: restore
+// the planned value for a known alias, leave everything else alone.
 func TestIncidentEngineConditionGroups_ReconcileOperations(t *testing.T) {
 	condition := func(subject, operation string) IncidentEngineCondition {
 		return IncidentEngineCondition{
@@ -175,16 +171,23 @@ func TestIncidentEngineConditionGroups_ReconcileOperations(t *testing.T) {
 			want:    "one_of",
 		},
 		{
-			name:    "restores planned not_one_of when API returns not_contains_one_of",
-			applied: groups(condition("alert.attributes.01ABC", "not_contains_one_of")),
-			plan:    groups(condition("alert.attributes.01ABC", "not_one_of")),
-			want:    "not_one_of",
+			name:    "restores planned contains when API returns name_contains",
+			applied: groups(condition("incident.custom_field.01ABC", "name_contains")),
+			plan:    groups(condition("incident.custom_field.01ABC", "contains")),
+			want:    "contains",
 		},
 		{
 			name:    "leaves matching operations untouched",
 			applied: groups(condition("alert.attributes.01ABC", "one_of")),
 			plan:    groups(condition("alert.attributes.01ABC", "one_of")),
 			want:    "one_of",
+		},
+		{
+			// `contains` is canonical on String, so the API returns it unchanged.
+			name:    "leaves an alias that is canonical for the subject untouched",
+			applied: groups(condition("alert.attributes.01ABC", "contains")),
+			plan:    groups(condition("alert.attributes.01ABC", "contains")),
+			want:    "contains",
 		},
 		{
 			name:    "does not mask an unrelated divergence",
@@ -209,10 +212,9 @@ func TestIncidentEngineConditionGroups_ReconcileOperations(t *testing.T) {
 	}
 }
 
-// TestIncidentEngineConditionGroups_ReconcileOperationsMismatchedLengths
-// asserts that reconciliation is safe when the plan and read-back have
-// different numbers of groups or conditions (it correlates positionally and
-// stops at the shorter length rather than panicking).
+// TestIncidentEngineConditionGroups_ReconcileOperationsMismatchedLengths asserts
+// reconciliation is safe when the plan and read-back have different numbers of
+// groups or conditions.
 func TestIncidentEngineConditionGroups_ReconcileOperationsMismatchedLengths(t *testing.T) {
 	applied := IncidentEngineConditionGroups{
 		{Conditions: IncidentEngineConditions{
@@ -233,6 +235,56 @@ func TestIncidentEngineConditionGroups_ReconcileOperationsMismatchedLengths(t *t
 
 	// A nil plan must be a no-op rather than a panic.
 	assert.NotPanics(t, func() { applied.ReconcileOperations(nil) })
+}
+
+// TestIncidentEngineExpressions_ReconcileOperationsCorrelatesByReference asserts
+// filter conditions still reconcile when the API returns expressions in a
+// different order to the plan.
+func TestIncidentEngineExpressions_ReconcileOperationsCorrelatesByReference(t *testing.T) {
+	expression := func(reference, operation string) IncidentEngineExpression {
+		return IncidentEngineExpression{
+			Reference: types.StringValue(reference),
+			Operations: IncidentEngineExpressionOperations{
+				{
+					OperationType: types.StringValue("filter"),
+					Filter: &IncidentEngineExpressionFilterOpts{
+						ConditionGroups: IncidentEngineConditionGroups{
+							{Conditions: IncidentEngineConditions{
+								{
+									Subject:   types.StringValue("alert.attributes.01ABC"),
+									Operation: types.StringValue(operation),
+								},
+							}},
+						},
+					},
+				},
+			},
+		}
+	}
+	operationOf := func(e IncidentEngineExpression) string {
+		return e.Operations[0].Filter.ConditionGroups[0].Conditions[0].Operation.ValueString()
+	}
+
+	applied := IncidentEngineExpressions{
+		expression("first", "contains_one_of"),
+		expression("second", "contains_one_of"),
+	}
+	// The plan holds the same expressions in the opposite order.
+	plan := IncidentEngineExpressions{
+		expression("second", "one_of"),
+		expression("first", "one_of"),
+	}
+
+	applied.ReconcileOperations(plan)
+
+	assert.Equal(t, "one_of", operationOf(applied[0]), "first expression reconciled")
+	assert.Equal(t, "one_of", operationOf(applied[1]), "second expression reconciled")
+
+	// An unplanned expression is left alone, and a nil plan must not panic.
+	unplanned := IncidentEngineExpressions{expression("third", "contains_one_of")}
+	assert.NotPanics(t, func() { unplanned.ReconcileOperations(plan) })
+	assert.Equal(t, "contains_one_of", operationOf(unplanned[0]))
+	assert.NotPanics(t, func() { unplanned.ReconcileOperations(nil) })
 }
 
 func TestIncidentEngineParamBinding_IsEmpty(t *testing.T) {

--- a/internal/provider/models/engine_test.go
+++ b/internal/provider/models/engine_test.go
@@ -145,6 +145,96 @@ func TestIncidentEngineParamBindings_TrimAppendedEmpty(t *testing.T) {
 	}
 }
 
+// TestIncidentEngineConditionGroups_ReconcileOperations covers ONC-12602: the
+// alert-route API accepts `one_of` on a String subject but stores and returns
+// `contains_one_of`. Without reconciliation the read-back operation disagrees
+// with the plan and apply fails with "Provider produced inconsistent result
+// after apply". ReconcileOperations must restore the planned value for that
+// known normalisation while leaving genuine changes and unrelated values alone.
+func TestIncidentEngineConditionGroups_ReconcileOperations(t *testing.T) {
+	condition := func(subject, operation string) IncidentEngineCondition {
+		return IncidentEngineCondition{
+			Subject:   types.StringValue(subject),
+			Operation: types.StringValue(operation),
+		}
+	}
+	groups := func(conds ...IncidentEngineCondition) IncidentEngineConditionGroups {
+		return IncidentEngineConditionGroups{{Conditions: IncidentEngineConditions(conds)}}
+	}
+
+	tests := []struct {
+		name    string
+		applied IncidentEngineConditionGroups
+		plan    IncidentEngineConditionGroups
+		want    string
+	}{
+		{
+			name:    "restores planned one_of when API returns contains_one_of",
+			applied: groups(condition("alert.attributes.01ABC", "contains_one_of")),
+			plan:    groups(condition("alert.attributes.01ABC", "one_of")),
+			want:    "one_of",
+		},
+		{
+			name:    "restores planned not_one_of when API returns not_contains_one_of",
+			applied: groups(condition("alert.attributes.01ABC", "not_contains_one_of")),
+			plan:    groups(condition("alert.attributes.01ABC", "not_one_of")),
+			want:    "not_one_of",
+		},
+		{
+			name:    "leaves matching operations untouched",
+			applied: groups(condition("alert.attributes.01ABC", "one_of")),
+			plan:    groups(condition("alert.attributes.01ABC", "one_of")),
+			want:    "one_of",
+		},
+		{
+			name:    "does not mask an unrelated divergence",
+			applied: groups(condition("alert.attributes.01ABC", "is_set")),
+			plan:    groups(condition("alert.attributes.01ABC", "one_of")),
+			want:    "is_set",
+		},
+		{
+			name:    "does not reconcile across a different subject",
+			applied: groups(condition("alert.attributes.02XYZ", "contains_one_of")),
+			plan:    groups(condition("alert.attributes.01ABC", "one_of")),
+			want:    "contains_one_of",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.applied.ReconcileOperations(tc.plan)
+			got := tc.applied[0].Conditions[0].Operation.ValueString()
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestIncidentEngineConditionGroups_ReconcileOperationsMismatchedLengths
+// asserts that reconciliation is safe when the plan and read-back have
+// different numbers of groups or conditions (it correlates positionally and
+// stops at the shorter length rather than panicking).
+func TestIncidentEngineConditionGroups_ReconcileOperationsMismatchedLengths(t *testing.T) {
+	applied := IncidentEngineConditionGroups{
+		{Conditions: IncidentEngineConditions{
+			{Subject: types.StringValue("alert.attributes.01ABC"), Operation: types.StringValue("contains_one_of")},
+			{Subject: types.StringValue("alert.attributes.02XYZ"), Operation: types.StringValue("contains_one_of")},
+		}},
+	}
+	plan := IncidentEngineConditionGroups{
+		{Conditions: IncidentEngineConditions{
+			{Subject: types.StringValue("alert.attributes.01ABC"), Operation: types.StringValue("one_of")},
+		}},
+	}
+
+	assert.NotPanics(t, func() { applied.ReconcileOperations(plan) })
+	assert.Equal(t, "one_of", applied[0].Conditions[0].Operation.ValueString())
+	// The second condition has no planned counterpart, so it is left as-is.
+	assert.Equal(t, "contains_one_of", applied[0].Conditions[1].Operation.ValueString())
+
+	// A nil plan must be a no-op rather than a panic.
+	assert.NotPanics(t, func() { applied.ReconcileOperations(nil) })
+}
+
 func TestIncidentEngineParamBinding_IsEmpty(t *testing.T) {
 	assert.True(t, IncidentEngineParamBinding{}.IsEmpty(), "zero binding is empty")
 	assert.True(t, IncidentEngineParamBinding{ArrayValue: []IncidentEngineParamBindingValue{}}.IsEmpty(),

--- a/internal/provider/schema_converters.go
+++ b/internal/provider/schema_converters.go
@@ -70,6 +70,12 @@ func (r *IncidentWorkflowResource) buildModel(ctx context.Context, workflow clie
 			ForSeconds:               types.Int64Value(workflow.Delay.ForSeconds),
 		}
 	}
+
+	if prior != nil {
+		model.ConditionGroups.ReconcileOperations(prior.ConditionGroups)
+		model.Expressions.ReconcileOperations(prior.Expressions)
+	}
+
 	return model
 }
 

--- a/internal/provider/schema_converters_test.go
+++ b/internal/provider/schema_converters_test.go
@@ -1,0 +1,54 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/incident-io/terraform-provider-incident/internal/client"
+	"github.com/incident-io/terraform-provider-incident/internal/provider/models"
+)
+
+// TestWorkflowBuildModelReconcilesConditionOperation covers ONC-12602 for
+// workflows, which carry condition groups just like alert routes do.
+func TestWorkflowBuildModelReconcilesConditionOperation(t *testing.T) {
+	workflow := client.WorkflowV2{
+		Id:   "01ABC",
+		Name: "workflow",
+		ConditionGroups: []client.ConditionGroupV2{
+			{
+				Conditions: []client.ConditionV2{
+					{
+						Subject:   client.ConditionSubjectV2{Reference: "incident.custom_field.01GH"},
+						Operation: client.ConditionOperationV2{Value: "contains_one_of"},
+					},
+				},
+			},
+		},
+	}
+
+	prior := &IncidentWorkflowResourceModel{
+		ConditionGroups: models.IncidentEngineConditionGroups{
+			{
+				Conditions: models.IncidentEngineConditions{
+					{
+						Subject:   types.StringValue("incident.custom_field.01GH"),
+						Operation: types.StringValue("one_of"),
+					},
+				},
+			},
+		},
+	}
+
+	r := &IncidentWorkflowResource{}
+
+	withPrior := r.buildModel(context.Background(), workflow, prior)
+	assert.Equal(t, "one_of", withPrior.ConditionGroups[0].Conditions[0].Operation.ValueString(),
+		"with a plan the operation should be reconciled")
+
+	noPrior := r.buildModel(context.Background(), workflow, nil)
+	assert.Equal(t, "contains_one_of", noPrior.ConditionGroups[0].Conditions[0].Operation.ValueString(),
+		"with no plan the operation should stay verbatim")
+}


### PR DESCRIPTION
The bug: In Terraform you write operation = "one_of" on an alert route condition. The API accepts it, but when the provider reads the route back, the API says contains_one_of instead. Terraform sees the result not matching the plan, so it errors and marks the route broken. The next apply does the same thing. It never succeeds.

Why: `one_of` is an old name for `contains_one_of`. Our engine still accepts it, and stores exactly what you sent. But when it reads the condition back out, it returns the new name. So input and output do not match, which Terraform will not tolerate.

The fix in the PR: The provider remembers what you planned. If the API returns `contains_one_of` and you asked for `one_of`, it keeps your `one_of`. Any other difference is still reported as normal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes post-apply state shaping for condition operations across several resources; behavior is limited to documented alias pairs and matching subjects, but mistakes could hide real API drift.
> 
> **Overview**
> Fixes **ONC-12602**, where configs using engine condition operation aliases (e.g. `one_of` on alert attributes) failed every apply because the API returns the canonical name (`contains_one_of`) and Terraform treated that as a state/plan mismatch.
> 
> Adds **`ReconcileOperations`** on shared engine models: when building state from an API response, if the planned operation is a known alias and the API returned its canonical form (with matching subject), state keeps the **planned** string. The same logic runs for nested condition groups in **alert routes** (v2/v3: top-level, alert sources, channel/message destinations, incident config, expression filters/branches), **maintenance windows**, and **workflows**. Imports and reads without a prior plan still store the API value verbatim.
> 
> Also adds unit tests and a live **`incident_alert_route`** acceptance test for `one_of` / empty-plan refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c8ad71e71ead0723a01eb78a5c1b094d142b7eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->