### PR TITLE
Collapse enveloped rich text so imports dont diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Fix a permanent diff after importing an `incident_alert_source_beta` that was created in the dashboard. Its `title` and `description` read back as raw JSON rather than the equivalent `{{ }}` template, so every plan showed a change on fields that hadn't changed.
+
 ## v6.2.0
 
 - Add beta support for splitting an alert source from the attributes it populates, as `incident_alert_source_beta` and `incident_alert_source_attribute_beta` resources. `incident_alert_source_beta` manages just the source itself (name, type, title, description, priority, options); each attribute binding is its own `incident_alert_source_attribute_beta` resource with its own lifecycle, so filling in one more attribute doesn't mean rewriting every other attribute on the same source. These resources are beta: their schemas may change in ways that aren't backwards compatible while we settle the design. The existing `incident_alert_source` resource is unchanged and not deprecated.

--- a/internal/provider/richtexttypes/convert.go
+++ b/internal/provider/richtexttypes/convert.go
@@ -265,11 +265,43 @@ func FromDocument(doc json.RawMessage) (string, bool) {
 	return template, true
 }
 
+// wireEnvelope captures the two wrapped shapes a stored literal can carry alongside the
+// bare node: the current {schema_version, text_node} envelope the dashboard's template
+// editor writes, and the legacy {root, value_markdown} one. Both wrap the same tree under
+// a different key.
+type wireEnvelope struct {
+	TextNode   *json.RawMessage `json:"text_node"`
+	LegacyRoot *json.RawMessage `json:"root"`
+}
+
+// unwrapDocument returns the bare ProseMirror node the rest of this file works on, peeling
+// off whichever envelope wraps it. A bare node, an envelope with neither key, and anything
+// that isn't JSON all pass through for the caller's own parse to judge.
+//
+// Both callers need it or neither does: emitDocument alone would produce a template that
+// FromDocument then compares against a still-enveloped original and rejects, and normalise
+// alone would leave the AST in state after an import.
+func unwrapDocument(doc json.RawMessage) json.RawMessage {
+	var envelope wireEnvelope
+	if err := json.Unmarshal(doc, &envelope); err != nil {
+		return doc
+	}
+
+	switch {
+	case envelope.TextNode != nil:
+		return *envelope.TextNode
+	case envelope.LegacyRoot != nil:
+		return *envelope.LegacyRoot
+	default:
+		return doc
+	}
+}
+
 // emitDocument renders a document to template form if its shape allows it. Callers want
 // FromDocument, which additionally proves the result round-trips.
 func emitDocument(doc json.RawMessage) (string, bool) {
 	var root wireNode
-	if err := json.Unmarshal(doc, &root); err != nil || root.Type != nodeDoc {
+	if err := json.Unmarshal(unwrapDocument(doc), &root); err != nil || root.Type != nodeDoc {
 		return "", false
 	}
 
@@ -405,14 +437,20 @@ func isDocument(s string) bool {
 }
 
 // normalise canonicalises either form to a comparable AST, so a template and the stored
-// document it corresponds to compare equal.
+// document it corresponds to compare equal. Unwrapping first is what makes that hold for a
+// dashboard-authored document, which arrives enveloped while a template only ever compiles
+// to a bare node.
+//
+// The result never leaves this package — it feeds semantic equality and FromDocument's
+// round-trip check — so dropping the envelope's schema_version here changes only which
+// values compare equal, never what we send or store.
 func normalise(s string) (json.RawMessage, error) {
 	if !isDocument(s) {
 		return ToDocument(s)
 	}
 
 	var tree any
-	if err := json.Unmarshal([]byte(s), &tree); err != nil {
+	if err := json.Unmarshal(unwrapDocument(json.RawMessage(s)), &tree); err != nil {
 		return nil, err
 	}
 

--- a/internal/provider/richtexttypes/templated_text_test.go
+++ b/internal/provider/richtexttypes/templated_text_test.go
@@ -20,6 +20,11 @@ const (
 	plainParagraph    = `{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Payments alert"}]}]}`
 	mentionDocument   = `{"type":"doc","content":[{"type":"paragraph","content":[{"type":"user","attrs":{"id":"01USER"}}]}]}`
 	legacyEnvelope    = `{"root":{"type":"doc","content":[]},"value_markdown":"Payments alert"}`
+
+	// What the dashboard's template editor actually stores: the tree wrapped in
+	// {text_node, schema_version}, carrying the display attrs an editor load rewrites.
+	// Sources built there are the common case.
+	dashboardEnvelope = `{"schema_version":"v1.0.0","text_node":` + dashboardVariable + `}`
 )
 
 // The whole point of the custom type: a raw-AST config and a {{ }} config must both
@@ -33,6 +38,10 @@ func TestStringSemanticEquals(t *testing.T) {
 		{"a template and the document it produces", "{{description}}", bareVariable, true},
 		{"a template and a dashboard-authored document", "{{description}}", dashboardVariable, true},
 		{"a document and an equivalent dashboard-authored one", bareVariable, dashboardVariable, true},
+		// Without unwrapping the envelope these compare unequal, which is a diff on the first
+		// plan after importing a source built in the dashboard.
+		{"a template and the enveloped document the dashboard stores", "{{description}}", dashboardEnvelope, true},
+		{"an enveloped document and its bare equivalent", dashboardEnvelope, bareVariable, true},
 		{"two spellings of the same template", "{{description}}", "{{ description }}", true},
 		{"the same document with keys in a different order", bareVariable, `{"content":[{"content":[{"attrs":{"name":"description"},"type":"varSpec"}],"type":"paragraph"}],"type":"doc"}`, true},
 		{"two different templates", "{{description}}", "{{title}}", false},
@@ -146,6 +155,8 @@ func TestLiteral(t *testing.T) {
 		{"plain text", NewTemplatedTextValue("Payments alert"), lo.ToPtr(plainParagraph)},
 		// The bytes a config wrote must be the bytes stored, or it diffs.
 		{"a raw document", NewTemplatedTextValue(dashboardVariable), lo.ToPtr(dashboardVariable)},
+		// Including an envelope: we read through one, but we never rewrite what a config sends.
+		{"a raw enveloped document", NewTemplatedTextValue(dashboardEnvelope), lo.ToPtr(dashboardEnvelope)},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			got, err := tc.value.Literal()
@@ -186,8 +197,11 @@ func TestNewTemplatedTextFromLiteral(t *testing.T) {
 		{"plain text in a paragraph", plainParagraph, "Payments alert"},
 		// A mention carries an ID the grammar has no syntax for, so a template would delete it.
 		{"a document no template can spell", mentionDocument, mentionDocument},
-		// Never written by us, but stored by older writers.
-		{"a legacy envelope", legacyEnvelope, legacyEnvelope},
+		// Read through the envelope, so an imported source's state holds the template rather
+		// than a wall of AST.
+		{"an enveloped document the dashboard stored", dashboardEnvelope, "{{description}}"},
+		// An envelope is no guarantee of expressibility: this one wraps a doc with no blocks.
+		{"a legacy envelope around an empty document", legacyEnvelope, legacyEnvelope},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := NewTemplatedTextFromLiteral(tc.literal).ValueString(); got != tc.want {

--- a/internal/provider/richtexttypes/testdata/README.md
+++ b/internal/provider/richtexttypes/testdata/README.md
@@ -17,5 +17,9 @@ Each file is a top-level JSON array. Every entry has a `name`, used as the test 
 - `error` is a stable slug, not message text: `unclosed_variable`, `unknown_filter`,
   `invalid_filter_argument`, `empty_variable_name`, `nested_variable`. Each implementation words its
   own diagnostics.
-- `document` is the bare ProseMirror doc (`{"type": "doc", …}`), matching what
-  `template.description.literal` actually holds. Key order is presentational — compare canonically.
+- `document` is usually the bare ProseMirror doc (`{"type": "doc", …}`), which is the shape we
+  *emit*. It is not the only shape `literal` holds: the dashboard's template editor writes the
+  `{schema_version, text_node}` envelope, and older rows carry the legacy
+  `{root, value_markdown}` one. Both appear here, and both collapse — an
+  implementation that only accepts the bare doc gives an imported source a permanent plan diff.
+  Key order is presentational — compare canonically.

--- a/internal/provider/richtexttypes/testdata/documents.json
+++ b/internal/provider/richtexttypes/testdata/documents.json
@@ -514,8 +514,8 @@
         ]
       }
     },
-    "expressible": false,
-    "reason": "envelope shape: root is not a doc node"
+    "expressible": true,
+    "template": "Payments alert"
   },
   {
     "name": "legacy envelope rather than a bare document",
@@ -528,7 +528,7 @@
         ]
       }
     },
-    "expressible": false,
-    "reason": "envelope shape: root is not a doc node"
+    "expressible": true,
+    "template": "Payments alert"
   }
 ]


### PR DESCRIPTION
An alert source created in the dashboard stores its title and description as a rich text document wrapped in an envelope: {schema_version, text_node} ({root, value_markdown} from older rows). richtexttypes only accepted a bare {"type": "doc:} node, so an imported source kept the raw JSON state and a config holding the equivalent {{}} template never compared equal.

unwrapDocument peels off either envelope, called from both emitDocument and normalise.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized to rich-text normalization and import/read paths; behavior change only affects comparison and state representation, not API payloads from explicit config.
> 
> **Overview**
> Fixes **permanent plan diffs** on `title` and `description` after importing dashboard-created `incident_alert_source_beta` resources when config uses `{{ }}` templates but state still held the API’s enveloped JSON.
> 
> Adds **`unwrapDocument`** in `richtexttypes` to peel `{schema_version, text_node}` (dashboard template editor) and legacy `{root, value_markdown}` wrappers before **`emitDocument`** and **`normalise`**, so enveloped literals collapse to templates on read, semantic equality matches templates to stored envelopes, and **`Literal()`** still sends config bytes unchanged. Tests and shared **`documents.json`** fixtures now expect expressible enveloped documents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89228397fe1d72267318f57a11e82914cbac2354. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->