### PR TITLE
Changelog for v6.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## v6.3.0
+
 - `incident_user` lookups by `email` now resolve to the single active user when
   several users share that email, instead of failing with "Multiple users
   found". A deactivated leftover from a user merge alongside a live SSO account


### PR DESCRIPTION
Cuts the unreleased `incident_user` email-lookup change as v6.3.0.

Minor rather than patch: #456 turns a case that previously errored into a successful lookup, and adds a new plan-time warning. No behaviour changes for lookups that already planned cleanly.

Once this merges, `git tag v6.3.0 && git push --tags` publishes to the registry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 2a872d5819a35392490c009385a5f058e85169c8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->