### PR TITLE
Bump Go to 1.26.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/incident-io/terraform-provider-incident
 
-go 1.26.5
+go 1.26.7
 
 require (
 	github.com/Masterminds/sprig v2.22.0+incompatible


### PR DESCRIPTION
Bumps the `go` directive from 1.26.5 to 1.26.7, the latest patch release of Go 1.26.

`go.mod` is the only place the version appears — both the test and release workflows resolve their toolchain with `go-version-file: 'go.mod'`, so CI picks this up automatically.

Verified with `go build`, `go vet`, `go test ./...` and `golangci-lint run` (0 issues) on go1.26.7.

Second half of the stack, dependency updates, is in a follow-up PR based on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch-level Go version bump only; no application or security-logic changes.
> 
> **Overview**
> Bumps the Go toolchain from **1.26.5** to **1.26.7** in `go.mod`. Test and release workflows already pin via `go-version-file: 'go.mod'`, so CI/release pick up the patch automatically.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1beaafe7a4b2e3ff264bc6bd895de017720e5877. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->