### PR TITLE
Changelog for v6.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## v6.1.2
+
 - Check an `incident_alert_source`'s template at plan time. A reference that doesn't resolve, or a merge strategy the attribute doesn't support, now fails the plan. Previously it failed part way through an apply, after other resources had been created. Templates whose values aren't known until apply are left alone, and when the check can't run the plan warns rather than failing.
 
 ## v6.1.1


### PR DESCRIPTION
Rolls the `## Unreleased` entry into a `## v6.1.2` heading ahead of tagging the patch release.

v6.1.2 contains the fix from #452 — an `incident_alert_source`'s template is now checked at plan time rather than failing part way through an apply.

Cut separately from the `incident_alert_source_beta` / `incident_alert_source_attribute_beta` work in #459, which is additive and will ship as its own v6.2.0 once merged.

Once merged, tag `v6.1.2` on the tip of `master` to trigger the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only release bookkeeping with no provider code or schema changes in this diff.
> 
> **Overview**
> Prepares the **v6.1.2** patch release by adding a `## v6.1.2` section and moving the former **Unreleased** note under it (the **Unreleased** heading stays empty for future entries).
> 
> The documented user-facing change for this tag is **`incident_alert_source` template validation at plan time** (invalid references or unsupported merge strategies fail the plan instead of mid-apply; unknown-at-plan values are skipped; soft warning when validation cannot run).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aba4a1ffcd764b087abedd70f54bd14310c8e7f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->