### PR TITLE
Bump Go to 1.26.7 in mise.toml

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-go = "1.26.5"
+go = "1.26.7"
 golangci-lint = "latest"
 node = "latest"
 


### PR DESCRIPTION
#469 moved the `go` directive in `go.mod` to 1.26.7 but left `mise.toml` pinned at 1.26.5, so contributors using mise were building on an older patch than CI resolves via `go-version-file: 'go.mod'`. This lines the two up.

Standalone PR off master, not stacked on #470.

Verified by installing the pin and building with it:

```
$ mise install go@1.26.7
mise go@1.26.7 ✓ installed
$ mise exec -- go version
go version go1.26.7 darwin/arm64
$ mise exec -- go build ./... && mise exec -- go test ./...
ok  github.com/incident-io/terraform-provider-incident/internal/provider
ok  github.com/incident-io/terraform-provider-incident/internal/provider/jsontypes
ok  github.com/incident-io/terraform-provider-incident/internal/provider/models
ok  github.com/incident-io/terraform-provider-incident/internal/provider/richtexttypes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line toolchain pin bump with no application or security logic changes.
> 
> **Overview**
> Aligns the local `mise.toml` Go pin with `go.mod` by bumping `go` from **1.26.5** to **1.26.7**, so mise users match the toolchain CI already uses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d58ba6f10b06736d8791456e4ab9353bab0a669d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->