### PR TITLE
changelog for v6.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## v6.2.1
+
 - Fix a permanent diff after importing an `incident_alert_source_beta` that was created in the dashboard. Its `title` and `description` read back as raw JSON rather than the equivalent `{{ }}` template, so every plan showed a change on fields that hadn't changed.
 
 ## v6.2.0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change to the changelog; no provider code or runtime behavior is modified in this diff.
> 
> **Overview**
> Adds a **v6.2.1** section to `CHANGELOG.md` under **Unreleased**, documenting the release fix for `incident_alert_source_beta`.
> 
> After importing a beta alert source created in the dashboard, **`title` and `description` were read into state as raw JSON** instead of the equivalent `{{ }}` template form, so **`terraform plan` kept showing changes** on fields that had not actually been edited. The changelog records that this import/read normalization issue is fixed in v6.2.1.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0990f08c609cd6b8b80e1e95c9ae7445225589e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->