### PR TITLE
Fix alert route requiring v2 alert route fields when using for_each

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Unreleased
 
+- Fix `incident_alert_route` wrongly requiring the deprecated v2 attributes
+  (`incident_template`, `incident_config.auto_decline_enabled` /
+  `grouping_window_seconds` / `defer_time_seconds`) when the resource is driven
+  by `for_each`/`count`, or when `grouping_config` otherwise derives from an
+  unknown value. `ValidateConfig` selects the v2/v3 schema mode from the
+  top-level `grouping_config` block; it now skips the mode-specific checks when
+  that value is unknown at plan time instead of assuming the v2 schema.
+
 ## v6.1.0
 
 - Add optional `retry_config` to `incident_escalation_path` levels, allowing you

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,7 @@
 ## Unreleased
 
-- Fix `incident_alert_route` wrongly requiring the deprecated v2 attributes
-  (`incident_template`, `incident_config.auto_decline_enabled` /
-  `grouping_window_seconds` / `defer_time_seconds`) when the resource is driven
-  by `for_each`/`count`, or when `grouping_config` otherwise derives from an
-  unknown value. `ValidateConfig` selects the v2/v3 schema mode from the
-  top-level `grouping_config` block; it now skips the mode-specific checks when
-  that value is unknown at plan time instead of assuming the v2 schema.
+- Fix `incident_alert_route` wrongly requiring deprecated v2 attributes
+  (`incident_template` etc.) when the resource is driven by `for_each`/`count`.
 
 ## v6.1.0
 

--- a/internal/provider/incident_alert_route_validate.go
+++ b/internal/provider/incident_alert_route_validate.go
@@ -97,6 +97,22 @@ func (r *IncidentAlertRouteResource) ValidateConfig(ctx context.Context, req res
 	}
 
 	groupingBase := path.Root("grouping_config")
+
+	// The schema mode (v2 vs v3) is selected by whether the top-level
+	// grouping_config block is set. When it is unknown — e.g. sourced from
+	// each.value under for_each/count, or from a variable — we can't tell which
+	// mode the user is targeting, so we skip the mode-specific requiredness and
+	// mutual-exclusion checks rather than guessing. Guessing v2 (which objectSet
+	// does, treating unknown the same as null) wrongly demands the v2-only fields
+	// (incident_template, incident_config.auto_decline_enabled / grouping_window_seconds
+	// / defer_time_seconds) of a config that is actually v3, and vice versa. The
+	// concrete value is validated once the instance is expanded and known.
+	// Expression validation below is mode-independent and still runs.
+	var groupingObj types.Object
+	if d := req.Config.GetAttribute(ctx, groupingBase, &groupingObj); !d.HasError() && groupingObj.IsUnknown() {
+		r.validateExpressions(ctx, req, resp)
+		return
+	}
 	isV3 := objectSet(groupingBase)
 
 	escalationBase := path.Root("escalation_config")

--- a/internal/provider/incident_alert_route_validate_test.go
+++ b/internal/provider/incident_alert_route_validate_test.go
@@ -297,6 +297,72 @@ resource "incident_alert_route" "test" {
 	})
 }
 
+// TestIncidentAlertRouteResource_ValidateConfigForEachUnknownGrouping is a
+// regression test for the case where the whole grouping_config object is
+// unknown at ValidateConfig time. Under for_each/count, Terraform validates the
+// resource block once with each.value entirely unknown, so
+// `grouping_config = each.value.grouping_config` is unknown. The mode selector
+// must not treat that unknown as v2 mode and demand the v2-only required fields
+// (incident_template, incident_config.auto_decline_enabled / grouping_window_seconds
+// / defer_time_seconds) — this config is a valid v3 route.
+func TestIncidentAlertRouteResource_ValidateConfigForEachUnknownGrouping(t *testing.T) {
+	config := `
+locals {
+  routes = {
+    "a" = {
+      grouping_config = { default = { enabled = false } }
+    }
+  }
+}
+
+resource "incident_alert_route" "test" {
+  for_each = local.routes
+
+  name       = "validate-foreach-${each.key}"
+  enabled    = true
+  is_private = false
+
+  alert_sources = [
+    {
+      alert_source_id  = "01SRC"
+      condition_groups = []
+    }
+  ]
+  condition_groups = []
+  expressions      = []
+
+  # Unknown at ValidateConfig time: each.value is unknown until for_each expands.
+  grouping_config = each.value.grouping_config
+
+  message_config = {
+    destinations = []
+  }
+
+  escalation_config = {
+    auto_cancel_escalations = true
+    escalation_targets      = []
+  }
+
+  incident_config = {
+    enabled          = false
+    condition_groups = []
+  }
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:             config,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestIncidentAlertRouteResource_ValidateConfig(t *testing.T) {
 	cases := []struct {
 		name   string


### PR DESCRIPTION
The alert route resource supports both the V2 and V3 public APIs. When validating or applying the config from Terraform, we check whether the `grouping_config` attribute is set. If so, we assume that the config is v3, otherwise v2, and then validate the rest of the config accordingly.

However, when using `for_each`, the validator does not see that `grouping_config` is set, assumes that the config is therefore v2, and fails validation of anything which is actually valid v3. We then surface an error message to the user, which is misleading (it complains that various v2 fields are not set).

## Root cause

The schema picks v2 vs v3 mode from whether the top-level `grouping_config` block is set (`incident_alert_route_validate.go`):

```go
isV3 := objectSet(groupingBase) // objectSet treats unknown the same as null
```

Under `for_each`/`count`, Terraform runs `ValidateConfig` once against the un-expanded block, where `each.value` — and therefore `grouping_config = each.value.grouping_config` — is **unknown**. `objectSet` returns `false` for unknown, so the validator assumes the legacy v2 schema and demands the v2-only required attributes (`incident_template`, `incident_config.auto_decline_enabled` / `grouping_window_seconds` / `defer_time_seconds`), which a v3 config doesn't have.

The same happens whenever `grouping_config` derives from a variable or another resource's computed value. The required-field checks themselves already skip unknowns (they use the `*Missing` helpers = null-but-not-unknown) — only the *mode selector* didn't.

## Fix

When `grouping_config` is unknown, skip the mode-specific requiredness and mutual-exclusion checks rather than guessing the mode. The concrete value is validated once the instance is expanded and known. Mode-independent expression validation still runs.

## Verification

- Added `TestIncidentAlertRouteResource_ValidateConfigForEachUnknownGrouping`, which reproduces the reported failure via `for_each`. It fails on `master` with the exact error above and passes with this change (red→green confirmed).
- The full `ValidateConfig` unit-test suite passes.
- Reproduced end-to-end against a real customer `routes.tf` (15 routes via `for_each`): fails on `master`, validates cleanly with a locally-built patched provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

!review #reviews-integration-experience

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to plan-time validation for incident_alert_route; known configs still validate fully once grouping_config is known.
> 
> **Overview**
> Fixes **`incident_alert_route`** plan/validate failures when **`grouping_config`** is unknown at **`ValidateConfig`** time (e.g. `grouping_config = each.value.grouping_config` under **`for_each`**/`count`, or values from variables/computed attributes).
> 
> **`ValidateConfig`** used presence of **`grouping_config`** to choose v2 vs v3; unknown was treated like unset, so the validator assumed legacy v2 and required deprecated fields such as **`incident_template`** even for v3 configs. When **`grouping_config`** is unknown, the provider now **skips mode-specific requiredness and mutual-exclusion checks**, runs expression validation only, and defers full checks until the instance value is known after expansion.
> 
> Adds a **`for_each`** regression unit test and an **Unreleased** CHANGELOG note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ddf86558781cf4696ef067ba12a6d7e7bcd0939. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->