### PR TITLE
Changelog for v6.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## v6.1.1
+
 - Fix `incident_alert_route` wrongly requiring deprecated v2 attributes
   (`incident_template` etc.) when the resource is driven by `for_each`/`count`.
 


### PR DESCRIPTION
Rolls the `## Unreleased` entry into a `## v6.1.1` heading ahead of tagging the patch release.

v6.1.1 contains the fix from #457 — `incident_alert_route` no longer wrongly requires the deprecated v2 attributes (`incident_template` etc.) when the resource is driven by `for_each`/`count`.

Once merged, tag `v6.1.1` on the tip of `master` to trigger the release.

!review #reviews-integration-experience

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog edit with no runtime or provider code changes.
> 
> **Overview**
> Prepares the **v6.1.1** patch release by adding a `## v6.1.1` section in `CHANGELOG.md` and moving the former **Unreleased** note there; **Unreleased** stays empty for the next cycle.
> 
> The v6.1.1 notes document the fix from #457: **`incident_alert_route`** no longer incorrectly requires deprecated v2 fields (`incident_template`, etc.) when the resource is used with **`for_each`** or **`count`**. Merging is intended to be followed by tagging **`v6.1.1`** on `master` to publish the release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7aac0cd38e1466fcc81cbe87306d495fcf385c53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->