### PR TITLE
Resolve user email lookup to the single active user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@
 - `incident_user` lookups by `email` now resolve to the single active user when
   several users share that email, rather than failing with "Multiple users
   found". Duplicate accounts (e.g. a deactivated leftover from a user merge
-  alongside a live SSO account) no longer break an apply. Lookups still error
+  alongside a live SSO account) no longer break an apply. The plan warns when a
+  lookup resolves this way, and names the user it picked. Set `id` or
+  `slack_user_id` to choose the user yourself. Lookups still error
   when several matching users are active, or when none are.
 
 ## v6.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
 ## v6.1.2
 
 - Check an `incident_alert_source`'s template at plan time. A reference that doesn't resolve, or a merge strategy the attribute doesn't support, now fails the plan. Previously it failed part way through an apply, after other resources had been created. Templates whose values aren't known until apply are left alone, and when the check can't run the plan warns rather than failing.
+- `incident_user` lookups by `email` now resolve to the single active user when
+  several users share that email, rather than failing with "Multiple users
+  found". Duplicate accounts (e.g. a deactivated leftover from a user merge
+  alongside a live SSO account) no longer break an apply. Lookups still error
+  when several matching users are active, or when none are.
 
 ## v6.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Unreleased
 
+- `incident_user` lookups by `email` now resolve to the single active user when
+  several users share that email, instead of failing with "Multiple users
+  found". A deactivated leftover from a user merge alongside a live SSO account
+  no longer breaks an apply. The plan warns when a lookup resolves this way, and
+  names the user it picked. Set `id` or `slack_user_id` to choose the user
+  yourself. Lookups still fail when several matches are active, or when none
+  are. A user who was invited but never logged in counts as inactive.
+
 ## v6.2.1
 
 - Fix a permanent diff after importing an `incident_alert_source_beta` that was created in the dashboard. Its `title` and `description` read back as raw JSON rather than the equivalent `{{ }}` template, so every plan showed a change on fields that hadn't changed.
@@ -12,13 +20,6 @@
 ## v6.1.2
 
 - Check an `incident_alert_source`'s template at plan time. A reference that doesn't resolve, or a merge strategy the attribute doesn't support, now fails the plan. Previously it failed part way through an apply, after other resources had been created. Templates whose values aren't known until apply are left alone, and when the check can't run the plan warns rather than failing.
-- `incident_user` lookups by `email` now resolve to the single active user when
-  several users share that email, instead of failing with "Multiple users
-  found". A deactivated leftover from a user merge alongside a live SSO account
-  no longer breaks an apply. The plan warns when a lookup resolves this way, and
-  names the user it picked. Set `id` or `slack_user_id` to choose the user
-  yourself. Lookups still fail when several matches are active, or when none
-  are. A user who was invited but never logged in counts as inactive.
 
 ## v6.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,12 @@
 
 - Check an `incident_alert_source`'s template at plan time. A reference that doesn't resolve, or a merge strategy the attribute doesn't support, now fails the plan. Previously it failed part way through an apply, after other resources had been created. Templates whose values aren't known until apply are left alone, and when the check can't run the plan warns rather than failing.
 - `incident_user` lookups by `email` now resolve to the single active user when
-  several users share that email, rather than failing with "Multiple users
-  found". Duplicate accounts (e.g. a deactivated leftover from a user merge
-  alongside a live SSO account) no longer break an apply. The plan warns when a
-  lookup resolves this way, and names the user it picked. Set `id` or
-  `slack_user_id` to choose the user yourself. Lookups still error
-  when several matching users are active, or when none are.
+  several users share that email, instead of failing with "Multiple users
+  found". A deactivated leftover from a user merge alongside a live SSO account
+  no longer breaks an apply. The plan warns when a lookup resolves this way, and
+  names the user it picked. Set `id` or `slack_user_id` to choose the user
+  yourself. Lookups still fail when several matches are active, or when none
+  are. A user who was invited but never logged in counts as inactive.
 
 ## v6.1.1
 

--- a/internal/provider/incident_user_data_source.go
+++ b/internal/provider/incident_user_data_source.go
@@ -161,7 +161,7 @@ func (i *IncidentUserDataSource) Read(ctx context.Context, req datasource.ReadRe
 func selectUserByEmail(users []client.UserWithRolesV2) (*client.UserWithRolesV2, error) {
 	switch len(users) {
 	case 0:
-		return nil, fmt.Errorf("User not found")
+		return nil, fmt.Errorf("user not found")
 	case 1:
 		return &users[0], nil
 	}
@@ -174,7 +174,7 @@ func selectUserByEmail(users []client.UserWithRolesV2) (*client.UserWithRolesV2,
 	}
 
 	return nil, fmt.Errorf(
-		"Multiple users found (%d matches, %d of them active) — refine the lookup by using id or slack_user_id instead",
+		"multiple users found (%d matches, %d of them active) — refine the lookup by using id or slack_user_id instead",
 		len(users), len(active),
 	)
 }

--- a/internal/provider/incident_user_data_source.go
+++ b/internal/provider/incident_user_data_source.go
@@ -92,6 +92,17 @@ func (i *IncidentUserDataSource) Read(ctx context.Context, req datasource.ReadRe
 			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read user, got error: %s", err))
 			return
 		}
+		// Picking the active user is a guess at what the config meant.
+		if len(result.JSON200.Users) > 1 {
+			resp.Diagnostics.AddWarning(
+				"Ambiguous user lookup",
+				fmt.Sprintf(
+					"%d users match the email %q. Terraform picked the only active one: %s (id %s). "+
+						"Set id or slack_user_id to choose the user yourself.",
+					len(result.JSON200.Users), data.Email.ValueString(), match.Name, match.Id,
+				),
+			)
+		}
 		user = match
 	} else if !data.SlackUserID.IsNull() {
 		result, err := i.client.UsersV2ListWithResponse(ctx, &client.UsersV2ListParams{

--- a/internal/provider/incident_user_data_source.go
+++ b/internal/provider/incident_user_data_source.go
@@ -160,15 +160,13 @@ func (i *IncidentUserDataSource) Read(ctx context.Context, req datasource.ReadRe
 // selectUserByEmail picks the user a config means when an email lookup returns
 // more than one match.
 //
-// We list with include_inactive so a deactivated user still resolves, which
-// means an email can legitimately match several rows: e.g. an old deactivated
-// account plus the live SSO one, or a duplicate that was merged and later had
-// its PII scrubbed. In that case there is normally exactly one active user, and
-// that's unambiguously the one the config wants — so return it rather than
-// failing the apply.
+// We list with include_inactive, and duplicate rows are common: a SAML or SCIM
+// identity and a chat identity for the same person land on separate rows, and
+// consolidating them deactivates the loser rather than deleting it. Where
+// exactly one match is still active, that's the one the config wants.
 //
-// We only fail when the ambiguity is real: several active users share the
-// email, or every match is inactive (nothing to sensibly prefer).
+// Note is_active is false for users who were invited but never logged in, not
+// just for deactivated ones.
 func selectUserByEmail(users []client.UserWithRolesV2) (*client.UserWithRolesV2, error) {
 	switch len(users) {
 	case 0:

--- a/internal/provider/incident_user_data_source.go
+++ b/internal/provider/incident_user_data_source.go
@@ -87,14 +87,12 @@ func (i *IncidentUserDataSource) Read(ctx context.Context, req datasource.ReadRe
 			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read user, got error: %s", err))
 			return
 		}
-		if len(result.JSON200.Users) == 0 {
-			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read user, got error: %s", "User not found"))
-			return
-		} else if len(result.JSON200.Users) > 1 {
-			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read user, got error: %s", "Multiple users found"))
+		match, err := selectUserByEmail(result.JSON200.Users)
+		if err != nil {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read user, got error: %s", err))
 			return
 		}
-		user = &result.JSON200.Users[0]
+		user = match
 	} else if !data.SlackUserID.IsNull() {
 		result, err := i.client.UsersV2ListWithResponse(ctx, &client.UsersV2ListParams{
 			SlackUserId:     data.SlackUserID.ValueStringPointer(),
@@ -146,6 +144,39 @@ func (i *IncidentUserDataSource) Read(ctx context.Context, req datasource.ReadRe
 
 	modelResp := i.buildModel(*user)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &modelResp)...)
+}
+
+// selectUserByEmail picks the user a config means when an email lookup returns
+// more than one match.
+//
+// We list with include_inactive so a deactivated user still resolves, which
+// means an email can legitimately match several rows: e.g. an old deactivated
+// account plus the live SSO one, or a duplicate that was merged and later had
+// its PII scrubbed. In that case there is normally exactly one active user, and
+// that's unambiguously the one the config wants — so return it rather than
+// failing the apply.
+//
+// We only fail when the ambiguity is real: several active users share the
+// email, or every match is inactive (nothing to sensibly prefer).
+func selectUserByEmail(users []client.UserWithRolesV2) (*client.UserWithRolesV2, error) {
+	switch len(users) {
+	case 0:
+		return nil, fmt.Errorf("User not found")
+	case 1:
+		return &users[0], nil
+	}
+
+	active := lo.Filter(users, func(user client.UserWithRolesV2, _ int) bool {
+		return user.IsActive
+	})
+	if len(active) == 1 {
+		return &active[0], nil
+	}
+
+	return nil, fmt.Errorf(
+		"Multiple users found (%d matches, %d of them active) — refine the lookup by using id or slack_user_id instead",
+		len(users), len(active),
+	)
 }
 
 func (i *IncidentUserDataSource) buildModel(userType client.UserWithRolesV2) *IncidentUserDataSourceModel {

--- a/internal/provider/incident_user_data_source_test.go
+++ b/internal/provider/incident_user_data_source_test.go
@@ -40,7 +40,7 @@ func TestSelectUserByEmail(t *testing.T) {
 			// The reported bug (PR-497): a deactivated duplicate left over from
 			// a merge broke the lookup for the live SSO account.
 			name:   "one active alongside deactivated duplicates",
-			users:  []client.UserWithRolesV2{user("deactivated", false), user("live", true), user("scrubbed", false)},
+			users:  []client.UserWithRolesV2{user("deactivated-slack", false), user("live", true), user("deactivated-saml", false)},
 			wantID: "live",
 		},
 		{

--- a/internal/provider/incident_user_data_source_test.go
+++ b/internal/provider/incident_user_data_source_test.go
@@ -1,0 +1,75 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/incident-io/terraform-provider-incident/internal/client"
+)
+
+// TestSelectUserByEmail covers picking a user when an email lookup matches more
+// than one row, which happens because we list with include_inactive.
+func TestSelectUserByEmail(t *testing.T) {
+	user := func(id string, isActive bool) client.UserWithRolesV2 {
+		return client.UserWithRolesV2{Id: id, Name: id, IsActive: isActive}
+	}
+
+	cases := []struct {
+		name    string
+		users   []client.UserWithRolesV2
+		wantID  string
+		wantErr bool
+	}{
+		{
+			name:    "no matches errors",
+			users:   nil,
+			wantErr: true,
+		},
+		{
+			name:   "single active match",
+			users:  []client.UserWithRolesV2{user("active", true)},
+			wantID: "active",
+		},
+		{
+			// A user who has since been offboarded must still resolve, so an
+			// apply doesn't break the moment they're deactivated.
+			name:   "single inactive match still resolves",
+			users:  []client.UserWithRolesV2{user("inactive", false)},
+			wantID: "inactive",
+		},
+		{
+			// The reported bug (PR-497): a deactivated duplicate left over from
+			// a merge broke the lookup for the live SSO account.
+			name:   "one active alongside deactivated duplicates",
+			users:  []client.UserWithRolesV2{user("deactivated", false), user("live", true), user("scrubbed", false)},
+			wantID: "live",
+		},
+		{
+			name:    "several active matches is genuinely ambiguous",
+			users:   []client.UserWithRolesV2{user("one", true), user("two", true)},
+			wantErr: true,
+		},
+		{
+			name:    "several matches with none active is ambiguous",
+			users:   []client.UserWithRolesV2{user("one", false), user("two", false)},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := selectUserByEmail(tc.users)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got user %v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if got.Id != tc.wantID {
+				t.Errorf("got user %q, want %q", got.Id, tc.wantID)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

[PR-497](https://linear.app/incident-io/issue/PR-497/duplicate-users-cant-be-merged-once-one-side-is-already-deactivated)

The `incident_user` data source lists users with `include_inactive` so someone who has been offboarded still resolves, rather than breaking an apply. The consequence is that an email can legitimately match several rows — a deactivated leftover from a user merge alongside the live SSO account — and we failed the whole lookup with `Multiple users found`.

That's what bit the customer on PR-497: a deactivated duplicate meant their Terraform email lookup returned two users instead of one, and the only fix available at the time was scrubbing the dead row's PII by hand in production.

Duplicate rows exist because a SAML or SCIM identity and a chat identity for the same person can land on separate `users` rows. Consolidating them deactivates the loser rather than deleting it, so the duplicate stays visible under `include_inactive`.

## Fix

Route the email lookup through a `selectUserByEmail` helper:

- no matches → error, as before
- one match, active or not → resolves, as before
- several matches with **exactly one active** → return the active user
- several active matches, or every match inactive → still an error, now reporting the counts and suggesting `id` / `slack_user_id`

When the helper disambiguates, the plan emits a warning naming the user it picked. Choosing the single active user is a guess at intent: it's right for a true duplicate, but where the matches are different people it would otherwise bind a schedule rotation or a `maintenance_window` lead to someone the author didn't choose, with nothing to notice. The warning makes that visible at plan time.

`slack_user_id` lookups are left alone — different duplicate story.

## Scope, and what this does not fix

`is_active` is false for users who were **invited but never logged in**, not just deactivated ones. So a duplicate pair where neither row is active still errors.

Checking production data, of the duplicate-email groups that exist today:

| Outcome after this change | Groups | Orgs |
|---|---|---|
| Newly resolves, same name on every row | 1,193 | 193 |
| Newly resolves, names differ across rows | 120 | 52 |
| Still errors — no active match | 10,081 | 262 |
| Still errors — several active | 117 | 54 |

Two things worth knowing before this lands:

1. This addresses roughly 11% of duplicate-email situations. The large "no active match" group is unchanged, and includes the offboarded-user shape the data source's `include_inactive` was added for.
2. The ~120 groups whose rows carry different names are where the warning earns its place — the surviving active user may not be the person the config meant.

This is strictly error → success. Every lookup that plans cleanly today resolves to the same user ID afterwards, so upgrading cannot silently re-point an existing working config.

## Testing

Added a table test over `selectUserByEmail` covering each case above, including the PR-497 shape (deactivated duplicate + live SSO account → returns the live one). `go build ./...`, `go vet ./internal/...` and the unit suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Disambiguation can bind schedules or rotations to a different person when duplicate emails are not true duplicates; mitigated by plan warnings and unchanged behavior for already-unambiguous lookups.
> 
> **Overview**
> **`incident_user` email lookups** no longer fail with "Multiple users found" when several rows share an email but **exactly one is active** (typical after a merge leaves deactivated SAML/Slack duplicates). Selection goes through new **`selectUserByEmail`**; zero matches, a single match, and multiple active or all-inactive matches behave as before (error with clearer counts where ambiguous).
> 
> When Terraform disambiguates, the **plan emits a warning** naming the user and id it chose and suggests **`id`** or **`slack_user_id`** for an explicit lookup. **`slack_user_id`** lookup logic is unchanged.
> 
> **CHANGELOG** documents the behavior; **table tests** cover `selectUserByEmail` including the deactivated-duplicate + live SSO case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a181bcb4215fd8a78e37c7610692803f8f46e4c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->