### PR TITLE
Validate escalation paths at plan time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- `incident_escalation_path` now validates its planned config against the API at plan time, so a config the API would reject - such as a target missing a required `selected_rota_id` - fails the plan with the API's own message instead of failing part way through an apply. A path that's valid but has no practical effect, like an `if_else` branch with no nodes, comes back as a plan warning rather than an error.
+
 ## v6.3.0
 
 - `incident_user` lookups by `email` now resolve to the single active user when

--- a/docs/data-sources/escalation_path.md
+++ b/docs/data-sources/escalation_path.md
@@ -46,6 +46,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--delay"></a>
@@ -123,6 +124,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--else_path--delay"></a>
@@ -200,6 +202,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--delay"></a>
@@ -277,6 +280,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--delay"></a>
@@ -354,6 +358,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--delay"></a>
@@ -430,6 +435,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--delay"></a>
@@ -537,6 +543,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--delay"></a>
@@ -723,6 +730,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--delay"></a>
@@ -799,6 +807,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--delay"></a>
@@ -906,6 +915,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--delay"></a>
@@ -1170,6 +1180,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--delay"></a>
@@ -1247,6 +1258,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--delay"></a>
@@ -1323,6 +1335,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--delay"></a>
@@ -1430,6 +1443,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--delay"></a>
@@ -1616,6 +1630,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--delay"></a>
@@ -1692,6 +1707,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--delay"></a>
@@ -1799,6 +1815,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--delay"></a>
@@ -2141,6 +2158,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--delay"></a>
@@ -2218,6 +2236,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--delay"></a>
@@ -2295,6 +2314,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--delay"></a>
@@ -2371,6 +2391,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--delay"></a>
@@ -2478,6 +2499,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--delay"></a>
@@ -2664,6 +2686,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--delay"></a>
@@ -2740,6 +2763,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--delay"></a>
@@ -2847,6 +2871,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--delay"></a>
@@ -3111,6 +3136,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--delay"></a>
@@ -3188,6 +3214,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--delay"></a>
@@ -3264,6 +3291,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--delay"></a>
@@ -3371,6 +3399,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--delay"></a>
@@ -3557,6 +3586,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--delay"></a>
@@ -3633,6 +3663,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--delay"></a>
@@ -3740,6 +3771,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--delay"></a>
@@ -4160,6 +4192,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--then_path--delay"></a>
@@ -4237,6 +4270,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--delay"></a>
@@ -4314,6 +4348,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--delay"></a>
@@ -4391,6 +4426,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--delay"></a>
@@ -4467,6 +4503,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--delay"></a>
@@ -4574,6 +4611,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--delay"></a>
@@ -4760,6 +4798,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--delay"></a>
@@ -4836,6 +4875,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--delay"></a>
@@ -4943,6 +4983,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--delay"></a>
@@ -5207,6 +5248,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--delay"></a>
@@ -5284,6 +5326,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--delay"></a>
@@ -5360,6 +5403,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--delay"></a>
@@ -5467,6 +5511,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--delay"></a>
@@ -5653,6 +5698,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--delay"></a>
@@ -5729,6 +5775,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--delay"></a>
@@ -5836,6 +5883,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--delay"></a>
@@ -6178,6 +6226,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--delay"></a>
@@ -6255,6 +6304,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--delay"></a>
@@ -6332,6 +6382,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--delay"></a>
@@ -6408,6 +6459,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--delay"></a>
@@ -6515,6 +6567,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--delay"></a>
@@ -6701,6 +6754,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--delay"></a>
@@ -6777,6 +6831,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--delay"></a>
@@ -6884,6 +6939,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--delay"></a>
@@ -7148,6 +7204,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--delay"></a>
@@ -7225,6 +7282,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--delay"></a>
@@ -7301,6 +7359,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--delay"></a>
@@ -7408,6 +7467,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--delay"></a>
@@ -7594,6 +7654,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--delay"></a>
@@ -7670,6 +7731,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--delay"></a>
@@ -7777,6 +7839,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--delay"></a>

--- a/docs/resources/escalation_path.md
+++ b/docs/resources/escalation_path.md
@@ -155,6 +155,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -238,6 +239,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -321,6 +323,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -404,6 +407,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -487,6 +491,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -570,6 +575,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -695,6 +701,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -913,6 +920,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -996,6 +1004,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -1121,6 +1130,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -1432,6 +1442,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -1515,6 +1526,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -1598,6 +1610,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -1723,6 +1736,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -1941,6 +1955,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -2024,6 +2039,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -2149,6 +2165,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -2553,6 +2570,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -2636,6 +2654,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -2719,6 +2738,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -2802,6 +2822,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -2927,6 +2948,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -3145,6 +3167,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -3228,6 +3251,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -3353,6 +3377,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -3664,6 +3689,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -3747,6 +3773,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -3830,6 +3857,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -3955,6 +3983,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -4173,6 +4202,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -4256,6 +4286,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -4381,6 +4412,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -4878,6 +4910,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -4961,6 +4994,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -5044,6 +5078,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -5127,6 +5162,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -5210,6 +5246,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -5335,6 +5372,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -5553,6 +5591,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -5636,6 +5675,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -5761,6 +5801,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -6072,6 +6113,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -6155,6 +6197,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -6238,6 +6281,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -6363,6 +6407,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -6581,6 +6626,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -6664,6 +6710,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -6789,6 +6836,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -7193,6 +7241,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -7276,6 +7325,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -7359,6 +7409,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -7442,6 +7493,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -7567,6 +7619,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -7785,6 +7838,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -7868,6 +7922,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -7993,6 +8048,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -8304,6 +8360,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -8387,6 +8444,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -8470,6 +8528,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -8595,6 +8654,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -8813,6 +8873,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -8896,6 +8957,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:
@@ -9021,6 +9083,7 @@ Required:
 * if_else: Branch the escalation based on a set of conditions.
 * repeat: Go back to a previous node and repeat the logic from there.
 * delay: Pause the escalation for a configured duration before advancing to the next node.
+* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 
 Optional:

--- a/internal/apischema/public-schema-v3-including-secret-endpoints.json
+++ b/internal/apischema/public-schema-v3-including-secret-endpoints.json
@@ -93,7 +93,8 @@
               "act_on_behalf_of_users",
               "secrets_manage",
               "secrets_use",
-              "call_transcripts_viewer"
+              "call_transcripts_viewer",
+              "heartbeats_ping"
             ],
             "example": "viewer",
             "type": "string",
@@ -130,7 +131,8 @@
               "workflows_editor",
               "private_workflows_editor",
               "secrets_manage",
-              "secrets_use"
+              "secrets_use",
+              "heartbeats_ping"
             ],
             "example": "catalog_editor",
             "type": "string",
@@ -339,7 +341,8 @@
                 "act_on_behalf_of_users",
                 "secrets_manage",
                 "secrets_use",
-                "call_transcripts_viewer"
+                "call_transcripts_viewer",
+                "heartbeats_ping"
               ],
               "example": "viewer",
               "type": "string"
@@ -374,7 +377,8 @@
                 "workflows_editor",
                 "private_workflows_editor",
                 "secrets_manage",
-                "secrets_use"
+                "secrets_use",
+                "heartbeats_ping"
               ],
               "example": "catalog_editor",
               "type": "string"
@@ -741,7 +745,8 @@
                 "act_on_behalf_of_users",
                 "secrets_manage",
                 "secrets_use",
-                "call_transcripts_viewer"
+                "call_transcripts_viewer",
+                "heartbeats_ping"
               ],
               "example": "viewer",
               "type": "string"
@@ -776,7 +781,8 @@
                 "workflows_editor",
                 "private_workflows_editor",
                 "secrets_manage",
-                "secrets_use"
+                "secrets_use",
+                "heartbeats_ping"
               ],
               "example": "catalog_editor",
               "type": "string"
@@ -24247,6 +24253,98 @@
         ],
         "type": "object"
       },
+      "AuditLogExtensionConnectorCalledMetadataV2": {
+        "example": {
+          "outcome": "success",
+          "source_kind": "mcp",
+          "surface": "chat",
+          "telemetry_query_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "write": "true"
+        },
+        "properties": {
+          "outcome": {
+            "description": "How the call ended (success, error)",
+            "example": "success",
+            "type": "string"
+          },
+          "source_kind": {
+            "description": "The kind of connector that was called (mcp, http)",
+            "example": "mcp",
+            "type": "string"
+          },
+          "surface": {
+            "description": "The product surface the call ran from (chat, investigation, explore, mcp_client, verify), or internal for system paths with no surface",
+            "example": "chat",
+            "type": "string"
+          },
+          "telemetry_query_id": {
+            "description": "ID of our stored record of this call",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "type": "string"
+          },
+          "write": {
+            "description": "Whether the call was permitted to change the connected system (true, false)",
+            "example": "true",
+            "type": "string"
+          }
+        },
+        "required": [
+          "surface",
+          "write",
+          "outcome",
+          "source_kind"
+        ],
+        "type": "object"
+      },
+      "AuditLogExtensionConnectorCalledMetadataV2V2": {
+        "example": {
+          "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "outcome": "success",
+          "source_kind": "mcp",
+          "surface": "chat",
+          "telemetry_query_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "write": "true"
+        },
+        "properties": {
+          "incident_id": {
+            "description": "The incident the call was made for, when incident-scoped",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "type": "string"
+          },
+          "outcome": {
+            "description": "How the call ended (success, error)",
+            "example": "success",
+            "type": "string"
+          },
+          "source_kind": {
+            "description": "The kind of connector that was called (mcp, http)",
+            "example": "mcp",
+            "type": "string"
+          },
+          "surface": {
+            "description": "The product surface the call ran from (chat, investigation, explore, mcp_client, verify), or internal for system paths with no surface",
+            "example": "chat",
+            "type": "string"
+          },
+          "telemetry_query_id": {
+            "description": "ID of our stored record of this call",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "type": "string"
+          },
+          "write": {
+            "description": "Whether the call was permitted to change the connected system (true, false)",
+            "example": "true",
+            "type": "string"
+          }
+        },
+        "required": [
+          "surface",
+          "write",
+          "outcome",
+          "source_kind"
+        ],
+        "type": "object"
+      },
       "AuditLogHrisTimeOffPolicyUpdatedMetadataV2": {
         "example": {
           "behaviour": "visible",
@@ -24704,6 +24802,8 @@
               "debrief_invite_rule",
               "escalation",
               "escalation_path",
+              "extension_connector",
+              "extension_connector_tool",
               "follow_up_category",
               "follow_up_priority",
               "holiday_user_feed",
@@ -24759,6 +24859,132 @@
         "required": [
           "id",
           "type"
+        ],
+        "type": "object"
+      },
+      "AuditLogTelemetryDataSourceQueriedMetadataV2": {
+        "example": {
+          "access_mode": "restricted",
+          "investigation_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "outcome": "granted",
+          "surface": "chat"
+        },
+        "properties": {
+          "access_mode": {
+            "description": "The data source's access mode at query time (default, restricted)",
+            "example": "restricted",
+            "type": "string"
+          },
+          "investigation_id": {
+            "description": "The investigation the query ran for, when investigation-driven",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "type": "string"
+          },
+          "outcome": {
+            "description": "Whether the query was granted or denied",
+            "example": "granted",
+            "type": "string"
+          },
+          "surface": {
+            "description": "The product surface the query ran from (chat, investigation, explore, mcp_client, verify), or internal for system paths with no surface",
+            "example": "chat",
+            "type": "string"
+          }
+        },
+        "required": [
+          "surface",
+          "access_mode",
+          "outcome"
+        ],
+        "type": "object"
+      },
+      "AuditLogTelemetryDataSourceQueriedMetadataV2V2": {
+        "example": {
+          "access_mode": "restricted",
+          "investigation_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "outcome": "granted",
+          "surface": "chat",
+          "telemetry_query_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+        },
+        "properties": {
+          "access_mode": {
+            "description": "The data source's access mode at query time (default, restricted)",
+            "example": "restricted",
+            "type": "string"
+          },
+          "investigation_id": {
+            "description": "The investigation the query ran for, when investigation-driven",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "type": "string"
+          },
+          "outcome": {
+            "description": "Whether the query was granted or denied",
+            "example": "granted",
+            "type": "string"
+          },
+          "surface": {
+            "description": "The product surface the query ran from (chat, investigation, explore, mcp_client, verify), or internal for system paths with no surface",
+            "example": "chat",
+            "type": "string"
+          },
+          "telemetry_query_id": {
+            "description": "ID of the recorded query, pointing at our full stored record of it",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "type": "string"
+          }
+        },
+        "required": [
+          "surface",
+          "access_mode",
+          "outcome"
+        ],
+        "type": "object"
+      },
+      "AuditLogTelemetryDataSourceRequestedMetadataV2": {
+        "example": {
+          "host": "grafana.example.com",
+          "method": "GET",
+          "origin": "dashboard_sync",
+          "response_status": "200",
+          "surface": "internal",
+          "telemetry_query_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+        },
+        "properties": {
+          "host": {
+            "description": "The data source host the request was sent to",
+            "example": "grafana.example.com",
+            "type": "string"
+          },
+          "method": {
+            "description": "The HTTP method of the request",
+            "example": "GET",
+            "type": "string"
+          },
+          "origin": {
+            "description": "The system job that made the request, when known (query, guidance, dashboard_sync, probe, unfurl, staff_cli, staff_workbench)",
+            "example": "dashboard_sync",
+            "type": "string"
+          },
+          "response_status": {
+            "description": "The HTTP status code of the response, absent when the request never completed",
+            "example": "200",
+            "type": "string"
+          },
+          "surface": {
+            "description": "The product surface the request served (chat, investigation, explore, mcp_client, verify), or internal for system paths with no surface",
+            "example": "internal",
+            "type": "string"
+          },
+          "telemetry_query_id": {
+            "description": "ID of the recorded query this request served, when one was in flight",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "type": "string"
+          }
+        },
+        "required": [
+          "surface",
+          "method",
+          "host"
         ],
         "type": "object"
       },
@@ -28717,6 +28943,199 @@
         ],
         "type": "object"
       },
+      "AuditLogsExtensionConnectorCalledV1": {
+        "example": {
+          "action": "extension_connector.called",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "metadata": {
+            "outcome": "success",
+            "source_kind": "mcp",
+            "surface": "chat",
+            "telemetry_query_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "write": "true"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Acme Deploy",
+              "type": "extension_connector"
+            },
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "restart_service",
+              "type": "extension_connector_tool"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "extension_connector.called",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/AuditLogExtensionConnectorCalledMetadataV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Acme Deploy",
+                "type": "extension_connector"
+              },
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "restart_service",
+                "type": "extension_connector_tool"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "AuditLogsExtensionConnectorCalledV2": {
+        "example": {
+          "action": "extension_connector.called",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "metadata": {
+            "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "outcome": "success",
+            "source_kind": "mcp",
+            "surface": "chat",
+            "telemetry_query_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "write": "true"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Acme Deploy",
+              "type": "extension_connector"
+            },
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "restart_service",
+              "type": "extension_connector_tool"
+            }
+          ],
+          "version": 2
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "extension_connector.called",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/AuditLogExtensionConnectorCalledMetadataV2V2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Acme Deploy",
+                "type": "extension_connector"
+              },
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "restart_service",
+                "type": "extension_connector_tool"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 2,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context",
+          "metadata"
+        ],
+        "type": "object"
+      },
       "AuditLogsFollowUpCategoryCreatedV1": {
         "example": {
           "action": "follow_up_category.created",
@@ -30494,6 +30913,81 @@
           "action": {
             "description": "The type of log entry that this is",
             "example": "incident_template.deleted",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Production incidents",
+                "type": "incident_template"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context"
+        ],
+        "type": "object"
+      },
+      "AuditLogsIncidentTemplateSetAsDefaultV1": {
+        "example": {
+          "action": "incident_template.set_as_default",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Production incidents",
+              "type": "incident_template"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "incident_template.set_as_default",
             "type": "string"
           },
           "actor": {
@@ -39082,6 +39576,264 @@
           "actor",
           "targets",
           "context"
+        ],
+        "type": "object"
+      },
+      "AuditLogsTelemetryDataSourceQueriedV1": {
+        "example": {
+          "action": "telemetry_data_source.queried",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "metadata": {
+            "access_mode": "restricted",
+            "investigation_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "outcome": "granted",
+            "surface": "chat"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Grafana Cloud",
+              "type": "telemetry_data_source"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "telemetry_data_source.queried",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/AuditLogTelemetryDataSourceQueriedMetadataV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Grafana Cloud",
+                "type": "telemetry_data_source"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "AuditLogsTelemetryDataSourceQueriedV2": {
+        "example": {
+          "action": "telemetry_data_source.queried",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "metadata": {
+            "access_mode": "restricted",
+            "investigation_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "outcome": "granted",
+            "surface": "chat",
+            "telemetry_query_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Grafana Cloud",
+              "type": "telemetry_data_source"
+            }
+          ],
+          "version": 2
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "telemetry_data_source.queried",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/AuditLogTelemetryDataSourceQueriedMetadataV2V2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Grafana Cloud",
+                "type": "telemetry_data_source"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 2,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "AuditLogsTelemetryDataSourceRequestedV1": {
+        "example": {
+          "action": "telemetry_data_source.requested",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "metadata": {
+            "host": "grafana.example.com",
+            "method": "GET",
+            "origin": "dashboard_sync",
+            "response_status": "200",
+            "surface": "internal",
+            "telemetry_query_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Grafana Cloud",
+              "type": "telemetry_data_source"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "telemetry_data_source.requested",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/AuditLogTelemetryDataSourceRequestedMetadataV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Grafana Cloud",
+                "type": "telemetry_data_source"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context",
+          "metadata"
         ],
         "type": "object"
       },
@@ -47684,6 +48436,22 @@
         },
         "type": "object"
       },
+      "EscalationPathNodeEscalationPathV2": {
+        "example": {
+          "escalation_path_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+        },
+        "properties": {
+          "escalation_path_id": {
+            "description": "The ID of the escalation path to reassign to",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "type": "string"
+          }
+        },
+        "required": [
+          "escalation_path_id"
+        ],
+        "type": "object"
+      },
       "EscalationPathNodeIfElsePayloadV2": {
         "example": {
           "conditions": [
@@ -47712,6 +48480,9 @@
                 "delay_interval_condition": "active",
                 "delay_seconds": 300,
                 "delay_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+              },
+              "escalation_path": {
+                "escalation_path_id": "01FCNDV6P870EA6S7TK1DSYDG0"
               },
               "id": "01FCNDV6P870EA6S7TK1DSYDG0",
               "if_else": {
@@ -47792,6 +48563,9 @@
                 "delay_interval_condition": "active",
                 "delay_seconds": 300,
                 "delay_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+              },
+              "escalation_path": {
+                "escalation_path_id": "01FCNDV6P870EA6S7TK1DSYDG0"
               },
               "id": "01FCNDV6P870EA6S7TK1DSYDG0",
               "if_else": {
@@ -47904,6 +48678,9 @@
                   "delay_seconds": 300,
                   "delay_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                 },
+                "escalation_path": {
+                  "escalation_path_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                },
                 "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                 "if_else": {
                   "conditions": [
@@ -47990,6 +48767,9 @@
                   "delay_interval_condition": "active",
                   "delay_seconds": 300,
                   "delay_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                },
+                "escalation_path": {
+                  "escalation_path_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                 },
                 "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                 "if_else": {
@@ -48113,6 +48893,9 @@
                 "delay_seconds": 300,
                 "delay_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
               },
+              "escalation_path": {
+                "escalation_path_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+              },
               "id": "01FCNDV6P870EA6S7TK1DSYDG0",
               "if_else": {
                 "conditions": [
@@ -48200,6 +48983,9 @@
                 "delay_interval_condition": "active",
                 "delay_seconds": 300,
                 "delay_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+              },
+              "escalation_path": {
+                "escalation_path_id": "01FCNDV6P870EA6S7TK1DSYDG0"
               },
               "id": "01FCNDV6P870EA6S7TK1DSYDG0",
               "if_else": {
@@ -48328,6 +49114,9 @@
                   "delay_seconds": 300,
                   "delay_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                 },
+                "escalation_path": {
+                  "escalation_path_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                },
                 "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                 "if_else": {
                   "conditions": [
@@ -48422,6 +49211,9 @@
                   "delay_interval_condition": "active",
                   "delay_seconds": 300,
                   "delay_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                },
+                "escalation_path": {
+                  "escalation_path_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                 },
                 "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                 "if_else": {
@@ -48664,6 +49456,9 @@
             "delay_seconds": 300,
             "delay_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
           },
+          "escalation_path": {
+            "escalation_path_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "if_else": {
             "conditions": [
@@ -48740,6 +49535,9 @@
           "delay": {
             "$ref": "#/components/schemas/EscalationPathNodeDelayV2"
           },
+          "escalation_path": {
+            "$ref": "#/components/schemas/EscalationPathNodeEscalationPathV2"
+          },
           "id": {
             "description": "An ID for this node, unique within the escalation path.\n\nThis allows you to reference the node in other nodes, such as when configuring a 'repeat' node.",
             "example": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -48758,14 +49556,15 @@
             "$ref": "#/components/schemas/EscalationPathNodeRepeatV2"
           },
           "type": {
-            "description": "The type of this node. Available types are:\n* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.\n* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.\n* if_else: Branch the escalation based on a set of conditions.\n* repeat: Go back to a previous node and repeat the logic from there.\n* delay: Pause the escalation for a configured duration before advancing to the next node.\n* voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.",
+            "description": "The type of this node. Available types are:\n* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.\n* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.\n* if_else: Branch the escalation based on a set of conditions.\n* repeat: Go back to a previous node and repeat the logic from there.\n* delay: Pause the escalation for a configured duration before advancing to the next node.\n* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.\n* voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.",
             "enum": [
               "if_else",
               "repeat",
               "level",
               "notify_channel",
               "delay",
-              "voicemail"
+              "voicemail",
+              "escalation_path"
             ],
             "example": "if_else",
             "type": "string"
@@ -48807,6 +49606,9 @@
             "delay_interval_condition": "active",
             "delay_seconds": 300,
             "delay_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "escalation_path": {
+            "escalation_path_id": "01FCNDV6P870EA6S7TK1DSYDG0"
           },
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "if_else": {
@@ -48892,6 +49694,9 @@
           "delay": {
             "$ref": "#/components/schemas/EscalationPathNodeDelayV2"
           },
+          "escalation_path": {
+            "$ref": "#/components/schemas/EscalationPathNodeEscalationPathV2"
+          },
           "id": {
             "description": "An ID for this node, unique within the escalation path.\n\nThis allows you to reference the node in other nodes, such as when configuring a 'repeat' node.",
             "example": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -48910,14 +49715,15 @@
             "$ref": "#/components/schemas/EscalationPathNodeRepeatV2"
           },
           "type": {
-            "description": "The type of this node. Available types are:\n* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.\n* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.\n* if_else: Branch the escalation based on a set of conditions.\n* repeat: Go back to a previous node and repeat the logic from there.\n* delay: Pause the escalation for a configured duration before advancing to the next node.\n* voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.",
+            "description": "The type of this node. Available types are:\n* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.\n* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.\n* if_else: Branch the escalation based on a set of conditions.\n* repeat: Go back to a previous node and repeat the logic from there.\n* delay: Pause the escalation for a configured duration before advancing to the next node.\n* escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.\n* voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.",
             "enum": [
               "if_else",
               "repeat",
               "level",
               "notify_channel",
               "delay",
-              "voicemail"
+              "voicemail",
+              "escalation_path"
             ],
             "example": "if_else",
             "type": "string"
@@ -49088,6 +49894,9 @@
                 "delay_seconds": 300,
                 "delay_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
               },
+              "escalation_path": {
+                "escalation_path_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+              },
               "id": "01FCNDV6P870EA6S7TK1DSYDG0",
               "if_else": {
                 "conditions": [
@@ -49227,6 +50036,9 @@
                   "delay_seconds": 300,
                   "delay_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                 },
+                "escalation_path": {
+                  "escalation_path_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                },
                 "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                 "if_else": {
                   "conditions": [
@@ -49357,6 +50169,36 @@
         ],
         "type": "object"
       },
+      "EscalationPathValidateWarningV2": {
+        "example": {
+          "detail": "When the condition matches, escalation stops here instead of continuing.",
+          "path": "path.0.if_else.then_path",
+          "summary": "if_else has an empty \"then\" branch"
+        },
+        "properties": {
+          "detail": {
+            "description": "The full explanation of what this means for the escalation",
+            "example": "When the condition matches, escalation stops here instead of continuing.",
+            "type": "string"
+          },
+          "path": {
+            "description": "The part of the payload this is about, so a client can point at the value that caused it",
+            "example": "path.0.if_else.then_path",
+            "type": "string"
+          },
+          "summary": {
+            "description": "A single line naming the problem",
+            "example": "if_else has an empty \"then\" branch",
+            "type": "string"
+          }
+        },
+        "required": [
+          "path",
+          "summary",
+          "detail"
+        ],
+        "type": "object"
+      },
       "EscalationPriorityV2": {
         "description": "The priority associated with this escalation.",
         "example": {
@@ -49394,6 +50236,7 @@
               "name": "My little workflow"
             }
           },
+          "description": "Database CPU has been above 90% for 5 minutes",
           "escalation_path_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
           "events": [
             {
@@ -49465,6 +50308,11 @@
           },
           "creator": {
             "$ref": "#/components/schemas/EscalationCreatorV2"
+          },
+          "description": {
+            "description": "Additional detail provided with this escalation. When it isn't set explicitly, this is taken from the alert description or the incident summary, and is empty when neither applies.",
+            "example": "Database CPU has been above 90% for 5 minutes",
+            "type": "string"
           },
           "escalation_path_id": {
             "description": "Unique identifier of the escalation path that the escalation was created from",
@@ -49587,6 +50435,7 @@
           "updated_at",
           "status",
           "title",
+          "description",
           "priority",
           "creator",
           "events",
@@ -49637,6 +50486,7 @@
                 "name": "My little workflow"
               }
             },
+            "description": "Database CPU has been above 90% for 5 minutes",
             "escalation_path_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
             "events": [
               {
@@ -49785,6 +50635,9 @@
                   "delay_seconds": 300,
                   "delay_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                 },
+                "escalation_path": {
+                  "escalation_path_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                },
                 "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                 "if_else": {
                   "conditions": [
@@ -49909,6 +50762,9 @@
                 "delay_seconds": 300,
                 "delay_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
               },
+              "escalation_path": {
+                "escalation_path_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+              },
               "id": "01FCNDV6P870EA6S7TK1DSYDG0",
               "if_else": {
                 "conditions": [
@@ -50018,6 +50874,9 @@
                   "delay_interval_condition": "active",
                   "delay_seconds": 300,
                   "delay_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                },
+                "escalation_path": {
+                  "escalation_path_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                 },
                 "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                 "if_else": {
@@ -50159,6 +51018,9 @@
                   "delay_interval_condition": "active",
                   "delay_seconds": 300,
                   "delay_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                },
+                "escalation_path": {
+                  "escalation_path_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                 },
                 "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                 "if_else": {
@@ -50352,6 +51214,7 @@
                 "name": "My little workflow"
               }
             },
+            "description": "Database CPU has been above 90% for 5 minutes",
             "escalation_path_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
             "events": [
               {
@@ -50537,6 +51400,9 @@
                     "delay_seconds": 300,
                     "delay_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                   },
+                  "escalation_path": {
+                    "escalation_path_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                  },
                   "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                   "if_else": {
                     "conditions": [
@@ -50667,6 +51533,9 @@
                       "delay_interval_condition": "active",
                       "delay_seconds": 300,
                       "delay_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                    },
+                    "escalation_path": {
+                      "escalation_path_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                     },
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "if_else": {
@@ -50809,6 +51678,7 @@
                   "name": "My little workflow"
                 }
               },
+              "description": "Database CPU has been above 90% for 5 minutes",
               "escalation_path_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
               "events": [
                 {
@@ -50899,6 +51769,7 @@
                     "name": "My little workflow"
                   }
                 },
+                "description": "Database CPU has been above 90% for 5 minutes",
                 "escalation_path_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
                 "events": [
                   {
@@ -50997,6 +51868,9 @@
                   "delay_interval_condition": "active",
                   "delay_seconds": 300,
                   "delay_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                },
+                "escalation_path": {
+                  "escalation_path_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                 },
                 "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                 "if_else": {
@@ -51133,6 +52007,7 @@
                 "name": "My little workflow"
               }
             },
+            "description": "Database CPU has been above 90% for 5 minutes",
             "escalation_path_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
             "events": [
               {
@@ -51215,6 +52090,9 @@
                 "delay_interval_condition": "active",
                 "delay_seconds": 300,
                 "delay_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+              },
+              "escalation_path": {
+                "escalation_path_id": "01FCNDV6P870EA6S7TK1DSYDG0"
               },
               "id": "01FCNDV6P870EA6S7TK1DSYDG0",
               "if_else": {
@@ -51325,6 +52203,9 @@
                   "delay_interval_condition": "active",
                   "delay_seconds": 300,
                   "delay_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                },
+                "escalation_path": {
+                  "escalation_path_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                 },
                 "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                 "if_else": {
@@ -51467,6 +52348,9 @@
                   "delay_seconds": 300,
                   "delay_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                 },
+                "escalation_path": {
+                  "escalation_path_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                },
                 "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                 "if_else": {
                   "conditions": [
@@ -51578,6 +52462,276 @@
         },
         "required": [
           "escalation_path"
+        ],
+        "type": "object"
+      },
+      "EscalationsValidatePathPayloadV2": {
+        "example": {
+          "path": [
+            {
+              "delay": {
+                "delay_interval_condition": "active",
+                "delay_seconds": 300,
+                "delay_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+              },
+              "escalation_path": {
+                "escalation_path_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+              },
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "if_else": {
+                "conditions": [
+                  {
+                    "operation": "one_of",
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": "incident.severity"
+                  }
+                ],
+                "else_path": [
+                  {}
+                ],
+                "then_path": [
+                  {}
+                ]
+              },
+              "level": {
+                "ack_mode": "all",
+                "retry_config": {
+                  "attempts": 3,
+                  "interval_seconds": 300
+                },
+                "round_robin_config": {
+                  "enabled": false,
+                  "rotate_after_seconds": 120
+                },
+                "targets": [
+                  {
+                    "id": "lawrencejones",
+                    "schedule_mode": "currently_on_call",
+                    "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "type": "schedule",
+                    "urgency": "high"
+                  }
+                ],
+                "time_to_ack_interval_condition": "active",
+                "time_to_ack_seconds": 1800,
+                "time_to_ack_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+              },
+              "notify_channel": {
+                "targets": [
+                  {
+                    "id": "lawrencejones",
+                    "schedule_mode": "currently_on_call",
+                    "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "type": "schedule",
+                    "urgency": "high"
+                  }
+                ],
+                "time_to_ack_interval_condition": "active",
+                "time_to_ack_seconds": 1800,
+                "time_to_ack_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+              },
+              "repeat": {
+                "repeat_times": 3,
+                "to_node": "01FCNDV6P870EA6S7TK1DSYDG0"
+              },
+              "type": "if_else"
+            }
+          ],
+          "repeat_config": {
+            "delay_repeat_on_activity": false,
+            "repeat_after_seconds": 1800
+          },
+          "team_ids": [
+            "01JPQA75EPNEES4479P16P4XAB"
+          ],
+          "working_hours": [
+            {
+              "id": "abc123",
+              "name": "abc123",
+              "timezone": "abc123",
+              "weekday_intervals": [
+                {
+                  "end_time": "17:00",
+                  "start_time": "09:00",
+                  "weekday": "monday"
+                }
+              ]
+            }
+          ]
+        },
+        "properties": {
+          "path": {
+            "description": "The nodes that form the levels and branches of this escalation path.",
+            "example": [
+              {
+                "delay": {
+                  "delay_interval_condition": "active",
+                  "delay_seconds": 300,
+                  "delay_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                },
+                "escalation_path": {
+                  "escalation_path_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                },
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "if_else": {
+                  "conditions": [
+                    {
+                      "operation": "one_of",
+                      "param_bindings": [
+                        {
+                          "array_value": [
+                            {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      ],
+                      "subject": "incident.severity"
+                    }
+                  ],
+                  "else_path": [
+                    {}
+                  ],
+                  "then_path": [
+                    {}
+                  ]
+                },
+                "level": {
+                  "ack_mode": "all",
+                  "retry_config": {
+                    "attempts": 3,
+                    "interval_seconds": 300
+                  },
+                  "round_robin_config": {
+                    "enabled": false,
+                    "rotate_after_seconds": 120
+                  },
+                  "targets": [
+                    {
+                      "id": "lawrencejones",
+                      "schedule_mode": "currently_on_call",
+                      "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "type": "schedule",
+                      "urgency": "high"
+                    }
+                  ],
+                  "time_to_ack_interval_condition": "active",
+                  "time_to_ack_seconds": 1800,
+                  "time_to_ack_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                },
+                "notify_channel": {
+                  "targets": [
+                    {
+                      "id": "lawrencejones",
+                      "schedule_mode": "currently_on_call",
+                      "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "type": "schedule",
+                      "urgency": "high"
+                    }
+                  ],
+                  "time_to_ack_interval_condition": "active",
+                  "time_to_ack_seconds": 1800,
+                  "time_to_ack_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                },
+                "repeat": {
+                  "repeat_times": 3,
+                  "to_node": "01FCNDV6P870EA6S7TK1DSYDG0"
+                },
+                "type": "if_else"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/EscalationPathNodePayloadV2"
+            },
+            "type": "array"
+          },
+          "repeat_config": {
+            "$ref": "#/components/schemas/EscalationPathRepeatConfigV2"
+          },
+          "team_ids": {
+            "description": "IDs of the teams that own this escalation path. This will automatically sync escalation paths with the right teams in Catalog. If you have an escalation paths attribute on your Teams, this attribute is required.",
+            "example": [
+              "01JPQA75EPNEES4479P16P4XAB"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "working_hours": {
+            "description": "The working hours for this escalation path.",
+            "example": [
+              {
+                "id": "abc123",
+                "name": "abc123",
+                "timezone": "abc123",
+                "weekday_intervals": [
+                  {
+                    "end_time": "17:00",
+                    "start_time": "09:00",
+                    "weekday": "monday"
+                  }
+                ]
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/WeekdayIntervalConfigV2"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "type": "object"
+      },
+      "EscalationsValidatePathResultV2": {
+        "example": {
+          "warnings": [
+            {
+              "detail": "When the condition matches, escalation stops here instead of continuing.",
+              "path": "path.0.if_else.then_path",
+              "summary": "if_else has an empty \"then\" branch"
+            }
+          ]
+        },
+        "properties": {
+          "warnings": {
+            "description": "Anything suspect about this config that isn't severe enough to reject it. Empty when there's nothing to say.",
+            "example": [
+              {
+                "detail": "When the condition matches, escalation stops here instead of continuing.",
+                "path": "path.0.if_else.then_path",
+                "summary": "if_else has an empty \"then\" branch"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/EscalationPathValidateWarningV2"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "warnings"
         ],
         "type": "object"
       },
@@ -56084,7 +57238,8 @@
                 "act_on_behalf_of_users",
                 "secrets_manage",
                 "secrets_use",
-                "call_transcripts_viewer"
+                "call_transcripts_viewer",
+                "heartbeats_ping"
               ],
               "example": "viewer",
               "type": "string",
@@ -56110,7 +57265,8 @@
                 "workflows_editor",
                 "private_workflows_editor",
                 "secrets_manage",
-                "secrets_use"
+                "secrets_use",
+                "heartbeats_ping"
               ],
               "example": "catalog_editor",
               "type": "string",
@@ -69571,6 +70727,84 @@
         ],
         "type": "object"
       },
+      "SchedulesUpdateOverridePayloadV2": {
+        "example": {
+          "end_at": "2021-08-17T14:00:00.000000Z",
+          "layer_id": "01G0J1EXE7AXZ2C93K61WBPYNH",
+          "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+          "start_at": "2021-08-17T13:00:00.000000Z",
+          "user": {
+            "email": "bob@example.com",
+            "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+            "slack_user_id": "USER123"
+          }
+        },
+        "properties": {
+          "end_at": {
+            "description": "End time of the override",
+            "example": "2021-08-17T14:00:00.000000Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "layer_id": {
+            "description": "The layer this override applies to",
+            "example": "01G0J1EXE7AXZ2C93K61WBPYNH",
+            "type": "string"
+          },
+          "rotation_id": {
+            "description": "The rotation this override applies to",
+            "example": "01G0J1EXE7AXZ2C93K61WBPYEH",
+            "type": "string"
+          },
+          "start_at": {
+            "description": "Start time of the override",
+            "example": "2021-08-17T13:00:00.000000Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "user": {
+            "$ref": "#/components/schemas/UserReferencePayloadV2"
+          }
+        },
+        "required": [
+          "start_at",
+          "end_at",
+          "rotation_id",
+          "layer_id",
+          "user"
+        ],
+        "type": "object"
+      },
+      "SchedulesUpdateOverrideResultV2": {
+        "example": {
+          "override": {
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "end_at": "2021-08-17T13:28:57.801578Z",
+            "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+            "layer_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+            "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+            "schedule_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+            "start_at": "2021-08-17T13:28:57.801578Z",
+            "updated_at": "2021-08-17T13:28:57.801578Z",
+            "user": {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "owner",
+              "slack_user_id": "U02AYNF2XJM"
+            }
+          }
+        },
+        "properties": {
+          "override": {
+            "$ref": "#/components/schemas/ScheduleOverrideV2"
+          }
+        },
+        "required": [
+          "override"
+        ],
+        "type": "object"
+      },
       "SchedulesUpdatePayloadV2": {
         "example": {
           "schedule": {
@@ -74933,6 +76167,7 @@
                 "name": "My little workflow"
               }
             },
+            "description": "Database CPU has been above 90% for 5 minutes",
             "escalation_path_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
             "events": [
               {
@@ -75036,6 +76271,7 @@
                   "name": "My little workflow"
                 }
               },
+              "description": "Database CPU has been above 90% for 5 minutes",
               "escalation_path_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
               "events": [
                 {
@@ -77149,6 +78385,7 @@
                 "name": "My little workflow"
               }
             },
+            "description": "Database CPU has been above 90% for 5 minutes",
             "escalation_path_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
             "events": [
               {
@@ -77307,6 +78544,7 @@
                   "name": "My little workflow"
                 }
               },
+              "description": "Database CPU has been above 90% for 5 minutes",
               "escalation_path_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
               "events": [
                 {
@@ -95833,6 +97071,9 @@
                             "delay_seconds": 300,
                             "delay_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                           },
+                          "escalation_path": {
+                            "escalation_path_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                          },
                           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                           "if_else": {
                             "conditions": [
@@ -95977,6 +97218,9 @@
                       "delay_seconds": 300,
                       "delay_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                     },
+                    "escalation_path": {
+                      "escalation_path_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                    },
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "if_else": {
                       "conditions": [
@@ -96103,6 +97347,9 @@
                           "delay_seconds": 300,
                           "delay_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                         },
+                        "escalation_path": {
+                          "escalation_path_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                        },
                         "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                         "if_else": {
                           "conditions": [
@@ -96225,6 +97472,160 @@
         "x-docs-resource-type": "EscalationPathV2",
         "x-rbac-scopes": [
           "escalation_paths.create"
+        ]
+      }
+    },
+    "/v2/escalation_paths/actions/validate": {
+      "post": {
+        "description": "Check whether an escalation path's config is valid, without creating or updating anything.\n\nThis runs the same checks creating or updating a path would, so a config this accepts is\none those endpoints will accept. A config that's valid but has no practical effect comes\nback as a warning on a successful response. A client can show it without blocking.",
+        "operationId": "Escalations V2#ValidatePath",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "path": [
+                  {
+                    "delay": {
+                      "delay_interval_condition": "active",
+                      "delay_seconds": 300,
+                      "delay_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                    },
+                    "escalation_path": {
+                      "escalation_path_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                    },
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "if_else": {
+                      "conditions": [
+                        {
+                          "operation": "one_of",
+                          "param_bindings": [
+                            {
+                              "array_value": [
+                                {
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              ],
+                              "value": {
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            }
+                          ],
+                          "subject": "incident.severity"
+                        }
+                      ],
+                      "else_path": [
+                        {}
+                      ],
+                      "then_path": [
+                        {}
+                      ]
+                    },
+                    "level": {
+                      "ack_mode": "all",
+                      "retry_config": {
+                        "attempts": 3,
+                        "interval_seconds": 300
+                      },
+                      "round_robin_config": {
+                        "enabled": false,
+                        "rotate_after_seconds": 120
+                      },
+                      "targets": [
+                        {
+                          "id": "lawrencejones",
+                          "schedule_mode": "currently_on_call",
+                          "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                          "type": "schedule",
+                          "urgency": "high"
+                        }
+                      ],
+                      "time_to_ack_interval_condition": "active",
+                      "time_to_ack_seconds": 1800,
+                      "time_to_ack_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                    },
+                    "notify_channel": {
+                      "targets": [
+                        {
+                          "id": "lawrencejones",
+                          "schedule_mode": "currently_on_call",
+                          "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                          "type": "schedule",
+                          "urgency": "high"
+                        }
+                      ],
+                      "time_to_ack_interval_condition": "active",
+                      "time_to_ack_seconds": 1800,
+                      "time_to_ack_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                    },
+                    "repeat": {
+                      "repeat_times": 3,
+                      "to_node": "01FCNDV6P870EA6S7TK1DSYDG0"
+                    },
+                    "type": "if_else"
+                  }
+                ],
+                "repeat_config": {
+                  "delay_repeat_on_activity": false,
+                  "repeat_after_seconds": 1800
+                },
+                "team_ids": [
+                  "01JPQA75EPNEES4479P16P4XAB"
+                ],
+                "working_hours": [
+                  {
+                    "id": "abc123",
+                    "name": "abc123",
+                    "timezone": "abc123",
+                    "weekday_intervals": [
+                      {
+                        "end_time": "17:00",
+                        "start_time": "09:00",
+                        "weekday": "monday"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "schema": {
+                "$ref": "#/components/schemas/EscalationsValidatePathPayloadV2"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "warnings": [
+                    {
+                      "detail": "When the condition matches, escalation stops here instead of continuing.",
+                      "path": "path.0.if_else.then_path",
+                      "summary": "if_else has an empty \"then\" branch"
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/EscalationsValidatePathResultV2"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "summary": "ValidatePath Escalations V2",
+        "tags": [
+          "Escalations V2"
+        ],
+        "x-display-name": "Validate",
+        "x-docs-display-name": "Validate",
+        "x-docs-group-name": "Escalation Paths V2",
+        "x-docs-resource-type": "EscalationPathV2",
+        "x-rbac-scopes": [
+          "escalation_paths.view"
         ]
       }
     },
@@ -96399,6 +97800,9 @@
                           "delay_interval_condition": "active",
                           "delay_seconds": 300,
                           "delay_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                        },
+                        "escalation_path": {
+                          "escalation_path_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                         },
                         "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                         "if_else": {
@@ -96600,6 +98004,9 @@
                           "delay_seconds": 300,
                           "delay_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                         },
+                        "escalation_path": {
+                          "escalation_path_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                        },
                         "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                         "if_else": {
                           "conditions": [
@@ -96753,6 +98160,9 @@
                       "delay_seconds": 300,
                       "delay_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                     },
+                    "escalation_path": {
+                      "escalation_path_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                    },
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "if_else": {
                       "conditions": [
@@ -96878,6 +98288,9 @@
                           "delay_interval_condition": "active",
                           "delay_seconds": 300,
                           "delay_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                        },
+                        "escalation_path": {
+                          "escalation_path_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                         },
                         "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                         "if_else": {
@@ -97006,7 +98419,7 @@
     },
     "/v2/escalations": {
       "get": {
-        "description": "List all escalations for your account.\n\nThis endpoint supports a number of filters, which can help find escalations matching certain\ncriteria.\n\nNote that:\n- Filters may be used together, and the result will be escalations that match all filters.\n- All query parameters must be URI encoded.\n\nTo use this API, you will need an API key with the \"View data\" or \"Create and manage on-call resources\" permission.\n\n### By escalation_path\n\nFind all escalations that escalated to escalation path with id=ABC:\n\n\t\tcurl --get 'https://api.incident.io/v2/escalations' \\\n\t\t\t--data 'escalation_path[one_of]=ABC'\n\n### By status\n\nFind all escalations with a current status of \"triggered\":\n\n\t\tcurl --get 'https://api.incident.io/v2/escalations' \\\n\t\t\t--data 'status[one_of]=triggered'\n\nPossible values are \"pending\", \"triggered\", \"acked\", \"resolved\", \"expired\" and \"cancelled\".\nEscalations are in \"pending\" when they are in a grace period when the related alert has\nbeen grouped in an incident.\n\n### By alert\n\nFind all escalations that were created by alert with id=ABC:\n\n\t\tcurl --get 'https://api.incident.io/v2/escalations' \\\n\t\t\t--data 'alert[one_of]=ABC'\n\n### By created_at and updated_at\nFind all escalations that follow specified date parameters for created_at and updated_at fields.\nPossible values are \"gte\" (greater than or equal to), \"lte\" (less than or equal to), and\n\"date_range\" (between two dates).\nFor example, to find all escalations updated after 2025-01-01:\n\n\t\tcurl --get 'https://api.incident.io/v2/escalations' \\\n\t\t\t--data 'updated_at[gte]=2025-01-01'\n\nTo find all escalations created between 2025-01-01 and 2025-01-31:\n\n\t\tcurl --get 'https://api.incident.io/v2/escalations' \\\n            --data 'created_at[date_range]=2025-01-01~2025-01-31'\n",
+        "description": "List all escalations for your account.\n\nThis endpoint supports a number of filters, which can help find escalations matching certain\ncriteria.\n\nNote that:\n- Filters may be used together, and the result will be escalations that match all filters.\n- All query parameters must be URI encoded.\n\nTo use this API, you will need an API key with the \"View data\" or \"Create and manage on-call resources\" permission.\n\n### By escalation_path\n\nFind all escalations that escalated to escalation path with id=ABC:\n\n\t\tcurl --get 'https://api.incident.io/v2/escalations' \\\n\t\t\t--data 'escalation_path[one_of]=ABC'\n\n### By status\n\nFind all escalations with a current status of \"triggered\":\n\n\t\tcurl --get 'https://api.incident.io/v2/escalations' \\\n\t\t\t--data 'status[one_of]=triggered'\n\nPossible values are \"pending\", \"triggered\", \"acked\", \"resolved\", \"expired\" and \"cancelled\".\nEscalations are in \"pending\" when they are in a grace period when the related alert has\nbeen grouped in an incident.\n\n### By alert\n\nFind all escalations that were created by alert with id=ABC:\n\n\t\tcurl --get 'https://api.incident.io/v2/escalations' \\\n\t\t\t--data 'alert[one_of]=ABC'\n\n### By incident\n\nFind all escalations related to incident with id=ABC:\n\n\t\tcurl --get 'https://api.incident.io/v2/escalations' \\\n\t\t\t--data 'incident[one_of]=ABC'\n\nAn escalation is related to an incident if it is linked to that incident directly, if it is\nattached to one of the incident's alerts, or if it triggered one of those alerts (which is\nwhat happens when someone pages by calling in, and that call raises the alert).\n\nTo find everything that is not related to an incident, use \"not_in\":\n\n\t\tcurl --get 'https://api.incident.io/v2/escalations' \\\n\t\t\t--data 'incident[not_in]=ABC'\n\n### By created_at and updated_at\nFind all escalations that follow specified date parameters for created_at and updated_at fields.\nPossible values are \"gte\" (greater than or equal to), \"lte\" (less than or equal to), and\n\"date_range\" (between two dates).\nFor example, to find all escalations updated after 2025-01-01:\n\n\t\tcurl --get 'https://api.incident.io/v2/escalations' \\\n\t\t\t--data 'updated_at[gte]=2025-01-01'\n\nTo find all escalations created between 2025-01-01 and 2025-01-31:\n\n\t\tcurl --get 'https://api.incident.io/v2/escalations' \\\n            --data 'created_at[date_range]=2025-01-01~2025-01-31'\n",
         "operationId": "Escalations V2#List",
         "parameters": [
           {
@@ -97119,6 +98532,36 @@
                 "type": "array"
               },
               "description": "Filter on the alert that created an escalation. Accepted operators are 'one_of' and 'not_in'.",
+              "example": {
+                "one_of": [
+                  "01J479052SSQAA4531ASFPR3BF"
+                ]
+              },
+              "type": "object"
+            }
+          },
+          {
+            "allowEmptyValue": true,
+            "description": "Filter on the incident that the escalation is connected to. Accepted operators are 'one_of' and 'not_in'.",
+            "example": {
+              "one_of": [
+                "01J479052SSQAA4531ASFPR3BF"
+              ]
+            },
+            "in": "query",
+            "name": "incident",
+            "schema": {
+              "additionalProperties": {
+                "example": [
+                  "some_value"
+                ],
+                "items": {
+                  "example": "some_value",
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "description": "Filter on the incident that the escalation is connected to. Accepted operators are 'one_of' and 'not_in'.",
               "example": {
                 "one_of": [
                   "01J479052SSQAA4531ASFPR3BF"
@@ -97243,6 +98686,7 @@
                           "name": "My little workflow"
                         }
                       },
+                      "description": "Database CPU has been above 90% for 5 minutes",
                       "escalation_path_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
                       "events": [
                         {
@@ -97331,7 +98775,7 @@
         ]
       },
       "post": {
-        "description": "Create an escalation.\n\nAn escalation pages people, either according to an escalation path, or directly to\nspecific users. You must provide either an escalation_path_id OR user_ids, but not both.\n\nWhen escalating via an escalation path, the escalation will follow the configured path\nwith its levels and timeouts, using your default [alert\npriority](https://app.incident.io/~/settings/alerts/configuration/priorities).\n\nWhen escalating directly to users, they will receive a high-urgency\nnotification, based on their notification rules.\n\nThis endpoint is rate-limited to 60 requests per minute, since it is intended for\ninteractive use cases (for example someone clicking a \"escalate to team\" button\nin your internal developer platform). To escalate based on automated alerts, we\nrecommend sending events to an alert source instead.\n",
+        "description": "Create an escalation.\n\nAn escalation pages people, either according to an escalation path, or directly to\nspecific users. You must provide either an escalation_path_id OR user_ids, but not both.\n\nWhen escalating via an escalation path, the escalation will follow the configured path\nwith its levels and timeouts, using your default [alert\npriority](https://app.incident.io/~/settings/alerts/configuration/priorities).\n\nWhen escalating directly to users, they will receive a high-urgency\nnotification, based on their notification rules.\n\nThis endpoint is rate-limited to 60 requests per minute, since it is intended for\ninteractive use cases (for example someone clicking a \"escalate to team\" button\nin your internal developer platform). To escalate based on automated alerts, we\nrecommend sending events to an alert source instead.\n\nIf your API key's permissions are scoped to teams, you can only escalate via an\nescalation path that one of those teams owns. Escalating directly to user_ids\nneeds the permission at the account level, because an escalation aimed at a\nperson has no owning team.\n",
         "operationId": "Escalations V2#Create",
         "requestBody": {
           "content": {
@@ -97378,6 +98822,7 @@
                         "name": "My little workflow"
                       }
                     },
+                    "description": "Database CPU has been above 90% for 5 minutes",
                     "escalation_path_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
                     "events": [
                       {
@@ -97503,6 +98948,7 @@
                         "name": "My little workflow"
                       }
                     },
+                    "description": "Database CPU has been above 90% for 5 minutes",
                     "escalation_path_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
                     "events": [
                       {
@@ -100793,6 +102239,123 @@
         "x-docs-resource-type": "ScheduleOverrideV2",
         "x-rbac-scopes": [
           "schedule_overrides.create"
+        ]
+      }
+    },
+    "/v2/schedule_overrides/{id}": {
+      "delete": {
+        "description": "Delete a schedule override, restoring whoever the rotations put on-call for that window.\n\nDeleting an override that has already been deleted succeeds, so it is safe to retry.",
+        "operationId": "Schedules V2#DestroyOverride",
+        "parameters": [
+          {
+            "description": "The override ID to delete",
+            "example": "01FDAG4SAP5TYPT98WGR2N7W91",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "The override ID to delete",
+              "example": "01FDAG4SAP5TYPT98WGR2N7W91",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content response."
+          }
+        },
+        "summary": "DestroyOverride Schedules V2",
+        "tags": [
+          "Schedules V2"
+        ],
+        "x-display-name": "Destroy",
+        "x-docs-display-name": "Delete",
+        "x-docs-group-name": "Schedule Overrides V2",
+        "x-docs-resource-type": "ScheduleOverrideV2",
+        "x-rbac-scopes": [
+          "schedule_overrides.destroy"
+        ]
+      },
+      "put": {
+        "description": "Update a schedule override, moving its window or the rotation and layer it sits on.\n\nAn override cannot be reassigned: send the user it already has, and delete and recreate\nit to put someone else on call for that window.\n\nOverrides on a layer cannot overlap, so widening one over its neighbour's window takes\nthat time over. The neighbour is deleted, and any of its time left outside the new\nwindow comes back as new overrides with new IDs, so other override IDs on this layer\nmay stop resolving — list the schedule's overrides again to pick up the replacements.",
+        "operationId": "Schedules V2#UpdateOverride",
+        "parameters": [
+          {
+            "description": "The override ID to update",
+            "example": "01FDAG4SAP5TYPT98WGR2N7W91",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "The override ID to update",
+              "example": "01FDAG4SAP5TYPT98WGR2N7W91",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "end_at": "2021-08-17T14:00:00.000000Z",
+                "layer_id": "01G0J1EXE7AXZ2C93K61WBPYNH",
+                "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "start_at": "2021-08-17T13:00:00.000000Z",
+                "user": {
+                  "email": "bob@example.com",
+                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                  "slack_user_id": "USER123"
+                }
+              },
+              "schema": {
+                "$ref": "#/components/schemas/SchedulesUpdateOverridePayloadV2"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "override": {
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "end_at": "2021-08-17T13:28:57.801578Z",
+                    "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                    "layer_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                    "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                    "schedule_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                    "start_at": "2021-08-17T13:28:57.801578Z",
+                    "updated_at": "2021-08-17T13:28:57.801578Z",
+                    "user": {
+                      "email": "lisa@incident.io",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Lisa Karlin Curtis",
+                      "role": "owner",
+                      "slack_user_id": "U02AYNF2XJM"
+                    }
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/SchedulesUpdateOverrideResultV2"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "summary": "UpdateOverride Schedules V2",
+        "tags": [
+          "Schedules V2"
+        ],
+        "x-display-name": "Update",
+        "x-docs-display-name": "Update",
+        "x-docs-group-name": "Schedule Overrides V2",
+        "x-docs-resource-type": "ScheduleOverrideV2",
+        "x-rbac-scopes": [
+          "schedule_overrides.update"
         ]
       }
     },
@@ -117337,6 +118900,123 @@
         ]
       }
     },
+    "/x-audit-logs/extension_connector.called.1": {
+      "get": {
+        "description": "This entry is created for every call an agent makes to a tool on a connector, whether the tool reads from the connected system or changes it",
+        "operationId": "ExtensionConnectorCalledV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "extension_connector.called",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "metadata": {
+                    "outcome": "success",
+                    "source_kind": "mcp",
+                    "surface": "chat",
+                    "telemetry_query_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "write": "true"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Acme Deploy",
+                      "type": "extension_connector"
+                    },
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "restart_service",
+                      "type": "extension_connector_tool"
+                    }
+                  ],
+                  "version": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsExtensionConnectorCalledV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
+    "/x-audit-logs/extension_connector.called.2": {
+      "get": {
+        "description": "This entry is created for every call an agent makes to a tool on a connector, whether the tool reads from the connected system or changes it",
+        "operationId": "ExtensionConnectorCalledV2",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "extension_connector.called",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "metadata": {
+                    "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "outcome": "success",
+                    "source_kind": "mcp",
+                    "surface": "chat",
+                    "telemetry_query_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "write": "true"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Acme Deploy",
+                      "type": "extension_connector"
+                    },
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "restart_service",
+                      "type": "extension_connector_tool"
+                    }
+                  ],
+                  "version": 2
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsExtensionConnectorCalledV2"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
     "/x-audit-logs/follow_up_category.created.1": {
       "get": {
         "description": "This entry is created whenever a follow up category is created",
@@ -118390,6 +120070,52 @@
                 },
                 "schema": {
                   "$ref": "#/components/schemas/AuditLogsIncidentTemplateDeletedV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
+    "/x-audit-logs/incident_template.set_as_default.1": {
+      "get": {
+        "description": "This entry is created whenever an incident template is set as the default",
+        "operationId": "IncidentTemplateSetAsDefaultV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "incident_template.set_as_default",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Production incidents",
+                      "type": "incident_template"
+                    }
+                  ],
+                  "version": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsIncidentTemplateSetAsDefaultV1"
                 }
               }
             },
@@ -123667,6 +125393,165 @@
         ]
       }
     },
+    "/x-audit-logs/telemetry_data_source.queried.1": {
+      "get": {
+        "description": "This entry is created when a telemetry data source is queried: one entry per session and data source, plus one entry per denied attempt",
+        "operationId": "TelemetryDataSourceQueriedV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "telemetry_data_source.queried",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "metadata": {
+                    "access_mode": "restricted",
+                    "investigation_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "outcome": "granted",
+                    "surface": "chat"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Grafana Cloud",
+                      "type": "telemetry_data_source"
+                    }
+                  ],
+                  "version": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsTelemetryDataSourceQueriedV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
+    "/x-audit-logs/telemetry_data_source.queried.2": {
+      "get": {
+        "description": "This entry is created when a telemetry data source is queried: one entry per session and data source, plus one entry per denied attempt",
+        "operationId": "TelemetryDataSourceQueriedV2",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "telemetry_data_source.queried",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "metadata": {
+                    "access_mode": "restricted",
+                    "investigation_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "outcome": "granted",
+                    "surface": "chat",
+                    "telemetry_query_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Grafana Cloud",
+                      "type": "telemetry_data_source"
+                    }
+                  ],
+                  "version": 2
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsTelemetryDataSourceQueriedV2"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
+    "/x-audit-logs/telemetry_data_source.requested.1": {
+      "get": {
+        "description": "This entry is created for every HTTP request our infrastructure sends to a telemetry data source, whatever made the request",
+        "operationId": "TelemetryDataSourceRequestedV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "telemetry_data_source.requested",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "metadata": {
+                    "host": "grafana.example.com",
+                    "method": "GET",
+                    "origin": "dashboard_sync",
+                    "response_status": "200",
+                    "surface": "internal",
+                    "telemetry_query_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Grafana Cloud",
+                      "type": "telemetry_data_source"
+                    }
+                  ],
+                  "version": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsTelemetryDataSourceRequestedV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
     "/x-audit-logs/telemetry_data_source.uninstalled.1": {
       "get": {
         "description": "This entry is created whenever a telemetry data source is disconnected",
@@ -124860,6 +126745,7 @@
                         "name": "My little workflow"
                       }
                     },
+                    "description": "Database CPU has been above 90% for 5 minutes",
                     "escalation_path_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
                     "events": [
                       {
@@ -124987,6 +126873,7 @@
                           "name": "My little workflow"
                         }
                       },
+                      "description": "Database CPU has been above 90% for 5 minutes",
                       "escalation_path_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
                       "events": [
                         {

--- a/internal/client/client.gen.go
+++ b/internal/client/client.gen.go
@@ -27,6 +27,7 @@ const (
 	APIKeyRoleV1NameCatalogViewer                       APIKeyRoleV1Name = "catalog_viewer"
 	APIKeyRoleV1NameEscalationCreator                   APIKeyRoleV1Name = "escalation_creator"
 	APIKeyRoleV1NameGlobalAccess                        APIKeyRoleV1Name = "global_access"
+	APIKeyRoleV1NameHeartbeatsPing                      APIKeyRoleV1Name = "heartbeats_ping"
 	APIKeyRoleV1NameIncidentCreator                     APIKeyRoleV1Name = "incident_creator"
 	APIKeyRoleV1NameIncidentEditor                      APIKeyRoleV1Name = "incident_editor"
 	APIKeyRoleV1NameIncidentMembershipsEditor           APIKeyRoleV1Name = "incident_memberships_editor"
@@ -71,6 +72,8 @@ func (e APIKeyRoleV1Name) Valid() bool {
 	case APIKeyRoleV1NameEscalationCreator:
 		return true
 	case APIKeyRoleV1NameGlobalAccess:
+		return true
+	case APIKeyRoleV1NameHeartbeatsPing:
 		return true
 	case APIKeyRoleV1NameIncidentCreator:
 		return true
@@ -134,6 +137,7 @@ const (
 	APIKeyTeamRoleV1NameApiKeysManage           APIKeyTeamRoleV1Name = "api_keys_manage"
 	APIKeyTeamRoleV1NameCatalogEditor           APIKeyTeamRoleV1Name = "catalog_editor"
 	APIKeyTeamRoleV1NameEscalationCreator       APIKeyTeamRoleV1Name = "escalation_creator"
+	APIKeyTeamRoleV1NameHeartbeatsPing          APIKeyTeamRoleV1Name = "heartbeats_ping"
 	APIKeyTeamRoleV1NameOnCallEditor            APIKeyTeamRoleV1Name = "on_call_editor"
 	APIKeyTeamRoleV1NamePrivateWorkflowsEditor  APIKeyTeamRoleV1Name = "private_workflows_editor"
 	APIKeyTeamRoleV1NameScheduleOverridesEditor APIKeyTeamRoleV1Name = "schedule_overrides_editor"
@@ -152,6 +156,8 @@ func (e APIKeyTeamRoleV1Name) Valid() bool {
 	case APIKeyTeamRoleV1NameCatalogEditor:
 		return true
 	case APIKeyTeamRoleV1NameEscalationCreator:
+		return true
+	case APIKeyTeamRoleV1NameHeartbeatsPing:
 		return true
 	case APIKeyTeamRoleV1NameOnCallEditor:
 		return true
@@ -183,6 +189,7 @@ const (
 	APIKeysCreatePayloadV1RoleNamesCatalogViewer                       APIKeysCreatePayloadV1RoleNames = "catalog_viewer"
 	APIKeysCreatePayloadV1RoleNamesEscalationCreator                   APIKeysCreatePayloadV1RoleNames = "escalation_creator"
 	APIKeysCreatePayloadV1RoleNamesGlobalAccess                        APIKeysCreatePayloadV1RoleNames = "global_access"
+	APIKeysCreatePayloadV1RoleNamesHeartbeatsPing                      APIKeysCreatePayloadV1RoleNames = "heartbeats_ping"
 	APIKeysCreatePayloadV1RoleNamesIncidentCreator                     APIKeysCreatePayloadV1RoleNames = "incident_creator"
 	APIKeysCreatePayloadV1RoleNamesIncidentEditor                      APIKeysCreatePayloadV1RoleNames = "incident_editor"
 	APIKeysCreatePayloadV1RoleNamesIncidentMembershipsEditor           APIKeysCreatePayloadV1RoleNames = "incident_memberships_editor"
@@ -227,6 +234,8 @@ func (e APIKeysCreatePayloadV1RoleNames) Valid() bool {
 	case APIKeysCreatePayloadV1RoleNamesEscalationCreator:
 		return true
 	case APIKeysCreatePayloadV1RoleNamesGlobalAccess:
+		return true
+	case APIKeysCreatePayloadV1RoleNamesHeartbeatsPing:
 		return true
 	case APIKeysCreatePayloadV1RoleNamesIncidentCreator:
 		return true
@@ -290,6 +299,7 @@ const (
 	APIKeysCreatePayloadV1TeamRoleNamesApiKeysManage           APIKeysCreatePayloadV1TeamRoleNames = "api_keys_manage"
 	APIKeysCreatePayloadV1TeamRoleNamesCatalogEditor           APIKeysCreatePayloadV1TeamRoleNames = "catalog_editor"
 	APIKeysCreatePayloadV1TeamRoleNamesEscalationCreator       APIKeysCreatePayloadV1TeamRoleNames = "escalation_creator"
+	APIKeysCreatePayloadV1TeamRoleNamesHeartbeatsPing          APIKeysCreatePayloadV1TeamRoleNames = "heartbeats_ping"
 	APIKeysCreatePayloadV1TeamRoleNamesOnCallEditor            APIKeysCreatePayloadV1TeamRoleNames = "on_call_editor"
 	APIKeysCreatePayloadV1TeamRoleNamesPrivateWorkflowsEditor  APIKeysCreatePayloadV1TeamRoleNames = "private_workflows_editor"
 	APIKeysCreatePayloadV1TeamRoleNamesScheduleOverridesEditor APIKeysCreatePayloadV1TeamRoleNames = "schedule_overrides_editor"
@@ -308,6 +318,8 @@ func (e APIKeysCreatePayloadV1TeamRoleNames) Valid() bool {
 	case APIKeysCreatePayloadV1TeamRoleNamesCatalogEditor:
 		return true
 	case APIKeysCreatePayloadV1TeamRoleNamesEscalationCreator:
+		return true
+	case APIKeysCreatePayloadV1TeamRoleNamesHeartbeatsPing:
 		return true
 	case APIKeysCreatePayloadV1TeamRoleNamesOnCallEditor:
 		return true
@@ -339,6 +351,7 @@ const (
 	APIKeysUpdatePayloadV1RoleNamesCatalogViewer                       APIKeysUpdatePayloadV1RoleNames = "catalog_viewer"
 	APIKeysUpdatePayloadV1RoleNamesEscalationCreator                   APIKeysUpdatePayloadV1RoleNames = "escalation_creator"
 	APIKeysUpdatePayloadV1RoleNamesGlobalAccess                        APIKeysUpdatePayloadV1RoleNames = "global_access"
+	APIKeysUpdatePayloadV1RoleNamesHeartbeatsPing                      APIKeysUpdatePayloadV1RoleNames = "heartbeats_ping"
 	APIKeysUpdatePayloadV1RoleNamesIncidentCreator                     APIKeysUpdatePayloadV1RoleNames = "incident_creator"
 	APIKeysUpdatePayloadV1RoleNamesIncidentEditor                      APIKeysUpdatePayloadV1RoleNames = "incident_editor"
 	APIKeysUpdatePayloadV1RoleNamesIncidentMembershipsEditor           APIKeysUpdatePayloadV1RoleNames = "incident_memberships_editor"
@@ -383,6 +396,8 @@ func (e APIKeysUpdatePayloadV1RoleNames) Valid() bool {
 	case APIKeysUpdatePayloadV1RoleNamesEscalationCreator:
 		return true
 	case APIKeysUpdatePayloadV1RoleNamesGlobalAccess:
+		return true
+	case APIKeysUpdatePayloadV1RoleNamesHeartbeatsPing:
 		return true
 	case APIKeysUpdatePayloadV1RoleNamesIncidentCreator:
 		return true
@@ -446,6 +461,7 @@ const (
 	APIKeysUpdatePayloadV1TeamRoleNamesApiKeysManage           APIKeysUpdatePayloadV1TeamRoleNames = "api_keys_manage"
 	APIKeysUpdatePayloadV1TeamRoleNamesCatalogEditor           APIKeysUpdatePayloadV1TeamRoleNames = "catalog_editor"
 	APIKeysUpdatePayloadV1TeamRoleNamesEscalationCreator       APIKeysUpdatePayloadV1TeamRoleNames = "escalation_creator"
+	APIKeysUpdatePayloadV1TeamRoleNamesHeartbeatsPing          APIKeysUpdatePayloadV1TeamRoleNames = "heartbeats_ping"
 	APIKeysUpdatePayloadV1TeamRoleNamesOnCallEditor            APIKeysUpdatePayloadV1TeamRoleNames = "on_call_editor"
 	APIKeysUpdatePayloadV1TeamRoleNamesPrivateWorkflowsEditor  APIKeysUpdatePayloadV1TeamRoleNames = "private_workflows_editor"
 	APIKeysUpdatePayloadV1TeamRoleNamesScheduleOverridesEditor APIKeysUpdatePayloadV1TeamRoleNames = "schedule_overrides_editor"
@@ -464,6 +480,8 @@ func (e APIKeysUpdatePayloadV1TeamRoleNames) Valid() bool {
 	case APIKeysUpdatePayloadV1TeamRoleNamesCatalogEditor:
 		return true
 	case APIKeysUpdatePayloadV1TeamRoleNamesEscalationCreator:
+		return true
+	case APIKeysUpdatePayloadV1TeamRoleNamesHeartbeatsPing:
 		return true
 	case APIKeysUpdatePayloadV1TeamRoleNamesOnCallEditor:
 		return true
@@ -3620,18 +3638,21 @@ func (e EscalationPathNodeNotifyChannelV2TimeToAckIntervalCondition) Valid() boo
 
 // Defines values for EscalationPathNodePayloadV2Type.
 const (
-	EscalationPathNodePayloadV2TypeDelay         EscalationPathNodePayloadV2Type = "delay"
-	EscalationPathNodePayloadV2TypeIfElse        EscalationPathNodePayloadV2Type = "if_else"
-	EscalationPathNodePayloadV2TypeLevel         EscalationPathNodePayloadV2Type = "level"
-	EscalationPathNodePayloadV2TypeNotifyChannel EscalationPathNodePayloadV2Type = "notify_channel"
-	EscalationPathNodePayloadV2TypeRepeat        EscalationPathNodePayloadV2Type = "repeat"
-	EscalationPathNodePayloadV2TypeVoicemail     EscalationPathNodePayloadV2Type = "voicemail"
+	EscalationPathNodePayloadV2TypeDelay          EscalationPathNodePayloadV2Type = "delay"
+	EscalationPathNodePayloadV2TypeEscalationPath EscalationPathNodePayloadV2Type = "escalation_path"
+	EscalationPathNodePayloadV2TypeIfElse         EscalationPathNodePayloadV2Type = "if_else"
+	EscalationPathNodePayloadV2TypeLevel          EscalationPathNodePayloadV2Type = "level"
+	EscalationPathNodePayloadV2TypeNotifyChannel  EscalationPathNodePayloadV2Type = "notify_channel"
+	EscalationPathNodePayloadV2TypeRepeat         EscalationPathNodePayloadV2Type = "repeat"
+	EscalationPathNodePayloadV2TypeVoicemail      EscalationPathNodePayloadV2Type = "voicemail"
 )
 
 // Valid indicates whether the value is a known member of the EscalationPathNodePayloadV2Type enum.
 func (e EscalationPathNodePayloadV2Type) Valid() bool {
 	switch e {
 	case EscalationPathNodePayloadV2TypeDelay:
+		return true
+	case EscalationPathNodePayloadV2TypeEscalationPath:
 		return true
 	case EscalationPathNodePayloadV2TypeIfElse:
 		return true
@@ -3650,18 +3671,21 @@ func (e EscalationPathNodePayloadV2Type) Valid() bool {
 
 // Defines values for EscalationPathNodeV2Type.
 const (
-	EscalationPathNodeV2TypeDelay         EscalationPathNodeV2Type = "delay"
-	EscalationPathNodeV2TypeIfElse        EscalationPathNodeV2Type = "if_else"
-	EscalationPathNodeV2TypeLevel         EscalationPathNodeV2Type = "level"
-	EscalationPathNodeV2TypeNotifyChannel EscalationPathNodeV2Type = "notify_channel"
-	EscalationPathNodeV2TypeRepeat        EscalationPathNodeV2Type = "repeat"
-	EscalationPathNodeV2TypeVoicemail     EscalationPathNodeV2Type = "voicemail"
+	EscalationPathNodeV2TypeDelay          EscalationPathNodeV2Type = "delay"
+	EscalationPathNodeV2TypeEscalationPath EscalationPathNodeV2Type = "escalation_path"
+	EscalationPathNodeV2TypeIfElse         EscalationPathNodeV2Type = "if_else"
+	EscalationPathNodeV2TypeLevel          EscalationPathNodeV2Type = "level"
+	EscalationPathNodeV2TypeNotifyChannel  EscalationPathNodeV2Type = "notify_channel"
+	EscalationPathNodeV2TypeRepeat         EscalationPathNodeV2Type = "repeat"
+	EscalationPathNodeV2TypeVoicemail      EscalationPathNodeV2Type = "voicemail"
 )
 
 // Valid indicates whether the value is a known member of the EscalationPathNodeV2Type enum.
 func (e EscalationPathNodeV2Type) Valid() bool {
 	switch e {
 	case EscalationPathNodeV2TypeDelay:
+		return true
+	case EscalationPathNodeV2TypeEscalationPath:
 		return true
 	case EscalationPathNodeV2TypeIfElse:
 		return true
@@ -4311,6 +4335,7 @@ const (
 	IdentityV1RolesCatalogViewer                       IdentityV1Roles = "catalog_viewer"
 	IdentityV1RolesEscalationCreator                   IdentityV1Roles = "escalation_creator"
 	IdentityV1RolesGlobalAccess                        IdentityV1Roles = "global_access"
+	IdentityV1RolesHeartbeatsPing                      IdentityV1Roles = "heartbeats_ping"
 	IdentityV1RolesIncidentCreator                     IdentityV1Roles = "incident_creator"
 	IdentityV1RolesIncidentEditor                      IdentityV1Roles = "incident_editor"
 	IdentityV1RolesIncidentMembershipsEditor           IdentityV1Roles = "incident_memberships_editor"
@@ -4355,6 +4380,8 @@ func (e IdentityV1Roles) Valid() bool {
 	case IdentityV1RolesEscalationCreator:
 		return true
 	case IdentityV1RolesGlobalAccess:
+		return true
+	case IdentityV1RolesHeartbeatsPing:
 		return true
 	case IdentityV1RolesIncidentCreator:
 		return true
@@ -4418,6 +4445,7 @@ const (
 	IdentityV1TeamRolesApiKeysManage           IdentityV1TeamRoles = "api_keys_manage"
 	IdentityV1TeamRolesCatalogEditor           IdentityV1TeamRoles = "catalog_editor"
 	IdentityV1TeamRolesEscalationCreator       IdentityV1TeamRoles = "escalation_creator"
+	IdentityV1TeamRolesHeartbeatsPing          IdentityV1TeamRoles = "heartbeats_ping"
 	IdentityV1TeamRolesOnCallEditor            IdentityV1TeamRoles = "on_call_editor"
 	IdentityV1TeamRolesPrivateWorkflowsEditor  IdentityV1TeamRoles = "private_workflows_editor"
 	IdentityV1TeamRolesScheduleOverridesEditor IdentityV1TeamRoles = "schedule_overrides_editor"
@@ -4436,6 +4464,8 @@ func (e IdentityV1TeamRoles) Valid() bool {
 	case IdentityV1TeamRolesCatalogEditor:
 		return true
 	case IdentityV1TeamRolesEscalationCreator:
+		return true
+	case IdentityV1TeamRolesHeartbeatsPing:
 		return true
 	case IdentityV1TeamRolesOnCallEditor:
 		return true
@@ -13020,7 +13050,15 @@ type EscalationPathNodeDelayV2 struct {
 // Example: active
 type EscalationPathNodeDelayV2DelayIntervalCondition string
 
-// EscalationPathNodeIfElsePayloadV2 Example: {"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"then_path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]}
+// EscalationPathNodeEscalationPathV2 Example: {"escalation_path_id":"01FCNDV6P870EA6S7TK1DSYDG0"}
+type EscalationPathNodeEscalationPathV2 struct {
+	// EscalationPathId The ID of the escalation path to reassign to
+	//
+	// Example: 01FCNDV6P870EA6S7TK1DSYDG0
+	EscalationPathId string `json:"escalation_path_id"`
+}
+
+// EscalationPathNodeIfElsePayloadV2 Example: {"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"escalation_path":{"escalation_path_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"then_path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"escalation_path":{"escalation_path_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]}
 type EscalationPathNodeIfElsePayloadV2 struct {
 	// Conditions The condition that defines which branch to take
 	//
@@ -13029,16 +13067,16 @@ type EscalationPathNodeIfElsePayloadV2 struct {
 
 	// ElsePath The nodes that form the levels if our condition is not met
 	//
-	// Example: [{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]
+	// Example: [{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"escalation_path":{"escalation_path_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]
 	ElsePath []EscalationPathNodePayloadV2 `json:"else_path"`
 
 	// ThenPath The nodes that form the levels if our condition is met
 	//
-	// Example: [{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]
+	// Example: [{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"escalation_path":{"escalation_path_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]
 	ThenPath []EscalationPathNodePayloadV2 `json:"then_path"`
 }
 
-// EscalationPathNodeIfElseV2 Example: {"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"then_path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]}
+// EscalationPathNodeIfElseV2 Example: {"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"escalation_path":{"escalation_path_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"then_path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"escalation_path":{"escalation_path_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]}
 type EscalationPathNodeIfElseV2 struct {
 	// Conditions The condition that defines which branch to take
 	//
@@ -13047,12 +13085,12 @@ type EscalationPathNodeIfElseV2 struct {
 
 	// ElsePath The nodes that form the levels if our condition is not met
 	//
-	// Example: [{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]
+	// Example: [{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"escalation_path":{"escalation_path_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]
 	ElsePath []EscalationPathNodeV2 `json:"else_path"`
 
 	// ThenPath The nodes that form the levels if our condition is met
 	//
-	// Example: [{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]
+	// Example: [{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"escalation_path":{"escalation_path_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]
 	ThenPath []EscalationPathNodeV2 `json:"then_path"`
 }
 
@@ -13128,10 +13166,13 @@ type EscalationPathNodeNotifyChannelV2 struct {
 // Example: active
 type EscalationPathNodeNotifyChannelV2TimeToAckIntervalCondition string
 
-// EscalationPathNodePayloadV2 Example: {"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}
+// EscalationPathNodePayloadV2 Example: {"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"escalation_path":{"escalation_path_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}
 type EscalationPathNodePayloadV2 struct {
 	// Delay Example: {"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"}
 	Delay *EscalationPathNodeDelayV2 `json:"delay,omitempty"`
+
+	// EscalationPath Example: {"escalation_path_id":"01FCNDV6P870EA6S7TK1DSYDG0"}
+	EscalationPath *EscalationPathNodeEscalationPathV2 `json:"escalation_path,omitempty"`
 
 	// Id An ID for this node, unique within the escalation path.
 	//
@@ -13140,7 +13181,7 @@ type EscalationPathNodePayloadV2 struct {
 	// Example: 01FCNDV6P870EA6S7TK1DSYDG0
 	Id string `json:"id"`
 
-	// IfElse Example: {"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"then_path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]}
+	// IfElse Example: {"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"escalation_path":{"escalation_path_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"then_path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"escalation_path":{"escalation_path_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]}
 	IfElse *EscalationPathNodeIfElsePayloadV2 `json:"if_else,omitempty"`
 
 	// Level Example: {"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"}
@@ -13158,6 +13199,7 @@ type EscalationPathNodePayloadV2 struct {
 	// * if_else: Branch the escalation based on a set of conditions.
 	// * repeat: Go back to a previous node and repeat the logic from there.
 	// * delay: Pause the escalation for a configured duration before advancing to the next node.
+	// * escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 	// * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 	//
 	// Example: if_else
@@ -13170,6 +13212,7 @@ type EscalationPathNodePayloadV2 struct {
 // * if_else: Branch the escalation based on a set of conditions.
 // * repeat: Go back to a previous node and repeat the logic from there.
 // * delay: Pause the escalation for a configured duration before advancing to the next node.
+// * escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 // * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 //
 // Example: if_else
@@ -13188,10 +13231,13 @@ type EscalationPathNodeRepeatV2 struct {
 	ToNode string `json:"to_node"`
 }
 
-// EscalationPathNodeV2 Example: {"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}
+// EscalationPathNodeV2 Example: {"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"escalation_path":{"escalation_path_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}
 type EscalationPathNodeV2 struct {
 	// Delay Example: {"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"}
 	Delay *EscalationPathNodeDelayV2 `json:"delay,omitempty"`
+
+	// EscalationPath Example: {"escalation_path_id":"01FCNDV6P870EA6S7TK1DSYDG0"}
+	EscalationPath *EscalationPathNodeEscalationPathV2 `json:"escalation_path,omitempty"`
 
 	// Id An ID for this node, unique within the escalation path.
 	//
@@ -13200,7 +13246,7 @@ type EscalationPathNodeV2 struct {
 	// Example: 01FCNDV6P870EA6S7TK1DSYDG0
 	Id string `json:"id"`
 
-	// IfElse Example: {"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"then_path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]}
+	// IfElse Example: {"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"escalation_path":{"escalation_path_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"then_path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"escalation_path":{"escalation_path_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]}
 	IfElse *EscalationPathNodeIfElseV2 `json:"if_else,omitempty"`
 
 	// Level Example: {"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"}
@@ -13218,6 +13264,7 @@ type EscalationPathNodeV2 struct {
 	// * if_else: Branch the escalation based on a set of conditions.
 	// * repeat: Go back to a previous node and repeat the logic from there.
 	// * delay: Pause the escalation for a configured duration before advancing to the next node.
+	// * escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 	// * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 	//
 	// Example: if_else
@@ -13230,6 +13277,7 @@ type EscalationPathNodeV2 struct {
 // * if_else: Branch the escalation based on a set of conditions.
 // * repeat: Go back to a previous node and repeat the logic from there.
 // * delay: Pause the escalation for a configured duration before advancing to the next node.
+// * escalation_path: Reassign the escalation to another escalation path, continuing from that path's first node.
 // * voicemail: Send an inbound caller to voicemail. Only valid inside a call route's path.
 //
 // Example: if_else
@@ -13317,7 +13365,7 @@ type EscalationPathTargetV2Type string
 // Example: high
 type EscalationPathTargetV2Urgency string
 
-// EscalationPathV2 Example: {"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}
+// EscalationPathV2 Example: {"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"escalation_path":{"escalation_path_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}
 type EscalationPathV2 struct {
 	// CurrentResponders Users who are currently on-call for this escalation path
 	//
@@ -13336,7 +13384,7 @@ type EscalationPathV2 struct {
 
 	// Path The nodes that form the levels and branches of this escalation path.
 	//
-	// Example: [{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]
+	// Example: [{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"escalation_path":{"escalation_path_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]
 	Path []EscalationPathNodeV2 `json:"path"`
 
 	// RepeatConfig Example: {"delay_repeat_on_activity":false,"repeat_after_seconds":1800}
@@ -13353,6 +13401,24 @@ type EscalationPathV2 struct {
 	WorkingHours *[]WeekdayIntervalConfigV2 `json:"working_hours,omitempty"`
 }
 
+// EscalationPathValidateWarningV2 Example: {"detail":"When the condition matches, escalation stops here instead of continuing.","path":"path.0.if_else.then_path","summary":"if_else has an empty \"then\" branch"}
+type EscalationPathValidateWarningV2 struct {
+	// Detail The full explanation of what this means for the escalation
+	//
+	// Example: When the condition matches, escalation stops here instead of continuing.
+	Detail string `json:"detail"`
+
+	// Path The part of the payload this is about, so a client can point at the value that caused it
+	//
+	// Example: path.0.if_else.then_path
+	Path string `json:"path"`
+
+	// Summary A single line naming the problem
+	//
+	// Example: if_else has an empty "then" branch
+	Summary string `json:"summary"`
+}
+
 // EscalationPriorityV2 The priority associated with this escalation.
 //
 // Example: {"name":"P1"}
@@ -13363,7 +13429,7 @@ type EscalationPriorityV2 struct {
 	Name string `json:"name"`
 }
 
-// EscalationV2 Example: {"created_at":"2021-08-17T13:28:57.801578Z","creator":{"alert":{"id":"01GW2G3V0S59R238FAHPDS1R66","title":"*errors.withMessage: PG::Error failed to connect"},"user":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"workflow":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My little workflow"}},"escalation_path_id":"01G0J1EXE7AXZ2C93K61WBPYEH","events":[{"channels":[{"microsoft_teams_channel_id":"abc123","microsoft_teams_team_id":"abc123","slack_channel_id":"abc123","slack_team_id":"abc123"}],"event":"entered_grace_period","id":"01G0J1EXE7AXZ2C93K61WBPYEH","occurred_at":"2021-08-17T13:28:57.801578Z","urgency":"high","users":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}]}],"id":"01G0J1EXE7AXZ2C93K61WBPYEH","priority":{"name":"P1"},"related_alerts":[{"alert_group_ids":["01GW2G3V0S59R238FAHPDS1R66"],"alert_source_id":"01GW2G3V0S59R238FAHPDS1R66","created_at":"2021-08-17T13:28:57.801578Z","deduplication_key":"4293868629","description":"CPU on the payments service has exceeded 75 percent for 5 minutes","id":"01GW2G3V0S59R238FAHPDS1R66","resolved_at":"2021-08-17T14:28:57.801578Z","source_url":"https://www.my-alerting-platform.com/alerts/my-alert-123","status":"firing","title":"*errors.withMessage: PG::Error failed to connect","updated_at":"2021-08-17T13:28:57.801578Z"}],"related_incidents":[{"external_id":123,"id":"01FDAG4SAP5TYPT98WGR2N7W91","name":"Our database is sad","reference":"INC-123","status_category":"triage","summary":"Our database is really really sad, and we don't know why yet.","visibility":"public"}],"status":"pending","title":"Database CPU is high","updated_at":"2021-08-17T13:28:57.801578Z"}
+// EscalationV2 Example: {"created_at":"2021-08-17T13:28:57.801578Z","creator":{"alert":{"id":"01GW2G3V0S59R238FAHPDS1R66","title":"*errors.withMessage: PG::Error failed to connect"},"user":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"workflow":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My little workflow"}},"description":"Database CPU has been above 90% for 5 minutes","escalation_path_id":"01G0J1EXE7AXZ2C93K61WBPYEH","events":[{"channels":[{"microsoft_teams_channel_id":"abc123","microsoft_teams_team_id":"abc123","slack_channel_id":"abc123","slack_team_id":"abc123"}],"event":"entered_grace_period","id":"01G0J1EXE7AXZ2C93K61WBPYEH","occurred_at":"2021-08-17T13:28:57.801578Z","urgency":"high","users":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}]}],"id":"01G0J1EXE7AXZ2C93K61WBPYEH","priority":{"name":"P1"},"related_alerts":[{"alert_group_ids":["01GW2G3V0S59R238FAHPDS1R66"],"alert_source_id":"01GW2G3V0S59R238FAHPDS1R66","created_at":"2021-08-17T13:28:57.801578Z","deduplication_key":"4293868629","description":"CPU on the payments service has exceeded 75 percent for 5 minutes","id":"01GW2G3V0S59R238FAHPDS1R66","resolved_at":"2021-08-17T14:28:57.801578Z","source_url":"https://www.my-alerting-platform.com/alerts/my-alert-123","status":"firing","title":"*errors.withMessage: PG::Error failed to connect","updated_at":"2021-08-17T13:28:57.801578Z"}],"related_incidents":[{"external_id":123,"id":"01FDAG4SAP5TYPT98WGR2N7W91","name":"Our database is sad","reference":"INC-123","status_category":"triage","summary":"Our database is really really sad, and we don't know why yet.","visibility":"public"}],"status":"pending","title":"Database CPU is high","updated_at":"2021-08-17T13:28:57.801578Z"}
 type EscalationV2 struct {
 	// CreatedAt When this escalation was created
 	//
@@ -13374,6 +13440,11 @@ type EscalationV2 struct {
 	//
 	// Example: {"alert":{"id":"01GW2G3V0S59R238FAHPDS1R66","title":"*errors.withMessage: PG::Error failed to connect"},"user":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"workflow":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My little workflow"}}
 	Creator EscalationCreatorV2 `json:"creator"`
+
+	// Description Additional detail provided with this escalation. When it isn't set explicitly, this is taken from the alert description or the incident summary, and is empty when neither applies.
+	//
+	// Example: Database CPU has been above 90% for 5 minutes
+	Description string `json:"description"`
 
 	// EscalationPathId Unique identifier of the escalation path that the escalation was created from
 	//
@@ -13434,13 +13505,13 @@ type EscalationsCreateExternalEscalationPathPayloadV2 struct {
 	ExternalEscalationPathId string `json:"external_escalation_path_id"`
 }
 
-// EscalationsCreateExternalEscalationPathResultV2 Example: {"escalation_path":{"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}}
+// EscalationsCreateExternalEscalationPathResultV2 Example: {"escalation_path":{"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"escalation_path":{"escalation_path_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}}
 type EscalationsCreateExternalEscalationPathResultV2 struct {
-	// EscalationPath Example: {"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}
+	// EscalationPath Example: {"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"escalation_path":{"escalation_path_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}
 	EscalationPath EscalationPathV2 `json:"escalation_path"`
 }
 
-// EscalationsCreatePathPayloadV2 Example: {"name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}
+// EscalationsCreatePathPayloadV2 Example: {"name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"escalation_path":{"escalation_path_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}
 type EscalationsCreatePathPayloadV2 struct {
 	// Name The name of this escalation path, for the user's reference.
 	//
@@ -13449,7 +13520,7 @@ type EscalationsCreatePathPayloadV2 struct {
 
 	// Path The nodes that form the levels and branches of this escalation path.
 	//
-	// Example: [{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]
+	// Example: [{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"escalation_path":{"escalation_path_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]
 	Path []EscalationPathNodePayloadV2 `json:"path"`
 
 	// RepeatConfig Example: {"delay_repeat_on_activity":false,"repeat_after_seconds":1800}
@@ -13466,9 +13537,9 @@ type EscalationsCreatePathPayloadV2 struct {
 	WorkingHours *[]WeekdayIntervalConfigV2 `json:"working_hours,omitempty"`
 }
 
-// EscalationsCreatePathResultV2 Example: {"escalation_path":{"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}}
+// EscalationsCreatePathResultV2 Example: {"escalation_path":{"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"escalation_path":{"escalation_path_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}}
 type EscalationsCreatePathResultV2 struct {
-	// EscalationPath Example: {"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}
+	// EscalationPath Example: {"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"escalation_path":{"escalation_path_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}
 	EscalationPath EscalationPathV2 `json:"escalation_path"`
 }
 
@@ -13505,9 +13576,9 @@ type EscalationsCreatePayloadV2 struct {
 	UserIds *[]string `json:"user_ids,omitempty"`
 }
 
-// EscalationsCreateResultV2 Example: {"escalation":{"created_at":"2021-08-17T13:28:57.801578Z","creator":{"alert":{"id":"01GW2G3V0S59R238FAHPDS1R66","title":"*errors.withMessage: PG::Error failed to connect"},"user":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"workflow":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My little workflow"}},"escalation_path_id":"01G0J1EXE7AXZ2C93K61WBPYEH","events":[{"channels":[{"microsoft_teams_channel_id":"abc123","microsoft_teams_team_id":"abc123","slack_channel_id":"abc123","slack_team_id":"abc123"}],"event":"entered_grace_period","id":"01G0J1EXE7AXZ2C93K61WBPYEH","occurred_at":"2021-08-17T13:28:57.801578Z","urgency":"high","users":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}]}],"id":"01G0J1EXE7AXZ2C93K61WBPYEH","priority":{"name":"P1"},"related_alerts":[{"alert_group_ids":["01GW2G3V0S59R238FAHPDS1R66"],"alert_source_id":"01GW2G3V0S59R238FAHPDS1R66","created_at":"2021-08-17T13:28:57.801578Z","deduplication_key":"4293868629","description":"CPU on the payments service has exceeded 75 percent for 5 minutes","id":"01GW2G3V0S59R238FAHPDS1R66","resolved_at":"2021-08-17T14:28:57.801578Z","source_url":"https://www.my-alerting-platform.com/alerts/my-alert-123","status":"firing","title":"*errors.withMessage: PG::Error failed to connect","updated_at":"2021-08-17T13:28:57.801578Z"}],"related_incidents":[{"external_id":123,"id":"01FDAG4SAP5TYPT98WGR2N7W91","name":"Our database is sad","reference":"INC-123","status_category":"triage","summary":"Our database is really really sad, and we don't know why yet.","visibility":"public"}],"status":"pending","title":"Database CPU is high","updated_at":"2021-08-17T13:28:57.801578Z"}}
+// EscalationsCreateResultV2 Example: {"escalation":{"created_at":"2021-08-17T13:28:57.801578Z","creator":{"alert":{"id":"01GW2G3V0S59R238FAHPDS1R66","title":"*errors.withMessage: PG::Error failed to connect"},"user":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"workflow":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My little workflow"}},"description":"Database CPU has been above 90% for 5 minutes","escalation_path_id":"01G0J1EXE7AXZ2C93K61WBPYEH","events":[{"channels":[{"microsoft_teams_channel_id":"abc123","microsoft_teams_team_id":"abc123","slack_channel_id":"abc123","slack_team_id":"abc123"}],"event":"entered_grace_period","id":"01G0J1EXE7AXZ2C93K61WBPYEH","occurred_at":"2021-08-17T13:28:57.801578Z","urgency":"high","users":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}]}],"id":"01G0J1EXE7AXZ2C93K61WBPYEH","priority":{"name":"P1"},"related_alerts":[{"alert_group_ids":["01GW2G3V0S59R238FAHPDS1R66"],"alert_source_id":"01GW2G3V0S59R238FAHPDS1R66","created_at":"2021-08-17T13:28:57.801578Z","deduplication_key":"4293868629","description":"CPU on the payments service has exceeded 75 percent for 5 minutes","id":"01GW2G3V0S59R238FAHPDS1R66","resolved_at":"2021-08-17T14:28:57.801578Z","source_url":"https://www.my-alerting-platform.com/alerts/my-alert-123","status":"firing","title":"*errors.withMessage: PG::Error failed to connect","updated_at":"2021-08-17T13:28:57.801578Z"}],"related_incidents":[{"external_id":123,"id":"01FDAG4SAP5TYPT98WGR2N7W91","name":"Our database is sad","reference":"INC-123","status_category":"triage","summary":"Our database is really really sad, and we don't know why yet.","visibility":"public"}],"status":"pending","title":"Database CPU is high","updated_at":"2021-08-17T13:28:57.801578Z"}}
 type EscalationsCreateResultV2 struct {
-	// Escalation Example: {"created_at":"2021-08-17T13:28:57.801578Z","creator":{"alert":{"id":"01GW2G3V0S59R238FAHPDS1R66","title":"*errors.withMessage: PG::Error failed to connect"},"user":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"workflow":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My little workflow"}},"escalation_path_id":"01G0J1EXE7AXZ2C93K61WBPYEH","events":[{"channels":[{"microsoft_teams_channel_id":"abc123","microsoft_teams_team_id":"abc123","slack_channel_id":"abc123","slack_team_id":"abc123"}],"event":"entered_grace_period","id":"01G0J1EXE7AXZ2C93K61WBPYEH","occurred_at":"2021-08-17T13:28:57.801578Z","urgency":"high","users":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}]}],"id":"01G0J1EXE7AXZ2C93K61WBPYEH","priority":{"name":"P1"},"related_alerts":[{"alert_group_ids":["01GW2G3V0S59R238FAHPDS1R66"],"alert_source_id":"01GW2G3V0S59R238FAHPDS1R66","created_at":"2021-08-17T13:28:57.801578Z","deduplication_key":"4293868629","description":"CPU on the payments service has exceeded 75 percent for 5 minutes","id":"01GW2G3V0S59R238FAHPDS1R66","resolved_at":"2021-08-17T14:28:57.801578Z","source_url":"https://www.my-alerting-platform.com/alerts/my-alert-123","status":"firing","title":"*errors.withMessage: PG::Error failed to connect","updated_at":"2021-08-17T13:28:57.801578Z"}],"related_incidents":[{"external_id":123,"id":"01FDAG4SAP5TYPT98WGR2N7W91","name":"Our database is sad","reference":"INC-123","status_category":"triage","summary":"Our database is really really sad, and we don't know why yet.","visibility":"public"}],"status":"pending","title":"Database CPU is high","updated_at":"2021-08-17T13:28:57.801578Z"}
+	// Escalation Example: {"created_at":"2021-08-17T13:28:57.801578Z","creator":{"alert":{"id":"01GW2G3V0S59R238FAHPDS1R66","title":"*errors.withMessage: PG::Error failed to connect"},"user":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"workflow":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My little workflow"}},"description":"Database CPU has been above 90% for 5 minutes","escalation_path_id":"01G0J1EXE7AXZ2C93K61WBPYEH","events":[{"channels":[{"microsoft_teams_channel_id":"abc123","microsoft_teams_team_id":"abc123","slack_channel_id":"abc123","slack_team_id":"abc123"}],"event":"entered_grace_period","id":"01G0J1EXE7AXZ2C93K61WBPYEH","occurred_at":"2021-08-17T13:28:57.801578Z","urgency":"high","users":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}]}],"id":"01G0J1EXE7AXZ2C93K61WBPYEH","priority":{"name":"P1"},"related_alerts":[{"alert_group_ids":["01GW2G3V0S59R238FAHPDS1R66"],"alert_source_id":"01GW2G3V0S59R238FAHPDS1R66","created_at":"2021-08-17T13:28:57.801578Z","deduplication_key":"4293868629","description":"CPU on the payments service has exceeded 75 percent for 5 minutes","id":"01GW2G3V0S59R238FAHPDS1R66","resolved_at":"2021-08-17T14:28:57.801578Z","source_url":"https://www.my-alerting-platform.com/alerts/my-alert-123","status":"firing","title":"*errors.withMessage: PG::Error failed to connect","updated_at":"2021-08-17T13:28:57.801578Z"}],"related_incidents":[{"external_id":123,"id":"01FDAG4SAP5TYPT98WGR2N7W91","name":"Our database is sad","reference":"INC-123","status_category":"triage","summary":"Our database is really really sad, and we don't know why yet.","visibility":"public"}],"status":"pending","title":"Database CPU is high","updated_at":"2021-08-17T13:28:57.801578Z"}
 	Escalation EscalationV2 `json:"escalation"`
 }
 
@@ -13520,37 +13591,37 @@ type EscalationsListExternalEscalationPathsResultV2 struct {
 	PaginationMeta PaginationMetaResultV2 `json:"pagination_meta"`
 }
 
-// EscalationsListPathsResultV2 Example: {"escalation_paths":[{"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}],"pagination_meta":{"after":"01FCNDV6P870EA6S7TK1DSYDG0","page_size":25}}
+// EscalationsListPathsResultV2 Example: {"escalation_paths":[{"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"escalation_path":{"escalation_path_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}],"pagination_meta":{"after":"01FCNDV6P870EA6S7TK1DSYDG0","page_size":25}}
 type EscalationsListPathsResultV2 struct {
-	// EscalationPaths Example: [{"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}]
+	// EscalationPaths Example: [{"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"escalation_path":{"escalation_path_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}]
 	EscalationPaths []EscalationPathV2 `json:"escalation_paths"`
 
 	// PaginationMeta Example: {"after":"01FCNDV6P870EA6S7TK1DSYDG0","page_size":25}
 	PaginationMeta PaginationMetaResultV2 `json:"pagination_meta"`
 }
 
-// EscalationsListResultV2 Example: {"escalations":[{"created_at":"2021-08-17T13:28:57.801578Z","creator":{"alert":{"id":"01GW2G3V0S59R238FAHPDS1R66","title":"*errors.withMessage: PG::Error failed to connect"},"user":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"workflow":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My little workflow"}},"escalation_path_id":"01G0J1EXE7AXZ2C93K61WBPYEH","events":[{"channels":[{"microsoft_teams_channel_id":"abc123","microsoft_teams_team_id":"abc123","slack_channel_id":"abc123","slack_team_id":"abc123"}],"event":"entered_grace_period","id":"01G0J1EXE7AXZ2C93K61WBPYEH","occurred_at":"2021-08-17T13:28:57.801578Z","urgency":"high","users":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}]}],"id":"01G0J1EXE7AXZ2C93K61WBPYEH","priority":{"name":"P1"},"related_alerts":[{"alert_group_ids":["01GW2G3V0S59R238FAHPDS1R66"],"alert_source_id":"01GW2G3V0S59R238FAHPDS1R66","created_at":"2021-08-17T13:28:57.801578Z","deduplication_key":"4293868629","description":"CPU on the payments service has exceeded 75 percent for 5 minutes","id":"01GW2G3V0S59R238FAHPDS1R66","resolved_at":"2021-08-17T14:28:57.801578Z","source_url":"https://www.my-alerting-platform.com/alerts/my-alert-123","status":"firing","title":"*errors.withMessage: PG::Error failed to connect","updated_at":"2021-08-17T13:28:57.801578Z"}],"related_incidents":[{"external_id":123,"id":"01FDAG4SAP5TYPT98WGR2N7W91","name":"Our database is sad","reference":"INC-123","status_category":"triage","summary":"Our database is really really sad, and we don't know why yet.","visibility":"public"}],"status":"pending","title":"Database CPU is high","updated_at":"2021-08-17T13:28:57.801578Z"}],"pagination_meta":{"after":"01FCNDV6P870EA6S7TK1DSYDG0","page_size":25}}
+// EscalationsListResultV2 Example: {"escalations":[{"created_at":"2021-08-17T13:28:57.801578Z","creator":{"alert":{"id":"01GW2G3V0S59R238FAHPDS1R66","title":"*errors.withMessage: PG::Error failed to connect"},"user":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"workflow":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My little workflow"}},"description":"Database CPU has been above 90% for 5 minutes","escalation_path_id":"01G0J1EXE7AXZ2C93K61WBPYEH","events":[{"channels":[{"microsoft_teams_channel_id":"abc123","microsoft_teams_team_id":"abc123","slack_channel_id":"abc123","slack_team_id":"abc123"}],"event":"entered_grace_period","id":"01G0J1EXE7AXZ2C93K61WBPYEH","occurred_at":"2021-08-17T13:28:57.801578Z","urgency":"high","users":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}]}],"id":"01G0J1EXE7AXZ2C93K61WBPYEH","priority":{"name":"P1"},"related_alerts":[{"alert_group_ids":["01GW2G3V0S59R238FAHPDS1R66"],"alert_source_id":"01GW2G3V0S59R238FAHPDS1R66","created_at":"2021-08-17T13:28:57.801578Z","deduplication_key":"4293868629","description":"CPU on the payments service has exceeded 75 percent for 5 minutes","id":"01GW2G3V0S59R238FAHPDS1R66","resolved_at":"2021-08-17T14:28:57.801578Z","source_url":"https://www.my-alerting-platform.com/alerts/my-alert-123","status":"firing","title":"*errors.withMessage: PG::Error failed to connect","updated_at":"2021-08-17T13:28:57.801578Z"}],"related_incidents":[{"external_id":123,"id":"01FDAG4SAP5TYPT98WGR2N7W91","name":"Our database is sad","reference":"INC-123","status_category":"triage","summary":"Our database is really really sad, and we don't know why yet.","visibility":"public"}],"status":"pending","title":"Database CPU is high","updated_at":"2021-08-17T13:28:57.801578Z"}],"pagination_meta":{"after":"01FCNDV6P870EA6S7TK1DSYDG0","page_size":25}}
 type EscalationsListResultV2 struct {
-	// Escalations Example: [{"created_at":"2021-08-17T13:28:57.801578Z","creator":{"alert":{"id":"01GW2G3V0S59R238FAHPDS1R66","title":"*errors.withMessage: PG::Error failed to connect"},"user":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"workflow":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My little workflow"}},"escalation_path_id":"01G0J1EXE7AXZ2C93K61WBPYEH","events":[{"channels":[{"microsoft_teams_channel_id":"abc123","microsoft_teams_team_id":"abc123","slack_channel_id":"abc123","slack_team_id":"abc123"}],"event":"entered_grace_period","id":"01G0J1EXE7AXZ2C93K61WBPYEH","occurred_at":"2021-08-17T13:28:57.801578Z","urgency":"high","users":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}]}],"id":"01G0J1EXE7AXZ2C93K61WBPYEH","priority":{"name":"P1"},"related_alerts":[{"alert_group_ids":["01GW2G3V0S59R238FAHPDS1R66"],"alert_source_id":"01GW2G3V0S59R238FAHPDS1R66","created_at":"2021-08-17T13:28:57.801578Z","deduplication_key":"4293868629","description":"CPU on the payments service has exceeded 75 percent for 5 minutes","id":"01GW2G3V0S59R238FAHPDS1R66","resolved_at":"2021-08-17T14:28:57.801578Z","source_url":"https://www.my-alerting-platform.com/alerts/my-alert-123","status":"firing","title":"*errors.withMessage: PG::Error failed to connect","updated_at":"2021-08-17T13:28:57.801578Z"}],"related_incidents":[{"external_id":123,"id":"01FDAG4SAP5TYPT98WGR2N7W91","name":"Our database is sad","reference":"INC-123","status_category":"triage","summary":"Our database is really really sad, and we don't know why yet.","visibility":"public"}],"status":"pending","title":"Database CPU is high","updated_at":"2021-08-17T13:28:57.801578Z"}]
+	// Escalations Example: [{"created_at":"2021-08-17T13:28:57.801578Z","creator":{"alert":{"id":"01GW2G3V0S59R238FAHPDS1R66","title":"*errors.withMessage: PG::Error failed to connect"},"user":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"workflow":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My little workflow"}},"description":"Database CPU has been above 90% for 5 minutes","escalation_path_id":"01G0J1EXE7AXZ2C93K61WBPYEH","events":[{"channels":[{"microsoft_teams_channel_id":"abc123","microsoft_teams_team_id":"abc123","slack_channel_id":"abc123","slack_team_id":"abc123"}],"event":"entered_grace_period","id":"01G0J1EXE7AXZ2C93K61WBPYEH","occurred_at":"2021-08-17T13:28:57.801578Z","urgency":"high","users":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}]}],"id":"01G0J1EXE7AXZ2C93K61WBPYEH","priority":{"name":"P1"},"related_alerts":[{"alert_group_ids":["01GW2G3V0S59R238FAHPDS1R66"],"alert_source_id":"01GW2G3V0S59R238FAHPDS1R66","created_at":"2021-08-17T13:28:57.801578Z","deduplication_key":"4293868629","description":"CPU on the payments service has exceeded 75 percent for 5 minutes","id":"01GW2G3V0S59R238FAHPDS1R66","resolved_at":"2021-08-17T14:28:57.801578Z","source_url":"https://www.my-alerting-platform.com/alerts/my-alert-123","status":"firing","title":"*errors.withMessage: PG::Error failed to connect","updated_at":"2021-08-17T13:28:57.801578Z"}],"related_incidents":[{"external_id":123,"id":"01FDAG4SAP5TYPT98WGR2N7W91","name":"Our database is sad","reference":"INC-123","status_category":"triage","summary":"Our database is really really sad, and we don't know why yet.","visibility":"public"}],"status":"pending","title":"Database CPU is high","updated_at":"2021-08-17T13:28:57.801578Z"}]
 	Escalations []EscalationV2 `json:"escalations"`
 
 	// PaginationMeta Example: {"after":"01FCNDV6P870EA6S7TK1DSYDG0","page_size":25}
 	PaginationMeta PaginationMetaResultV2 `json:"pagination_meta"`
 }
 
-// EscalationsShowPathResultV2 Example: {"escalation_path":{"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}}
+// EscalationsShowPathResultV2 Example: {"escalation_path":{"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"escalation_path":{"escalation_path_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}}
 type EscalationsShowPathResultV2 struct {
-	// EscalationPath Example: {"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}
+	// EscalationPath Example: {"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"escalation_path":{"escalation_path_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}
 	EscalationPath EscalationPathV2 `json:"escalation_path"`
 }
 
-// EscalationsShowResultV2 Example: {"escalation":{"created_at":"2021-08-17T13:28:57.801578Z","creator":{"alert":{"id":"01GW2G3V0S59R238FAHPDS1R66","title":"*errors.withMessage: PG::Error failed to connect"},"user":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"workflow":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My little workflow"}},"escalation_path_id":"01G0J1EXE7AXZ2C93K61WBPYEH","events":[{"channels":[{"microsoft_teams_channel_id":"abc123","microsoft_teams_team_id":"abc123","slack_channel_id":"abc123","slack_team_id":"abc123"}],"event":"entered_grace_period","id":"01G0J1EXE7AXZ2C93K61WBPYEH","occurred_at":"2021-08-17T13:28:57.801578Z","urgency":"high","users":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}]}],"id":"01G0J1EXE7AXZ2C93K61WBPYEH","priority":{"name":"P1"},"related_alerts":[{"alert_group_ids":["01GW2G3V0S59R238FAHPDS1R66"],"alert_source_id":"01GW2G3V0S59R238FAHPDS1R66","created_at":"2021-08-17T13:28:57.801578Z","deduplication_key":"4293868629","description":"CPU on the payments service has exceeded 75 percent for 5 minutes","id":"01GW2G3V0S59R238FAHPDS1R66","resolved_at":"2021-08-17T14:28:57.801578Z","source_url":"https://www.my-alerting-platform.com/alerts/my-alert-123","status":"firing","title":"*errors.withMessage: PG::Error failed to connect","updated_at":"2021-08-17T13:28:57.801578Z"}],"related_incidents":[{"external_id":123,"id":"01FDAG4SAP5TYPT98WGR2N7W91","name":"Our database is sad","reference":"INC-123","status_category":"triage","summary":"Our database is really really sad, and we don't know why yet.","visibility":"public"}],"status":"pending","title":"Database CPU is high","updated_at":"2021-08-17T13:28:57.801578Z"}}
+// EscalationsShowResultV2 Example: {"escalation":{"created_at":"2021-08-17T13:28:57.801578Z","creator":{"alert":{"id":"01GW2G3V0S59R238FAHPDS1R66","title":"*errors.withMessage: PG::Error failed to connect"},"user":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"workflow":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My little workflow"}},"description":"Database CPU has been above 90% for 5 minutes","escalation_path_id":"01G0J1EXE7AXZ2C93K61WBPYEH","events":[{"channels":[{"microsoft_teams_channel_id":"abc123","microsoft_teams_team_id":"abc123","slack_channel_id":"abc123","slack_team_id":"abc123"}],"event":"entered_grace_period","id":"01G0J1EXE7AXZ2C93K61WBPYEH","occurred_at":"2021-08-17T13:28:57.801578Z","urgency":"high","users":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}]}],"id":"01G0J1EXE7AXZ2C93K61WBPYEH","priority":{"name":"P1"},"related_alerts":[{"alert_group_ids":["01GW2G3V0S59R238FAHPDS1R66"],"alert_source_id":"01GW2G3V0S59R238FAHPDS1R66","created_at":"2021-08-17T13:28:57.801578Z","deduplication_key":"4293868629","description":"CPU on the payments service has exceeded 75 percent for 5 minutes","id":"01GW2G3V0S59R238FAHPDS1R66","resolved_at":"2021-08-17T14:28:57.801578Z","source_url":"https://www.my-alerting-platform.com/alerts/my-alert-123","status":"firing","title":"*errors.withMessage: PG::Error failed to connect","updated_at":"2021-08-17T13:28:57.801578Z"}],"related_incidents":[{"external_id":123,"id":"01FDAG4SAP5TYPT98WGR2N7W91","name":"Our database is sad","reference":"INC-123","status_category":"triage","summary":"Our database is really really sad, and we don't know why yet.","visibility":"public"}],"status":"pending","title":"Database CPU is high","updated_at":"2021-08-17T13:28:57.801578Z"}}
 type EscalationsShowResultV2 struct {
-	// Escalation Example: {"created_at":"2021-08-17T13:28:57.801578Z","creator":{"alert":{"id":"01GW2G3V0S59R238FAHPDS1R66","title":"*errors.withMessage: PG::Error failed to connect"},"user":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"workflow":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My little workflow"}},"escalation_path_id":"01G0J1EXE7AXZ2C93K61WBPYEH","events":[{"channels":[{"microsoft_teams_channel_id":"abc123","microsoft_teams_team_id":"abc123","slack_channel_id":"abc123","slack_team_id":"abc123"}],"event":"entered_grace_period","id":"01G0J1EXE7AXZ2C93K61WBPYEH","occurred_at":"2021-08-17T13:28:57.801578Z","urgency":"high","users":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}]}],"id":"01G0J1EXE7AXZ2C93K61WBPYEH","priority":{"name":"P1"},"related_alerts":[{"alert_group_ids":["01GW2G3V0S59R238FAHPDS1R66"],"alert_source_id":"01GW2G3V0S59R238FAHPDS1R66","created_at":"2021-08-17T13:28:57.801578Z","deduplication_key":"4293868629","description":"CPU on the payments service has exceeded 75 percent for 5 minutes","id":"01GW2G3V0S59R238FAHPDS1R66","resolved_at":"2021-08-17T14:28:57.801578Z","source_url":"https://www.my-alerting-platform.com/alerts/my-alert-123","status":"firing","title":"*errors.withMessage: PG::Error failed to connect","updated_at":"2021-08-17T13:28:57.801578Z"}],"related_incidents":[{"external_id":123,"id":"01FDAG4SAP5TYPT98WGR2N7W91","name":"Our database is sad","reference":"INC-123","status_category":"triage","summary":"Our database is really really sad, and we don't know why yet.","visibility":"public"}],"status":"pending","title":"Database CPU is high","updated_at":"2021-08-17T13:28:57.801578Z"}
+	// Escalation Example: {"created_at":"2021-08-17T13:28:57.801578Z","creator":{"alert":{"id":"01GW2G3V0S59R238FAHPDS1R66","title":"*errors.withMessage: PG::Error failed to connect"},"user":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"workflow":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My little workflow"}},"description":"Database CPU has been above 90% for 5 minutes","escalation_path_id":"01G0J1EXE7AXZ2C93K61WBPYEH","events":[{"channels":[{"microsoft_teams_channel_id":"abc123","microsoft_teams_team_id":"abc123","slack_channel_id":"abc123","slack_team_id":"abc123"}],"event":"entered_grace_period","id":"01G0J1EXE7AXZ2C93K61WBPYEH","occurred_at":"2021-08-17T13:28:57.801578Z","urgency":"high","users":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}]}],"id":"01G0J1EXE7AXZ2C93K61WBPYEH","priority":{"name":"P1"},"related_alerts":[{"alert_group_ids":["01GW2G3V0S59R238FAHPDS1R66"],"alert_source_id":"01GW2G3V0S59R238FAHPDS1R66","created_at":"2021-08-17T13:28:57.801578Z","deduplication_key":"4293868629","description":"CPU on the payments service has exceeded 75 percent for 5 minutes","id":"01GW2G3V0S59R238FAHPDS1R66","resolved_at":"2021-08-17T14:28:57.801578Z","source_url":"https://www.my-alerting-platform.com/alerts/my-alert-123","status":"firing","title":"*errors.withMessage: PG::Error failed to connect","updated_at":"2021-08-17T13:28:57.801578Z"}],"related_incidents":[{"external_id":123,"id":"01FDAG4SAP5TYPT98WGR2N7W91","name":"Our database is sad","reference":"INC-123","status_category":"triage","summary":"Our database is really really sad, and we don't know why yet.","visibility":"public"}],"status":"pending","title":"Database CPU is high","updated_at":"2021-08-17T13:28:57.801578Z"}
 	Escalation EscalationV2 `json:"escalation"`
 }
 
-// EscalationsUpdatePathPayloadV2 Example: {"name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}
+// EscalationsUpdatePathPayloadV2 Example: {"name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"escalation_path":{"escalation_path_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}
 type EscalationsUpdatePathPayloadV2 struct {
 	// Name The name of this escalation path, for the user's reference.
 	//
@@ -13559,7 +13630,7 @@ type EscalationsUpdatePathPayloadV2 struct {
 
 	// Path The nodes that form the levels and branches of this escalation path.
 	//
-	// Example: [{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]
+	// Example: [{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"escalation_path":{"escalation_path_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]
 	Path []EscalationPathNodePayloadV2 `json:"path"`
 
 	// RepeatConfig Example: {"delay_repeat_on_activity":false,"repeat_after_seconds":1800}
@@ -13576,10 +13647,39 @@ type EscalationsUpdatePathPayloadV2 struct {
 	WorkingHours *[]WeekdayIntervalConfigV2 `json:"working_hours,omitempty"`
 }
 
-// EscalationsUpdatePathResultV2 Example: {"escalation_path":{"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}}
+// EscalationsUpdatePathResultV2 Example: {"escalation_path":{"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"escalation_path":{"escalation_path_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}}
 type EscalationsUpdatePathResultV2 struct {
-	// EscalationPath Example: {"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}
+	// EscalationPath Example: {"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"escalation_path":{"escalation_path_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}
 	EscalationPath EscalationPathV2 `json:"escalation_path"`
+}
+
+// EscalationsValidatePathPayloadV2 Example: {"path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"escalation_path":{"escalation_path_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}
+type EscalationsValidatePathPayloadV2 struct {
+	// Path The nodes that form the levels and branches of this escalation path.
+	//
+	// Example: [{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"escalation_path":{"escalation_path_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]
+	Path []EscalationPathNodePayloadV2 `json:"path"`
+
+	// RepeatConfig Example: {"delay_repeat_on_activity":false,"repeat_after_seconds":1800}
+	RepeatConfig *EscalationPathRepeatConfigV2 `json:"repeat_config,omitempty"`
+
+	// TeamIds IDs of the teams that own this escalation path. This will automatically sync escalation paths with the right teams in Catalog. If you have an escalation paths attribute on your Teams, this attribute is required.
+	//
+	// Example: ["01JPQA75EPNEES4479P16P4XAB"]
+	TeamIds *[]string `json:"team_ids,omitempty"`
+
+	// WorkingHours The working hours for this escalation path.
+	//
+	// Example: [{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]
+	WorkingHours *[]WeekdayIntervalConfigV2 `json:"working_hours,omitempty"`
+}
+
+// EscalationsValidatePathResultV2 Example: {"warnings":[{"detail":"When the condition matches, escalation stops here instead of continuing.","path":"path.0.if_else.then_path","summary":"if_else has an empty \"then\" branch"}]}
+type EscalationsValidatePathResultV2 struct {
+	// Warnings Anything suspect about this config that isn't severe enough to reject it. Empty when there's nothing to say.
+	//
+	// Example: [{"detail":"When the condition matches, escalation stops here instead of continuing.","path":"path.0.if_else.then_path","summary":"if_else has an empty \"then\" branch"}]
+	Warnings []EscalationPathValidateWarningV2 `json:"warnings"`
 }
 
 // ExpressionBranchPayloadV2 Example: {"condition_groups":[{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}]}],"result":{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}}
@@ -18752,6 +18852,38 @@ type SchedulesShowScheduleSyncRuleResultV2 struct {
 	ScheduleSyncRule ScheduleSyncRuleV2 `json:"schedule_sync_rule"`
 }
 
+// SchedulesUpdateOverridePayloadV2 Example: {"end_at":"2021-08-17T14:00:00.000000Z","layer_id":"01G0J1EXE7AXZ2C93K61WBPYNH","rotation_id":"01G0J1EXE7AXZ2C93K61WBPYEH","start_at":"2021-08-17T13:00:00.000000Z","user":{"email":"bob@example.com","id":"01G0J1EXE7AXZ2C93K61WBPYEH","slack_user_id":"USER123"}}
+type SchedulesUpdateOverridePayloadV2 struct {
+	// EndAt End time of the override
+	//
+	// Example: 2021-08-17T14:00:00.000000Z
+	EndAt time.Time `json:"end_at"`
+
+	// LayerId The layer this override applies to
+	//
+	// Example: 01G0J1EXE7AXZ2C93K61WBPYNH
+	LayerId string `json:"layer_id"`
+
+	// RotationId The rotation this override applies to
+	//
+	// Example: 01G0J1EXE7AXZ2C93K61WBPYEH
+	RotationId string `json:"rotation_id"`
+
+	// StartAt Start time of the override
+	//
+	// Example: 2021-08-17T13:00:00.000000Z
+	StartAt time.Time `json:"start_at"`
+
+	// User Example: {"email":"bob@example.com","id":"01G0J1EXE7AXZ2C93K61WBPYEH","slack_user_id":"USER123"}
+	User UserReferencePayloadV2 `json:"user"`
+}
+
+// SchedulesUpdateOverrideResultV2 Example: {"override":{"created_at":"2021-08-17T13:28:57.801578Z","end_at":"2021-08-17T13:28:57.801578Z","id":"01G0J1EXE7AXZ2C93K61WBPYEH","layer_id":"01G0J1EXE7AXZ2C93K61WBPYEH","rotation_id":"01G0J1EXE7AXZ2C93K61WBPYEH","schedule_id":"01G0J1EXE7AXZ2C93K61WBPYEH","start_at":"2021-08-17T13:28:57.801578Z","updated_at":"2021-08-17T13:28:57.801578Z","user":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}}}
+type SchedulesUpdateOverrideResultV2 struct {
+	// Override Example: {"created_at":"2021-08-17T13:28:57.801578Z","end_at":"2021-08-17T13:28:57.801578Z","id":"01G0J1EXE7AXZ2C93K61WBPYEH","layer_id":"01G0J1EXE7AXZ2C93K61WBPYEH","rotation_id":"01G0J1EXE7AXZ2C93K61WBPYEH","schedule_id":"01G0J1EXE7AXZ2C93K61WBPYEH","start_at":"2021-08-17T13:28:57.801578Z","updated_at":"2021-08-17T13:28:57.801578Z","user":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}}
+	Override ScheduleOverrideV2 `json:"override"`
+}
+
 // SchedulesUpdatePayloadV2 Example: {"schedule":{"annotations":{"incident.io/terraform/version":"version-of-terraform"},"config":{"rotations":[{"effective_from":"2021-08-17T13:28:57.801578Z","handover_start_at":"2021-08-17T13:28:57.801578Z","handovers":[{"interval":1,"interval_type":"hourly"}],"id":"01G0J1EXE7AXZ2C93K61WBPYEH","layers":[{"id":"01G0J1EXE7AXZ2C93K61WBPYEH","name":"Layer 1"}],"name":"My Rotation","scheduling_mode":"fair","users":[{"email":"bob@example.com","id":"01G0J1EXE7AXZ2C93K61WBPYEH","slack_user_id":"USER123"}],"working_interval":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}],"working_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]},"holidays_public_config":{"country_codes":["abc123"]},"name":"Primary On-call Schedule","team_ids":["01JPQA75EPNEES4479P16P4XAB"],"timezone":"America/Los_Angeles"}}
 type SchedulesUpdatePayloadV2 struct {
 	// Schedule Example: {"annotations":{"incident.io/terraform/version":"version-of-terraform"},"config":{"rotations":[{"effective_from":"2021-08-17T13:28:57.801578Z","handover_start_at":"2021-08-17T13:28:57.801578Z","handovers":[{"interval":1,"interval_type":"hourly"}],"id":"01G0J1EXE7AXZ2C93K61WBPYEH","layers":[{"id":"01G0J1EXE7AXZ2C93K61WBPYEH","name":"Layer 1"}],"name":"My Rotation","scheduling_mode":"fair","users":[{"email":"bob@example.com","id":"01G0J1EXE7AXZ2C93K61WBPYEH","slack_user_id":"USER123"}],"working_interval":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}],"working_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]},"holidays_public_config":{"country_codes":["abc123"]},"name":"Primary On-call Schedule","team_ids":["01JPQA75EPNEES4479P16P4XAB"],"timezone":"America/Los_Angeles"}
@@ -21689,6 +21821,9 @@ type EscalationsV2ListParams struct {
 	// Alert Filter on the alert that created an escalation. Accepted operators are 'one_of' and 'not_in'.
 	Alert *map[string][]string `form:"alert,omitempty" json:"alert,omitempty"`
 
+	// Incident Filter on the incident that the escalation is connected to. Accepted operators are 'one_of' and 'not_in'.
+	Incident *map[string][]string `form:"incident,omitempty" json:"incident,omitempty"`
+
 	// CreatedAt Filter on the created_at timestamp of the escalation. Accepted operators are 'gte', 'lte' and 'date_range'.
 	CreatedAt *map[string][]string `form:"created_at,omitempty" json:"created_at,omitempty"`
 
@@ -22213,6 +22348,9 @@ type CustomFieldsV2UpdateJSONRequestBody = CustomFieldsUpdatePayloadV2
 // EscalationsV2CreatePathJSONRequestBody defines body for EscalationsV2CreatePath for application/json ContentType.
 type EscalationsV2CreatePathJSONRequestBody = EscalationsCreatePathPayloadV2
 
+// EscalationsV2ValidatePathJSONRequestBody defines body for EscalationsV2ValidatePath for application/json ContentType.
+type EscalationsV2ValidatePathJSONRequestBody = EscalationsValidatePathPayloadV2
+
 // EscalationsV2CreateExternalEscalationPathJSONRequestBody defines body for EscalationsV2CreateExternalEscalationPath for application/json ContentType.
 type EscalationsV2CreateExternalEscalationPathJSONRequestBody = EscalationsCreateExternalEscalationPathPayloadV2
 
@@ -22251,6 +22389,9 @@ type ManagedResourcesV2CreateManagedResourceJSONRequestBody = ManagedResourcesCr
 
 // SchedulesV2CreateOverrideJSONRequestBody defines body for SchedulesV2CreateOverride for application/json ContentType.
 type SchedulesV2CreateOverrideJSONRequestBody = SchedulesCreateOverridePayloadV2
+
+// SchedulesV2UpdateOverrideJSONRequestBody defines body for SchedulesV2UpdateOverride for application/json ContentType.
+type SchedulesV2UpdateOverrideJSONRequestBody = SchedulesUpdateOverridePayloadV2
 
 // ScheduleSyncTargetsV2CreateJSONRequestBody defines body for ScheduleSyncTargetsV2Create for application/json ContentType.
 type ScheduleSyncTargetsV2CreateJSONRequestBody = ScheduleSyncTargetsCreatePayloadV2
@@ -24035,6 +24176,32 @@ type ClientInterface interface {
 	// Corresponds with POST /v2/escalation_paths (the `EscalationsV2CreatePath` operationId).
 	EscalationsV2CreatePath(ctx context.Context, body EscalationsV2CreatePathJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// EscalationsV2ValidatePathWithBody ValidatePath Escalations V2
+	//
+	// Check whether an escalation path's config is valid, without creating or updating anything.
+	//
+	// This runs the same checks creating or updating a path would, so a config this accepts is
+	// one those endpoints will accept. A config that's valid but has no practical effect comes
+	// back as a warning on a successful response. A client can show it without blocking.
+	//
+	// Takes any type of body and a specified content type.
+	//
+	// Corresponds with POST /v2/escalation_paths/actions/validate (the `EscalationsV2ValidatePath` operationId).
+	EscalationsV2ValidatePathWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// EscalationsV2ValidatePath ValidatePath Escalations V2
+	//
+	// Check whether an escalation path's config is valid, without creating or updating anything.
+	//
+	// This runs the same checks creating or updating a path would, so a config this accepts is
+	// one those endpoints will accept. A config that's valid but has no practical effect comes
+	// back as a warning on a successful response. A client can show it without blocking.
+	//
+	// Takes a body of the `application/json` content type.
+	//
+	// Corresponds with POST /v2/escalation_paths/actions/validate (the `EscalationsV2ValidatePath` operationId).
+	EscalationsV2ValidatePath(ctx context.Context, body EscalationsV2ValidatePathJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// EscalationsV2ListExternalEscalationPaths ListExternalEscalationPaths Escalations V2
 	//
 	// List external escalation paths available for import from connected providers.
@@ -24152,6 +24319,22 @@ type ClientInterface interface {
 	// 		curl --get 'https://api.incident.io/v2/escalations' \
 	// 			--data 'alert[one_of]=ABC'
 	//
+	// ### By incident
+	//
+	// Find all escalations related to incident with id=ABC:
+	//
+	// 		curl --get 'https://api.incident.io/v2/escalations' \
+	// 			--data 'incident[one_of]=ABC'
+	//
+	// An escalation is related to an incident if it is linked to that incident directly, if it is
+	// attached to one of the incident's alerts, or if it triggered one of those alerts (which is
+	// what happens when someone pages by calling in, and that call raises the alert).
+	//
+	// To find everything that is not related to an incident, use "not_in":
+	//
+	// 		curl --get 'https://api.incident.io/v2/escalations' \
+	// 			--data 'incident[not_in]=ABC'
+	//
 	// ### By created_at and updated_at
 	// Find all escalations that follow specified date parameters for created_at and updated_at fields.
 	// Possible values are "gte" (greater than or equal to), "lte" (less than or equal to), and
@@ -24188,6 +24371,11 @@ type ClientInterface interface {
 	// in your internal developer platform). To escalate based on automated alerts, we
 	// recommend sending events to an alert source instead.
 	//
+	// If your API key's permissions are scoped to teams, you can only escalate via an
+	// escalation path that one of those teams owns. Escalating directly to user_ids
+	// needs the permission at the account level, because an escalation aimed at a
+	// person has no owning team.
+	//
 	// Takes any type of body and a specified content type.
 	//
 	// Corresponds with POST /v2/escalations (the `EscalationsV2Create` operationId).
@@ -24211,6 +24399,11 @@ type ClientInterface interface {
 	// interactive use cases (for example someone clicking a "escalate to team" button
 	// in your internal developer platform). To escalate based on automated alerts, we
 	// recommend sending events to an alert source instead.
+	//
+	// If your API key's permissions are scoped to teams, you can only escalate via an
+	// escalation path that one of those teams owns. Escalating directly to user_ids
+	// needs the permission at the account level, because an escalation aimed at a
+	// person has no owning team.
 	//
 	// Takes a body of the `application/json` content type.
 	//
@@ -24815,6 +25008,49 @@ type ClientInterface interface {
 	//
 	// Corresponds with POST /v2/schedule_overrides (the `SchedulesV2CreateOverride` operationId).
 	SchedulesV2CreateOverride(ctx context.Context, body SchedulesV2CreateOverrideJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// SchedulesV2DestroyOverride DestroyOverride Schedules V2
+	//
+	// Delete a schedule override, restoring whoever the rotations put on-call for that window.
+	//
+	// Deleting an override that has already been deleted succeeds, so it is safe to retry.
+	//
+	// Corresponds with DELETE /v2/schedule_overrides/{id} (the `SchedulesV2DestroyOverride` operationId).
+	SchedulesV2DestroyOverride(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// SchedulesV2UpdateOverrideWithBody UpdateOverride Schedules V2
+	//
+	// Update a schedule override, moving its window or the rotation and layer it sits on.
+	//
+	// An override cannot be reassigned: send the user it already has, and delete and recreate
+	// it to put someone else on call for that window.
+	//
+	// Overrides on a layer cannot overlap, so widening one over its neighbour's window takes
+	// that time over. The neighbour is deleted, and any of its time left outside the new
+	// window comes back as new overrides with new IDs, so other override IDs on this layer
+	// may stop resolving — list the schedule's overrides again to pick up the replacements.
+	//
+	// Takes any type of body and a specified content type.
+	//
+	// Corresponds with PUT /v2/schedule_overrides/{id} (the `SchedulesV2UpdateOverride` operationId).
+	SchedulesV2UpdateOverrideWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// SchedulesV2UpdateOverride UpdateOverride Schedules V2
+	//
+	// Update a schedule override, moving its window or the rotation and layer it sits on.
+	//
+	// An override cannot be reassigned: send the user it already has, and delete and recreate
+	// it to put someone else on call for that window.
+	//
+	// Overrides on a layer cannot overlap, so widening one over its neighbour's window takes
+	// that time over. The neighbour is deleted, and any of its time left outside the new
+	// window comes back as new overrides with new IDs, so other override IDs on this layer
+	// may stop resolving — list the schedule's overrides again to pick up the replacements.
+	//
+	// Takes a body of the `application/json` content type.
+	//
+	// Corresponds with PUT /v2/schedule_overrides/{id} (the `SchedulesV2UpdateOverride` operationId).
+	SchedulesV2UpdateOverride(ctx context.Context, id string, body SchedulesV2UpdateOverrideJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ScheduleSyncTargetsV2List List Schedule Sync Targets V2
 	//
@@ -29335,6 +29571,52 @@ func (c *Client) EscalationsV2CreatePath(ctx context.Context, body EscalationsV2
 	return c.Client.Do(req)
 }
 
+// EscalationsV2ValidatePathWithBody ValidatePath Escalations V2
+//
+// Check whether an escalation path's config is valid, without creating or updating anything.
+//
+// This runs the same checks creating or updating a path would, so a config this accepts is
+// one those endpoints will accept. A config that's valid but has no practical effect comes
+// back as a warning on a successful response. A client can show it without blocking.
+//
+// Takes any type of body and a specified content type.
+//
+// Corresponds with POST /v2/escalation_paths/actions/validate (the `EscalationsV2ValidatePath` operationId).
+func (c *Client) EscalationsV2ValidatePathWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEscalationsV2ValidatePathRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+// EscalationsV2ValidatePath ValidatePath Escalations V2
+//
+// Check whether an escalation path's config is valid, without creating or updating anything.
+//
+// This runs the same checks creating or updating a path would, so a config this accepts is
+// one those endpoints will accept. A config that's valid but has no practical effect comes
+// back as a warning on a successful response. A client can show it without blocking.
+//
+// Takes a body of the `application/json` content type.
+//
+// Corresponds with POST /v2/escalation_paths/actions/validate (the `EscalationsV2ValidatePath` operationId).
+func (c *Client) EscalationsV2ValidatePath(ctx context.Context, body EscalationsV2ValidatePathJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEscalationsV2ValidatePathRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 // EscalationsV2ListExternalEscalationPaths ListExternalEscalationPaths Escalations V2
 //
 // List external escalation paths available for import from connected providers.
@@ -29522,6 +29804,22 @@ func (c *Client) EscalationsV2UpdatePath(ctx context.Context, id string, body Es
 //	curl --get 'https://api.incident.io/v2/escalations' \
 //		--data 'alert[one_of]=ABC'
 //
+// ### By incident
+//
+// Find all escalations related to incident with id=ABC:
+//
+//	curl --get 'https://api.incident.io/v2/escalations' \
+//		--data 'incident[one_of]=ABC'
+//
+// An escalation is related to an incident if it is linked to that incident directly, if it is
+// attached to one of the incident's alerts, or if it triggered one of those alerts (which is
+// what happens when someone pages by calling in, and that call raises the alert).
+//
+// To find everything that is not related to an incident, use "not_in":
+//
+//	curl --get 'https://api.incident.io/v2/escalations' \
+//		--data 'incident[not_in]=ABC'
+//
 // ### By created_at and updated_at
 // Find all escalations that follow specified date parameters for created_at and updated_at fields.
 // Possible values are "gte" (greater than or equal to), "lte" (less than or equal to), and
@@ -29568,6 +29866,11 @@ func (c *Client) EscalationsV2List(ctx context.Context, params *EscalationsV2Lis
 // in your internal developer platform). To escalate based on automated alerts, we
 // recommend sending events to an alert source instead.
 //
+// If your API key's permissions are scoped to teams, you can only escalate via an
+// escalation path that one of those teams owns. Escalating directly to user_ids
+// needs the permission at the account level, because an escalation aimed at a
+// person has no owning team.
+//
 // Takes any type of body and a specified content type.
 //
 // Corresponds with POST /v2/escalations (the `EscalationsV2Create` operationId).
@@ -29601,6 +29904,11 @@ func (c *Client) EscalationsV2CreateWithBody(ctx context.Context, contentType st
 // interactive use cases (for example someone clicking a "escalate to team" button
 // in your internal developer platform). To escalate based on automated alerts, we
 // recommend sending events to an alert source instead.
+//
+// If your API key's permissions are scoped to teams, you can only escalate via an
+// escalation path that one of those teams owns. Escalating directly to user_ids
+// needs the permission at the account level, because an escalation aimed at a
+// person has no owning team.
 //
 // Takes a body of the `application/json` content type.
 //
@@ -30604,6 +30912,79 @@ func (c *Client) SchedulesV2CreateOverrideWithBody(ctx context.Context, contentT
 // Corresponds with POST /v2/schedule_overrides (the `SchedulesV2CreateOverride` operationId).
 func (c *Client) SchedulesV2CreateOverride(ctx context.Context, body SchedulesV2CreateOverrideJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewSchedulesV2CreateOverrideRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+// SchedulesV2DestroyOverride DestroyOverride Schedules V2
+//
+// Delete a schedule override, restoring whoever the rotations put on-call for that window.
+//
+// Deleting an override that has already been deleted succeeds, so it is safe to retry.
+//
+// Corresponds with DELETE /v2/schedule_overrides/{id} (the `SchedulesV2DestroyOverride` operationId).
+func (c *Client) SchedulesV2DestroyOverride(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSchedulesV2DestroyOverrideRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+// SchedulesV2UpdateOverrideWithBody UpdateOverride Schedules V2
+//
+// Update a schedule override, moving its window or the rotation and layer it sits on.
+//
+// An override cannot be reassigned: send the user it already has, and delete and recreate
+// it to put someone else on call for that window.
+//
+// Overrides on a layer cannot overlap, so widening one over its neighbour's window takes
+// that time over. The neighbour is deleted, and any of its time left outside the new
+// window comes back as new overrides with new IDs, so other override IDs on this layer
+// may stop resolving — list the schedule's overrides again to pick up the replacements.
+//
+// Takes any type of body and a specified content type.
+//
+// Corresponds with PUT /v2/schedule_overrides/{id} (the `SchedulesV2UpdateOverride` operationId).
+func (c *Client) SchedulesV2UpdateOverrideWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSchedulesV2UpdateOverrideRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+// SchedulesV2UpdateOverride UpdateOverride Schedules V2
+//
+// Update a schedule override, moving its window or the rotation and layer it sits on.
+//
+// An override cannot be reassigned: send the user it already has, and delete and recreate
+// it to put someone else on call for that window.
+//
+// Overrides on a layer cannot overlap, so widening one over its neighbour's window takes
+// that time over. The neighbour is deleted, and any of its time left outside the new
+// window comes back as new overrides with new IDs, so other override IDs on this layer
+// may stop resolving — list the schedule's overrides again to pick up the replacements.
+//
+// Takes a body of the `application/json` content type.
+//
+// Corresponds with PUT /v2/schedule_overrides/{id} (the `SchedulesV2UpdateOverride` operationId).
+func (c *Client) SchedulesV2UpdateOverride(ctx context.Context, id string, body SchedulesV2UpdateOverrideJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSchedulesV2UpdateOverrideRequest(c.Server, id, body)
 	if err != nil {
 		return nil, err
 	}
@@ -38358,6 +38739,46 @@ func NewEscalationsV2CreatePathRequestWithBody(server string, contentType string
 	return req, nil
 }
 
+// NewEscalationsV2ValidatePathRequest calls the generic EscalationsV2ValidatePath builder with application/json body
+func NewEscalationsV2ValidatePathRequest(server string, body EscalationsV2ValidatePathJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewEscalationsV2ValidatePathRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewEscalationsV2ValidatePathRequestWithBody constructs an http.Request for the EscalationsV2ValidatePath method, with any body, and a specified content type
+func NewEscalationsV2ValidatePathRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/escalation_paths/actions/validate")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewEscalationsV2ListExternalEscalationPathsRequest constructs an http.Request for the EscalationsV2ListExternalEscalationPaths method
 func NewEscalationsV2ListExternalEscalationPathsRequest(server string, params *EscalationsV2ListExternalEscalationPathsParams) (*http.Request, error) {
 	var err error
@@ -38694,6 +39115,18 @@ func NewEscalationsV2ListRequest(server string, params *EscalationsV2ListParams)
 		if params.Alert != nil {
 
 			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "alert", *params.Alert, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "object", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.Incident != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "incident", *params.Incident, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "object", Format: ""}); err != nil {
 				return nil, err
 			} else {
 				for _, qp := range strings.Split(queryFrag, "&") {
@@ -40409,6 +40842,87 @@ func NewSchedulesV2CreateOverrideRequestWithBody(server string, contentType stri
 	}
 
 	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewSchedulesV2DestroyOverrideRequest constructs an http.Request for the SchedulesV2DestroyOverride method
+func NewSchedulesV2DestroyOverrideRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/schedule_overrides/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewSchedulesV2UpdateOverrideRequest calls the generic SchedulesV2UpdateOverride builder with application/json body
+func NewSchedulesV2UpdateOverrideRequest(server string, id string, body SchedulesV2UpdateOverrideJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewSchedulesV2UpdateOverrideRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewSchedulesV2UpdateOverrideRequestWithBody constructs an http.Request for the SchedulesV2UpdateOverride method, with any body, and a specified content type
+func NewSchedulesV2UpdateOverrideRequestWithBody(server string, id string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/schedule_overrides/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPut, queryURL.String(), body)
 	if err != nil {
 		return nil, err
 	}
@@ -46789,6 +47303,32 @@ type ClientWithResponsesInterface interface {
 	// Corresponds with POST /v2/escalation_paths (the `EscalationsV2CreatePath` operationId).
 	EscalationsV2CreatePathWithResponse(ctx context.Context, body EscalationsV2CreatePathJSONRequestBody, reqEditors ...RequestEditorFn) (*EscalationsV2CreatePathResponse, error)
 
+	// EscalationsV2ValidatePathWithBodyWithResponse ValidatePath Escalations V2
+	//
+	// Check whether an escalation path's config is valid, without creating or updating anything.
+	//
+	// This runs the same checks creating or updating a path would, so a config this accepts is
+	// one those endpoints will accept. A config that's valid but has no practical effect comes
+	// back as a warning on a successful response. A client can show it without blocking.
+	//
+	// Takes any type of body and a specified content type, and returns a wrapper object for the known response body format(s).
+	//
+	// Corresponds with POST /v2/escalation_paths/actions/validate (the `EscalationsV2ValidatePath` operationId).
+	EscalationsV2ValidatePathWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EscalationsV2ValidatePathResponse, error)
+
+	// EscalationsV2ValidatePathWithResponse ValidatePath Escalations V2
+	//
+	// Check whether an escalation path's config is valid, without creating or updating anything.
+	//
+	// This runs the same checks creating or updating a path would, so a config this accepts is
+	// one those endpoints will accept. A config that's valid but has no practical effect comes
+	// back as a warning on a successful response. A client can show it without blocking.
+	//
+	// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+	//
+	// Corresponds with POST /v2/escalation_paths/actions/validate (the `EscalationsV2ValidatePath` operationId).
+	EscalationsV2ValidatePathWithResponse(ctx context.Context, body EscalationsV2ValidatePathJSONRequestBody, reqEditors ...RequestEditorFn) (*EscalationsV2ValidatePathResponse, error)
+
 	// EscalationsV2ListExternalEscalationPathsWithResponse ListExternalEscalationPaths Escalations V2
 	//
 	// List external escalation paths available for import from connected providers.
@@ -46912,6 +47452,22 @@ type ClientWithResponsesInterface interface {
 	// 		curl --get 'https://api.incident.io/v2/escalations' \
 	// 			--data 'alert[one_of]=ABC'
 	//
+	// ### By incident
+	//
+	// Find all escalations related to incident with id=ABC:
+	//
+	// 		curl --get 'https://api.incident.io/v2/escalations' \
+	// 			--data 'incident[one_of]=ABC'
+	//
+	// An escalation is related to an incident if it is linked to that incident directly, if it is
+	// attached to one of the incident's alerts, or if it triggered one of those alerts (which is
+	// what happens when someone pages by calling in, and that call raises the alert).
+	//
+	// To find everything that is not related to an incident, use "not_in":
+	//
+	// 		curl --get 'https://api.incident.io/v2/escalations' \
+	// 			--data 'incident[not_in]=ABC'
+	//
 	// ### By created_at and updated_at
 	// Find all escalations that follow specified date parameters for created_at and updated_at fields.
 	// Possible values are "gte" (greater than or equal to), "lte" (less than or equal to), and
@@ -46950,6 +47506,11 @@ type ClientWithResponsesInterface interface {
 	// in your internal developer platform). To escalate based on automated alerts, we
 	// recommend sending events to an alert source instead.
 	//
+	// If your API key's permissions are scoped to teams, you can only escalate via an
+	// escalation path that one of those teams owns. Escalating directly to user_ids
+	// needs the permission at the account level, because an escalation aimed at a
+	// person has no owning team.
+	//
 	// Takes any type of body and a specified content type, and returns a wrapper object for the known response body format(s).
 	//
 	// Corresponds with POST /v2/escalations (the `EscalationsV2Create` operationId).
@@ -46973,6 +47534,11 @@ type ClientWithResponsesInterface interface {
 	// interactive use cases (for example someone clicking a "escalate to team" button
 	// in your internal developer platform). To escalate based on automated alerts, we
 	// recommend sending events to an alert source instead.
+	//
+	// If your API key's permissions are scoped to teams, you can only escalate via an
+	// escalation path that one of those teams owns. Escalating directly to user_ids
+	// needs the permission at the account level, because an escalation aimed at a
+	// person has no owning team.
 	//
 	// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
 	//
@@ -47617,6 +48183,51 @@ type ClientWithResponsesInterface interface {
 	//
 	// Corresponds with POST /v2/schedule_overrides (the `SchedulesV2CreateOverride` operationId).
 	SchedulesV2CreateOverrideWithResponse(ctx context.Context, body SchedulesV2CreateOverrideJSONRequestBody, reqEditors ...RequestEditorFn) (*SchedulesV2CreateOverrideResponse, error)
+
+	// SchedulesV2DestroyOverrideWithResponse DestroyOverride Schedules V2
+	//
+	// Delete a schedule override, restoring whoever the rotations put on-call for that window.
+	//
+	// Deleting an override that has already been deleted succeeds, so it is safe to retry.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	//
+	// Corresponds with DELETE /v2/schedule_overrides/{id} (the `SchedulesV2DestroyOverride` operationId).
+	SchedulesV2DestroyOverrideWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*SchedulesV2DestroyOverrideResponse, error)
+
+	// SchedulesV2UpdateOverrideWithBodyWithResponse UpdateOverride Schedules V2
+	//
+	// Update a schedule override, moving its window or the rotation and layer it sits on.
+	//
+	// An override cannot be reassigned: send the user it already has, and delete and recreate
+	// it to put someone else on call for that window.
+	//
+	// Overrides on a layer cannot overlap, so widening one over its neighbour's window takes
+	// that time over. The neighbour is deleted, and any of its time left outside the new
+	// window comes back as new overrides with new IDs, so other override IDs on this layer
+	// may stop resolving — list the schedule's overrides again to pick up the replacements.
+	//
+	// Takes any type of body and a specified content type, and returns a wrapper object for the known response body format(s).
+	//
+	// Corresponds with PUT /v2/schedule_overrides/{id} (the `SchedulesV2UpdateOverride` operationId).
+	SchedulesV2UpdateOverrideWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SchedulesV2UpdateOverrideResponse, error)
+
+	// SchedulesV2UpdateOverrideWithResponse UpdateOverride Schedules V2
+	//
+	// Update a schedule override, moving its window or the rotation and layer it sits on.
+	//
+	// An override cannot be reassigned: send the user it already has, and delete and recreate
+	// it to put someone else on call for that window.
+	//
+	// Overrides on a layer cannot overlap, so widening one over its neighbour's window takes
+	// that time over. The neighbour is deleted, and any of its time left outside the new
+	// window comes back as new overrides with new IDs, so other override IDs on this layer
+	// may stop resolving — list the schedule's overrides again to pick up the replacements.
+	//
+	// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+	//
+	// Corresponds with PUT /v2/schedule_overrides/{id} (the `SchedulesV2UpdateOverride` operationId).
+	SchedulesV2UpdateOverrideWithResponse(ctx context.Context, id string, body SchedulesV2UpdateOverrideJSONRequestBody, reqEditors ...RequestEditorFn) (*SchedulesV2UpdateOverrideResponse, error)
 
 	// ScheduleSyncTargetsV2ListWithResponse List Schedule Sync Targets V2
 	//
@@ -53624,6 +54235,47 @@ func (r EscalationsV2CreatePathResponse) ContentType() string {
 	return ""
 }
 
+type EscalationsV2ValidatePathResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *EscalationsValidatePathResultV2
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r EscalationsV2ValidatePathResponse) GetJSON200() *EscalationsValidatePathResultV2 {
+	return r.JSON200
+}
+
+// GetBody returns the raw response body bytes
+func (r EscalationsV2ValidatePathResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r EscalationsV2ValidatePathResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r EscalationsV2ValidatePathResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r EscalationsV2ValidatePathResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
 type EscalationsV2ListExternalEscalationPathsResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -55100,6 +55752,81 @@ func (r SchedulesV2CreateOverrideResponse) StatusCode() int {
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
 func (r SchedulesV2CreateOverrideResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type SchedulesV2DestroyOverrideResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// GetBody returns the raw response body bytes
+func (r SchedulesV2DestroyOverrideResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r SchedulesV2DestroyOverrideResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r SchedulesV2DestroyOverrideResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r SchedulesV2DestroyOverrideResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type SchedulesV2UpdateOverrideResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *SchedulesUpdateOverrideResultV2
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r SchedulesV2UpdateOverrideResponse) GetJSON200() *SchedulesUpdateOverrideResultV2 {
+	return r.JSON200
+}
+
+// GetBody returns the raw response body bytes
+func (r SchedulesV2UpdateOverrideResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r SchedulesV2UpdateOverrideResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r SchedulesV2UpdateOverrideResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r SchedulesV2UpdateOverrideResponse) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -61668,6 +62395,44 @@ func (c *ClientWithResponses) EscalationsV2CreatePathWithResponse(ctx context.Co
 	return ParseEscalationsV2CreatePathResponse(rsp)
 }
 
+// EscalationsV2ValidatePathWithBodyWithResponse ValidatePath Escalations V2
+//
+// Check whether an escalation path's config is valid, without creating or updating anything.
+//
+// This runs the same checks creating or updating a path would, so a config this accepts is
+// one those endpoints will accept. A config that's valid but has no practical effect comes
+// back as a warning on a successful response. A client can show it without blocking.
+//
+// Takes any type of body and a specified content type, and returns a wrapper object for the known response body format(s).
+//
+// Corresponds with POST /v2/escalation_paths/actions/validate (the `EscalationsV2ValidatePath` operationId).
+func (c *ClientWithResponses) EscalationsV2ValidatePathWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EscalationsV2ValidatePathResponse, error) {
+	rsp, err := c.EscalationsV2ValidatePathWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEscalationsV2ValidatePathResponse(rsp)
+}
+
+// EscalationsV2ValidatePathWithResponse ValidatePath Escalations V2
+//
+// Check whether an escalation path's config is valid, without creating or updating anything.
+//
+// This runs the same checks creating or updating a path would, so a config this accepts is
+// one those endpoints will accept. A config that's valid but has no practical effect comes
+// back as a warning on a successful response. A client can show it without blocking.
+//
+// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+//
+// Corresponds with POST /v2/escalation_paths/actions/validate (the `EscalationsV2ValidatePath` operationId).
+func (c *ClientWithResponses) EscalationsV2ValidatePathWithResponse(ctx context.Context, body EscalationsV2ValidatePathJSONRequestBody, reqEditors ...RequestEditorFn) (*EscalationsV2ValidatePathResponse, error) {
+	rsp, err := c.EscalationsV2ValidatePath(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEscalationsV2ValidatePathResponse(rsp)
+}
+
 // EscalationsV2ListExternalEscalationPathsWithResponse ListExternalEscalationPaths Escalations V2
 //
 // List external escalation paths available for import from connected providers.
@@ -61833,6 +62598,22 @@ func (c *ClientWithResponses) EscalationsV2UpdatePathWithResponse(ctx context.Co
 //	curl --get 'https://api.incident.io/v2/escalations' \
 //		--data 'alert[one_of]=ABC'
 //
+// ### By incident
+//
+// Find all escalations related to incident with id=ABC:
+//
+//	curl --get 'https://api.incident.io/v2/escalations' \
+//		--data 'incident[one_of]=ABC'
+//
+// An escalation is related to an incident if it is linked to that incident directly, if it is
+// attached to one of the incident's alerts, or if it triggered one of those alerts (which is
+// what happens when someone pages by calling in, and that call raises the alert).
+//
+// To find everything that is not related to an incident, use "not_in":
+//
+//	curl --get 'https://api.incident.io/v2/escalations' \
+//		--data 'incident[not_in]=ABC'
+//
 // ### By created_at and updated_at
 // Find all escalations that follow specified date parameters for created_at and updated_at fields.
 // Possible values are "gte" (greater than or equal to), "lte" (less than or equal to), and
@@ -61877,6 +62658,11 @@ func (c *ClientWithResponses) EscalationsV2ListWithResponse(ctx context.Context,
 // in your internal developer platform). To escalate based on automated alerts, we
 // recommend sending events to an alert source instead.
 //
+// If your API key's permissions are scoped to teams, you can only escalate via an
+// escalation path that one of those teams owns. Escalating directly to user_ids
+// needs the permission at the account level, because an escalation aimed at a
+// person has no owning team.
+//
 // Takes any type of body and a specified content type, and returns a wrapper object for the known response body format(s).
 //
 // Corresponds with POST /v2/escalations (the `EscalationsV2Create` operationId).
@@ -61906,6 +62692,11 @@ func (c *ClientWithResponses) EscalationsV2CreateWithBodyWithResponse(ctx contex
 // interactive use cases (for example someone clicking a "escalate to team" button
 // in your internal developer platform). To escalate based on automated alerts, we
 // recommend sending events to an alert source instead.
+//
+// If your API key's permissions are scoped to teams, you can only escalate via an
+// escalation path that one of those teams owns. Escalating directly to user_ids
+// needs the permission at the account level, because an escalation aimed at a
+// person has no owning team.
 //
 // Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
 //
@@ -62793,6 +63584,69 @@ func (c *ClientWithResponses) SchedulesV2CreateOverrideWithResponse(ctx context.
 		return nil, err
 	}
 	return ParseSchedulesV2CreateOverrideResponse(rsp)
+}
+
+// SchedulesV2DestroyOverrideWithResponse DestroyOverride Schedules V2
+//
+// Delete a schedule override, restoring whoever the rotations put on-call for that window.
+//
+// Deleting an override that has already been deleted succeeds, so it is safe to retry.
+//
+// Returns a wrapper object for the known response body format(s).
+//
+// Corresponds with DELETE /v2/schedule_overrides/{id} (the `SchedulesV2DestroyOverride` operationId).
+func (c *ClientWithResponses) SchedulesV2DestroyOverrideWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*SchedulesV2DestroyOverrideResponse, error) {
+	rsp, err := c.SchedulesV2DestroyOverride(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSchedulesV2DestroyOverrideResponse(rsp)
+}
+
+// SchedulesV2UpdateOverrideWithBodyWithResponse UpdateOverride Schedules V2
+//
+// Update a schedule override, moving its window or the rotation and layer it sits on.
+//
+// An override cannot be reassigned: send the user it already has, and delete and recreate
+// it to put someone else on call for that window.
+//
+// Overrides on a layer cannot overlap, so widening one over its neighbour's window takes
+// that time over. The neighbour is deleted, and any of its time left outside the new
+// window comes back as new overrides with new IDs, so other override IDs on this layer
+// may stop resolving — list the schedule's overrides again to pick up the replacements.
+//
+// Takes any type of body and a specified content type, and returns a wrapper object for the known response body format(s).
+//
+// Corresponds with PUT /v2/schedule_overrides/{id} (the `SchedulesV2UpdateOverride` operationId).
+func (c *ClientWithResponses) SchedulesV2UpdateOverrideWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SchedulesV2UpdateOverrideResponse, error) {
+	rsp, err := c.SchedulesV2UpdateOverrideWithBody(ctx, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSchedulesV2UpdateOverrideResponse(rsp)
+}
+
+// SchedulesV2UpdateOverrideWithResponse UpdateOverride Schedules V2
+//
+// Update a schedule override, moving its window or the rotation and layer it sits on.
+//
+// An override cannot be reassigned: send the user it already has, and delete and recreate
+// it to put someone else on call for that window.
+//
+// Overrides on a layer cannot overlap, so widening one over its neighbour's window takes
+// that time over. The neighbour is deleted, and any of its time left outside the new
+// window comes back as new overrides with new IDs, so other override IDs on this layer
+// may stop resolving — list the schedule's overrides again to pick up the replacements.
+//
+// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+//
+// Corresponds with PUT /v2/schedule_overrides/{id} (the `SchedulesV2UpdateOverride` operationId).
+func (c *ClientWithResponses) SchedulesV2UpdateOverrideWithResponse(ctx context.Context, id string, body SchedulesV2UpdateOverrideJSONRequestBody, reqEditors ...RequestEditorFn) (*SchedulesV2UpdateOverrideResponse, error) {
+	rsp, err := c.SchedulesV2UpdateOverride(ctx, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSchedulesV2UpdateOverrideResponse(rsp)
 }
 
 // ScheduleSyncTargetsV2ListWithResponse List Schedule Sync Targets V2
@@ -67888,6 +68742,32 @@ func ParseEscalationsV2CreatePathResponse(rsp *http.Response) (*EscalationsV2Cre
 	return response, nil
 }
 
+// ParseEscalationsV2ValidatePathResponse parses an HTTP response from a EscalationsV2ValidatePathWithResponse call
+func ParseEscalationsV2ValidatePathResponse(rsp *http.Response) (*EscalationsV2ValidatePathResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &EscalationsV2ValidatePathResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest EscalationsValidatePathResultV2
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseEscalationsV2ListExternalEscalationPathsResponse parses an HTTP response from a EscalationsV2ListExternalEscalationPathsWithResponse call
 func ParseEscalationsV2ListExternalEscalationPathsResponse(rsp *http.Response) (*EscalationsV2ListExternalEscalationPathsResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -68797,6 +69677,48 @@ func ParseSchedulesV2CreateOverrideResponse(rsp *http.Response) (*SchedulesV2Cre
 			return nil, err
 		}
 		response.JSON201 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseSchedulesV2DestroyOverrideResponse parses an HTTP response from a SchedulesV2DestroyOverrideWithResponse call
+func ParseSchedulesV2DestroyOverrideResponse(rsp *http.Response) (*SchedulesV2DestroyOverrideResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &SchedulesV2DestroyOverrideResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	return response, nil
+}
+
+// ParseSchedulesV2UpdateOverrideResponse parses an HTTP response from a SchedulesV2UpdateOverrideWithResponse call
+func ParseSchedulesV2UpdateOverrideResponse(rsp *http.Response) (*SchedulesV2UpdateOverrideResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &SchedulesV2UpdateOverrideResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest SchedulesUpdateOverrideResultV2
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
 
 	}
 

--- a/internal/provider/incident_escalation_path_modify_plan_test.go
+++ b/internal/provider/incident_escalation_path_modify_plan_test.go
@@ -1,0 +1,386 @@
+package provider
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
+	"github.com/incident-io/terraform-provider-incident/internal/client"
+)
+
+// fakeEscalationPathValidateAPI stands in for the validate endpoint during a plan.
+// Counting requests is what proves the plan stays quiet when there is nothing it could
+// usefully check.
+type fakeEscalationPathValidateAPI struct {
+	// status is the response code, 200 when unset. body is served with it, so a case can
+	// assert the API's own words reach the user.
+	status int
+	body   string
+
+	requests int
+	// lastPayload is what the provider sent, for cases that care about the request rather
+	// than the response.
+	lastPayload client.EscalationsValidatePathPayloadV2
+}
+
+func (f *fakeEscalationPathValidateAPI) start(t *testing.T) *client.ClientWithResponses {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/escalation_paths/actions/validate", func(w http.ResponseWriter, r *http.Request) {
+		f.requests++
+
+		f.lastPayload = client.EscalationsValidatePathPayloadV2{}
+		if err := json.NewDecoder(r.Body).Decode(&f.lastPayload); err != nil {
+			t.Errorf("decoding the validate payload: %v", err)
+		}
+
+		status := f.status
+		if status == 0 {
+			status = http.StatusOK
+		}
+
+		body := f.body
+		if body == "" && status == http.StatusOK {
+			body = `{"warnings":[]}`
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		if body != "" {
+			_, _ = w.Write([]byte(body))
+		}
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	api, err := client.New(t.Context(), "test-key", server.URL, "test")
+	if err != nil {
+		t.Fatalf("building client: %v", err)
+	}
+
+	return api
+}
+
+func escalationPathSchemaType(t *testing.T) tftypes.Object {
+	t.Helper()
+
+	var schemaResp resource.SchemaResponse
+	NewIncidentEscalationPathResource().Schema(t.Context(), resource.SchemaRequest{}, &schemaResp)
+
+	objType, ok := schemaResp.Schema.Type().TerraformType(t.Context()).(tftypes.Object)
+	if !ok {
+		t.Fatal("expected the escalation path schema to be an object")
+	}
+
+	return objType
+}
+
+// escalationPathTargetValue builds a single level target, matching the schema's target
+// object type. scheduleModeUnknown simulates the plan for a target whose config doesn't
+// set schedule_mode, which is Optional+Computed with no static default.
+func escalationPathTargetValue(t *testing.T, targetType tftypes.Object, scheduleModeUnknown bool) tftypes.Value {
+	t.Helper()
+
+	attributes := map[string]tftypes.Value{}
+	if err := nullFilledObject(t, targetType).As(&attributes); err != nil {
+		t.Fatalf("reading the target back: %v", err)
+	}
+	attributes["id"] = tftypes.NewValue(tftypes.String, "01SCHEDULE")
+	attributes["type"] = tftypes.NewValue(tftypes.String, "schedule")
+	attributes["urgency"] = tftypes.NewValue(tftypes.String, "high")
+	if scheduleModeUnknown {
+		attributes["schedule_mode"] = tftypes.NewValue(tftypes.String, tftypes.UnknownValue)
+	}
+
+	return tftypes.NewValue(targetType, attributes)
+}
+
+// escalationPathPlan builds a plan for one "level" node with one target, which is all
+// validation needs. Filling from the schema's own type keeps this working as the schema
+// grows.
+func escalationPathPlan(t *testing.T, scheduleModeUnknown bool) tftypes.Value {
+	t.Helper()
+
+	objType := escalationPathSchemaType(t)
+
+	pathType, ok := objType.AttributeTypes["path"].(tftypes.List)
+	if !ok {
+		t.Fatal("expected path to be a list")
+	}
+	nodeType, ok := pathType.ElementType.(tftypes.Object)
+	if !ok {
+		t.Fatal("expected path elements to be objects")
+	}
+	levelType, ok := nodeType.AttributeTypes["level"].(tftypes.Object)
+	if !ok {
+		t.Fatal("expected level to be an object")
+	}
+	targetsType, ok := levelType.AttributeTypes["targets"].(tftypes.List)
+	if !ok {
+		t.Fatal("expected level.targets to be a list")
+	}
+	targetType, ok := targetsType.ElementType.(tftypes.Object)
+	if !ok {
+		t.Fatal("expected level.targets elements to be objects")
+	}
+
+	target := escalationPathTargetValue(t, targetType, scheduleModeUnknown)
+
+	levelAttributes := map[string]tftypes.Value{}
+	if err := nullFilledObject(t, levelType).As(&levelAttributes); err != nil {
+		t.Fatalf("reading level back: %v", err)
+	}
+	levelAttributes["targets"] = tftypes.NewValue(targetsType, []tftypes.Value{target})
+
+	nodeAttributes := map[string]tftypes.Value{}
+	if err := nullFilledObject(t, nodeType).As(&nodeAttributes); err != nil {
+		t.Fatalf("reading node back: %v", err)
+	}
+	nodeAttributes["type"] = tftypes.NewValue(tftypes.String, "level")
+	nodeAttributes["level"] = tftypes.NewValue(levelType, levelAttributes)
+	node := tftypes.NewValue(nodeType, nodeAttributes)
+
+	attributes := map[string]tftypes.Value{}
+	for name, attrType := range objType.AttributeTypes {
+		attributes[name] = tftypes.NewValue(attrType, nil)
+	}
+	attributes["name"] = tftypes.NewValue(tftypes.String, "Test Path")
+	attributes["path"] = tftypes.NewValue(pathType, []tftypes.Value{node})
+
+	return tftypes.NewValue(objType, attributes)
+}
+
+// modifyEscalationPathPlan runs ModifyPlan against the fake API, as a create: no prior
+// state. A nil plan is a destroy.
+func modifyEscalationPathPlan(t *testing.T, api *fakeEscalationPathValidateAPI, plan *tftypes.Value) resource.ModifyPlanResponse {
+	t.Helper()
+
+	return modifyEscalationPathPlanWithState(t, api, plan, tftypes.NewValue(escalationPathSchemaType(t), nil))
+}
+
+// modifyEscalationPathPlanWithState runs ModifyPlan against a resource that already
+// exists, for the cases that turn on how the plan differs from its state.
+func modifyEscalationPathPlanWithState(t *testing.T, api *fakeEscalationPathValidateAPI, plan *tftypes.Value, state tftypes.Value) resource.ModifyPlanResponse {
+	t.Helper()
+
+	var schemaResp resource.SchemaResponse
+	NewIncidentEscalationPathResource().Schema(t.Context(), resource.SchemaRequest{}, &schemaResp)
+
+	planRaw := tftypes.NewValue(escalationPathSchemaType(t), nil)
+	if plan != nil {
+		planRaw = *plan
+	}
+
+	r := &IncidentEscalationPathResource{client: api.start(t)}
+
+	var resp resource.ModifyPlanResponse
+	r.ModifyPlan(t.Context(), resource.ModifyPlanRequest{
+		Plan:  tfsdk.Plan{Schema: schemaResp.Schema, Raw: planRaw},
+		State: tfsdk.State{Schema: schemaResp.Schema, Raw: state},
+	}, &resp)
+
+	return resp
+}
+
+func TestEscalationPathModifyPlanAcceptsValidPath(t *testing.T) {
+	api := &fakeEscalationPathValidateAPI{}
+	plan := escalationPathPlan(t, false)
+
+	resp := modifyEscalationPathPlan(t, api, &plan)
+
+	if resp.Diagnostics.HasError() || resp.Diagnostics.WarningsCount() > 0 {
+		t.Errorf("expected no diagnostics, got %+v", resp.Diagnostics)
+	}
+	if api.requests != 1 {
+		t.Errorf("expected 1 request, got %d", api.requests)
+	}
+}
+
+// A 422 is the API rejecting this config, which is the whole point of the check, so it
+// fails the plan and repeats what the API said.
+func TestEscalationPathModifyPlanRejectsInvalidPath(t *testing.T) {
+	api := &fakeEscalationPathValidateAPI{
+		status: http.StatusUnprocessableEntity,
+		body:   `{"type":"validation_error","errors":[{"code":"invalid_value","message":"selected_rota_id is required","source":{"field":"path.0.level.targets.0.selected_rota_id"}}]}`,
+	}
+	plan := escalationPathPlan(t, false)
+
+	resp := modifyEscalationPathPlan(t, api, &plan)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatalf("expected an error, got %+v", resp.Diagnostics)
+	}
+
+	detail := resp.Diagnostics.Errors()[0].Detail()
+	if want := "path.0.level.targets.0.selected_rota_id"; !strings.Contains(detail, want) {
+		t.Errorf("expected the field path %q in the diagnostic, got %q", want, detail)
+	}
+}
+
+// Any other status means the check didn't run: the endpoint isn't deployed yet, the API is
+// down. The config may be perfectly good, so this warns rather than failing the plan.
+// The 500 also covers the timeout: the shared client would retry it for minutes, so this
+// passing quickly is the bound doing its job.
+func TestEscalationPathModifyPlanWarnsWhenCheckUnavailable(t *testing.T) {
+	original := escalationPathValidateTimeout
+	escalationPathValidateTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { escalationPathValidateTimeout = original })
+
+	for _, status := range []int{http.StatusNotFound, http.StatusInternalServerError} {
+		api := &fakeEscalationPathValidateAPI{status: status}
+		plan := escalationPathPlan(t, false)
+
+		resp := modifyEscalationPathPlan(t, api, &plan)
+
+		if resp.Diagnostics.HasError() {
+			t.Errorf("status %d: expected no error, got %+v", status, resp.Diagnostics)
+		}
+		if resp.Diagnostics.WarningsCount() != 1 {
+			t.Errorf("status %d: expected 1 warning, got %+v", status, resp.Diagnostics)
+		}
+	}
+}
+
+// A successful response can still carry warnings about a config that's valid but has no
+// practical effect, like an if_else with an empty branch. Those should reach the user
+// without failing the plan.
+func TestEscalationPathModifyPlanSurfacesWarnings(t *testing.T) {
+	api := &fakeEscalationPathValidateAPI{
+		body: `{"warnings":[{"path":"path.0.if_else.then_path","summary":"if_else has an empty \"then\" branch","detail":"When the condition matches, escalation stops here instead of continuing."}]}`,
+	}
+	plan := escalationPathPlan(t, false)
+
+	resp := modifyEscalationPathPlan(t, api, &plan)
+
+	if resp.Diagnostics.HasError() {
+		t.Errorf("expected no error, got %+v", resp.Diagnostics)
+	}
+	if resp.Diagnostics.WarningsCount() != 1 {
+		t.Fatalf("expected 1 warning, got %+v", resp.Diagnostics)
+	}
+	if got := resp.Diagnostics.Warnings()[0].Summary(); got != `if_else has an empty "then" branch` {
+		t.Errorf("expected the API's warning summary, got %q", got)
+	}
+}
+
+// schedule_mode is Optional+Computed, so it is unknown in the plan for every target the
+// config doesn't set it on. Treating that as unsettled would skip the check on exactly the
+// configs worth checking, so this guards the gate against tightening back to "everything
+// known".
+func TestEscalationPathModifyPlanValidatesWhenOnlyComputedValuesAreUnknown(t *testing.T) {
+	api := &fakeEscalationPathValidateAPI{}
+	plan := escalationPathPlan(t, true)
+
+	resp := modifyEscalationPathPlan(t, api, &plan)
+
+	if resp.Diagnostics.HasError() || resp.Diagnostics.WarningsCount() > 0 {
+		t.Errorf("expected no diagnostics, got %+v", resp.Diagnostics)
+	}
+	if api.requests != 1 {
+		t.Errorf("expected the path to be checked, got %d requests", api.requests)
+	}
+}
+
+// A plan that matches state changes nothing, so there is no apply to fail - and checking
+// anyway would cost a request per escalation path on every plan.
+func TestEscalationPathModifyPlanSkipsUnchangedPath(t *testing.T) {
+	api := &fakeEscalationPathValidateAPI{}
+	plan := escalationPathPlan(t, false)
+
+	resp := modifyEscalationPathPlanWithState(t, api, &plan, plan)
+
+	if resp.Diagnostics.HasError() || resp.Diagnostics.WarningsCount() > 0 {
+		t.Errorf("expected no diagnostics, got %+v", resp.Diagnostics)
+	}
+	if api.requests != 0 {
+		t.Errorf("expected no request for an unchanged path, got %d", api.requests)
+	}
+}
+
+// A target pointing at a rota this same apply creates is unknown until it exists.
+// Validating around the gap would report errors the apply won't hit, so we don't ask.
+func TestEscalationPathModifyPlanSkipsUnknownTarget(t *testing.T) {
+	api := &fakeEscalationPathValidateAPI{}
+	plan := escalationPathPlan(t, false)
+
+	objType := escalationPathSchemaType(t)
+	pathType, ok := objType.AttributeTypes["path"].(tftypes.List)
+	if !ok {
+		t.Fatal("expected path to be a list")
+	}
+	nodeType, ok := pathType.ElementType.(tftypes.Object)
+	if !ok {
+		t.Fatal("expected path elements to be objects")
+	}
+	levelType, ok := nodeType.AttributeTypes["level"].(tftypes.Object)
+	if !ok {
+		t.Fatal("expected level to be an object")
+	}
+	targetsType, ok := levelType.AttributeTypes["targets"].(tftypes.List)
+	if !ok {
+		t.Fatal("expected level.targets to be a list")
+	}
+	targetType, ok := targetsType.ElementType.(tftypes.Object)
+	if !ok {
+		t.Fatal("expected level.targets elements to be objects")
+	}
+
+	attributes := map[string]tftypes.Value{}
+	if err := plan.As(&attributes); err != nil {
+		t.Fatalf("reading plan back: %v", err)
+	}
+	pathElements := []tftypes.Value{}
+	if err := attributes["path"].As(&pathElements); err != nil {
+		t.Fatalf("reading path back: %v", err)
+	}
+	nodeAttributes := map[string]tftypes.Value{}
+	if err := pathElements[0].As(&nodeAttributes); err != nil {
+		t.Fatalf("reading node back: %v", err)
+	}
+	levelAttributes := map[string]tftypes.Value{}
+	if err := nodeAttributes["level"].As(&levelAttributes); err != nil {
+		t.Fatalf("reading level back: %v", err)
+	}
+	targetAttributes := map[string]tftypes.Value{}
+	if err := nullFilledObject(t, targetType).As(&targetAttributes); err != nil {
+		t.Fatalf("reading target back: %v", err)
+	}
+	// selected_rota_id referencing a rota created in the same apply: known type, unknown
+	// value.
+	targetAttributes["id"] = tftypes.NewValue(tftypes.String, tftypes.UnknownValue)
+	levelAttributes["targets"] = tftypes.NewValue(targetsType, []tftypes.Value{tftypes.NewValue(targetType, targetAttributes)})
+	nodeAttributes["level"] = tftypes.NewValue(levelType, levelAttributes)
+	attributes["path"] = tftypes.NewValue(pathType, []tftypes.Value{tftypes.NewValue(nodeType, nodeAttributes)})
+	unsettled := tftypes.NewValue(objType, attributes)
+
+	resp := modifyEscalationPathPlan(t, api, &unsettled)
+
+	if resp.Diagnostics.HasError() || resp.Diagnostics.WarningsCount() > 0 {
+		t.Errorf("expected no diagnostics, got %+v", resp.Diagnostics)
+	}
+	if api.requests != 0 {
+		t.Errorf("expected no request for an unsettled target, got %d", api.requests)
+	}
+}
+
+func TestEscalationPathModifyPlanSkipsDestroy(t *testing.T) {
+	api := &fakeEscalationPathValidateAPI{}
+
+	resp := modifyEscalationPathPlan(t, api, nil)
+
+	if resp.Diagnostics.HasError() || resp.Diagnostics.WarningsCount() > 0 {
+		t.Errorf("expected no diagnostics, got %+v", resp.Diagnostics)
+	}
+	if api.requests != 0 {
+		t.Errorf("expected no request for a destroy, got %d", api.requests)
+	}
+}

--- a/internal/provider/incident_escalation_path_resource.go
+++ b/internal/provider/incident_escalation_path_resource.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"reflect"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -17,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oklog/ulid/v2"
 	"github.com/samber/lo"
@@ -30,6 +33,7 @@ var (
 	_ resource.Resource                   = &IncidentEscalationPathResource{}
 	_ resource.ResourceWithImportState    = &IncidentEscalationPathResource{}
 	_ resource.ResourceWithValidateConfig = &IncidentEscalationPathResource{}
+	_ resource.ResourceWithModifyPlan     = &IncidentEscalationPathResource{}
 )
 
 type IncidentEscalationPathResource struct {
@@ -499,6 +503,167 @@ func (r *IncidentEscalationPathResource) ValidateConfig(ctx context.Context, req
 	validateEscalationPathNodes(ctx, data.Path, pathSchemaDepth, &resp.Diagnostics)
 }
 
+// escalationPathValidateTimeout bounds the plan-time validate call. Long enough that a
+// slow-but-working API still answers, short enough that an unhealthy one costs a plan
+// seconds rather than minutes. A var so tests don't have to wait it out.
+var escalationPathValidateTimeout = 10 * time.Second
+
+// escalationPathLeafIsSafeUnknown reports whether an unknown value at this path is one the
+// validate payload doesn't need settled: a path node's own "id" (Computed+Optional; we
+// generate one in toPathPayload when it's empty) and a target's "schedule_mode"
+// (Optional+Computed with no static default; the API fills it in regardless). A target's
+// own "id" is Required, user-supplied data that may reference another resource this same
+// apply creates, so that one is NOT safe - an unknown there means we skip the check rather
+// than validate around the gap.
+func escalationPathLeafIsSafeUnknown(steps *tftypes.AttributePath) bool {
+	all := steps.Steps()
+	if len(all) == 0 {
+		return false
+	}
+
+	name, ok := all[len(all)-1].(tftypes.AttributeName)
+	if !ok {
+		return false
+	}
+
+	switch string(name) {
+	case "schedule_mode":
+		return true
+	case "id":
+		if len(all) == 1 {
+			// The resource's own id: Computed only, always unknown on create, and not part
+			// of the validate payload at all.
+			return true
+		}
+		if len(all) < 3 {
+			return false
+		}
+		if _, ok := all[len(all)-2].(tftypes.ElementKeyInt); !ok {
+			return false
+		}
+		parent, ok := all[len(all)-3].(tftypes.AttributeName)
+		return ok && (string(parent) == "path" || string(parent) == "then_path" || string(parent) == "else_path")
+	default:
+		return false
+	}
+}
+
+// ModifyPlan asks the API whether the planned escalation path would be accepted, so a
+// config the API would reject - such as a target missing a required selected_rota_id -
+// surfaces in the plan instead of part way through an apply.
+//
+// It can't live in ValidateConfig, which `terraform validate` also calls: that runs the
+// provider without configuring it, so there's no client to ask with.
+func (r *IncidentEscalationPathResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	// A destroy plans no escalation path, and an unconfigured provider has no client.
+	if r.client == nil || req.Plan.Raw.IsNull() {
+		return
+	}
+
+	// A path the plan doesn't change isn't going to be applied, so there's nothing to warn
+	// about - and checking every escalation path on every plan is a request each.
+	if req.Plan.Raw.Equal(req.State.Raw) {
+		return
+	}
+
+	// A target or condition pointing at something this same apply creates is unknown until
+	// it exists. Validating around the gaps would report errors the apply won't hit, so
+	// leave those configs alone.
+	if !escalationPathValidateSettled(req.Plan.Raw) {
+		return
+	}
+
+	var data *IncidentEscalationPathResourceModel
+	if req.Plan.Get(ctx, &data).HasError() || data == nil {
+		return
+	}
+
+	// A decode failure here means a value the model's concrete types can't represent, not
+	// that the config is bad - give up on validating rather than failing the plan over a
+	// config the API may well accept.
+	var localDiags diag.Diagnostics
+	workingHours, teamIDs, repeatConfig, pathPayload := r.toEscalationPathPayload(ctx, data, &localDiags)
+	if localDiags.HasError() {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, escalationPathValidateTimeout)
+	defer cancel()
+
+	result, err := r.client.EscalationsV2ValidatePathWithResponse(ctx, client.EscalationsV2ValidatePathJSONRequestBody{
+		Path:         pathPayload,
+		WorkingHours: workingHours,
+		TeamIds:      teamIDs,
+		RepeatConfig: repeatConfig,
+	})
+	if err == nil {
+		addEscalationPathValidateWarnings(result, &resp.Diagnostics)
+		return
+	}
+
+	// 422 is the API rejecting this config, which is the whole point.
+	var httpErr client.HTTPError
+	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusUnprocessableEntity {
+		resp.Diagnostics.AddError("Invalid escalation path", httpErr.Error())
+		return
+	}
+
+	// Anything else means the check didn't run, not that the config is bad: the endpoint
+	// isn't deployed yet, the API is down, the request timed out. Warn, because failing here
+	// would break plans over a config that may be perfectly good.
+	resp.Diagnostics.AddWarning(
+		"Could not validate the escalation path",
+		fmt.Sprintf("The escalation path was not checked, and may still be rejected when you apply: %s", err),
+	)
+}
+
+// addEscalationPathValidateWarnings reports what the API found suspect without rejecting,
+// such as an if_else branch with no nodes in it. The API's path is a dotted/indexed
+// location into the payload (e.g. "path.0.if_else.then_path") rather than a schema
+// attribute path, so these surface as plan-level warnings rather than attribute ones.
+func addEscalationPathValidateWarnings(result *client.EscalationsV2ValidatePathResponse, diags *diag.Diagnostics) {
+	if result == nil || result.JSON200 == nil {
+		return
+	}
+
+	for _, warning := range result.JSON200.Warnings {
+		diags.AddWarning(warning.Summary, fmt.Sprintf("%s (at %s)", warning.Detail, warning.Path))
+	}
+}
+
+// escalationPathValidateSettled reports whether every value the validate payload could
+// carry is known, other than the computed leaves the API fills in regardless.
+func escalationPathValidateSettled(plan tftypes.Value) bool {
+	var attributes map[string]tftypes.Value
+	if err := plan.As(&attributes); err != nil {
+		return false
+	}
+
+	settled := true
+	for _, key := range []string{"path", "working_hours", "team_ids", "repeat_config"} {
+		value, ok := attributes[key]
+		if !ok {
+			continue
+		}
+
+		err := tftypes.Walk(value, func(steps *tftypes.AttributePath, v tftypes.Value) (bool, error) {
+			if v.IsKnown() {
+				return true, nil
+			}
+			if escalationPathLeafIsSafeUnknown(steps) {
+				return false, nil
+			}
+			settled = false
+			return false, nil
+		})
+		if err != nil {
+			return false
+		}
+	}
+
+	return settled
+}
+
 // decodeNodes decodes a types.List of escalation path node objects into the
 // Go model structs. It returns nil if the list is null or unknown.
 //
@@ -649,44 +814,42 @@ func validateEscalationPathTarget(target IncidentEscalationPathTarget, diags *di
 	}
 }
 
-func (r *IncidentEscalationPathResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var data *IncidentEscalationPathResourceModel
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	var workingHours *[]client.WeekdayIntervalConfigV2
+// toEscalationPathPayload builds the working hours, team IDs, repeat config, and node
+// path shared by the create, update, and validate requests.
+func (r *IncidentEscalationPathResource) toEscalationPathPayload(ctx context.Context, data *IncidentEscalationPathResourceModel, diags *diag.Diagnostics) (
+	workingHours *[]client.WeekdayIntervalConfigV2,
+	teamIDs *[]string,
+	repeatConfig *client.EscalationPathRepeatConfigV2,
+	pathPayload []client.EscalationPathNodePayloadV2,
+) {
 	if !data.WorkingHours.IsNull() && !data.WorkingHours.IsUnknown() {
 		var whModels []models.IncidentWeekdayIntervalConfig
-		resp.Diagnostics.Append(data.WorkingHours.ElementsAs(ctx, &whModels, false)...)
-		if resp.Diagnostics.HasError() {
+		diags.Append(data.WorkingHours.ElementsAs(ctx, &whModels, false)...)
+		if diags.HasError() {
 			return
 		}
 		if len(whModels) > 0 {
-			workingHours = &[]client.WeekdayIntervalConfigV2{}
-			for _, wh := range whModels {
-				*workingHours = append(*workingHours, wh.ToClientV2(ctx, &resp.Diagnostics))
+			wh := make([]client.WeekdayIntervalConfigV2, 0, len(whModels))
+			for _, w := range whModels {
+				wh = append(wh, w.ToClientV2(ctx, diags))
 			}
+			workingHours = &wh
 		}
 	}
 
-	var teamIDs *[]string
 	if !data.TeamIDs.IsUnknown() && !data.TeamIDs.IsNull() {
 		ids := []string{}
-		diags := data.TeamIDs.ElementsAs(ctx, &ids, false)
+		diags.Append(data.TeamIDs.ElementsAs(ctx, &ids, false)...)
 		if diags.HasError() {
-			resp.Diagnostics.Append(diags...)
 			return
 		}
 		teamIDs = &ids
 	}
 
-	var repeatConfig *client.EscalationPathRepeatConfigV2
 	if !data.RepeatConfig.IsNull() && !data.RepeatConfig.IsUnknown() {
 		var rc IncidentEscalationPathRepeatConfig
-		resp.Diagnostics.Append(data.RepeatConfig.As(ctx, &rc, basetypes.ObjectAsOptions{})...)
-		if resp.Diagnostics.HasError() {
+		diags.Append(data.RepeatConfig.As(ctx, &rc, basetypes.ObjectAsOptions{})...)
+		if diags.HasError() {
 			return
 		}
 		repeatConfig = &client.EscalationPathRepeatConfigV2{
@@ -695,7 +858,19 @@ func (r *IncidentEscalationPathResource) Create(ctx context.Context, req resourc
 		}
 	}
 
-	pathPayload := r.toPathPayload(ctx, data.Path, &resp.Diagnostics)
+	pathPayload = r.toPathPayload(ctx, data.Path, diags)
+
+	return
+}
+
+func (r *IncidentEscalationPathResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data *IncidentEscalationPathResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	workingHours, teamIDs, repeatConfig, pathPayload := r.toEscalationPathPayload(ctx, data, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -766,46 +941,7 @@ func (r *IncidentEscalationPathResource) Update(ctx context.Context, req resourc
 		return
 	}
 
-	var workingHours *[]client.WeekdayIntervalConfigV2
-	if !data.WorkingHours.IsNull() && !data.WorkingHours.IsUnknown() {
-		var whModels []models.IncidentWeekdayIntervalConfig
-		resp.Diagnostics.Append(data.WorkingHours.ElementsAs(ctx, &whModels, false)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-		if len(whModels) > 0 {
-			workingHours = &[]client.WeekdayIntervalConfigV2{}
-			for _, wh := range whModels {
-				*workingHours = append(*workingHours, wh.ToClientV2(ctx, &resp.Diagnostics))
-			}
-		}
-	}
-
-	var teamIDs *[]string
-	if !data.TeamIDs.IsUnknown() && !data.TeamIDs.IsNull() {
-		ids := []string{}
-		diags := data.TeamIDs.ElementsAs(ctx, &ids, false)
-		if diags.HasError() {
-			resp.Diagnostics.Append(diags...)
-			return
-		}
-		teamIDs = &ids
-	}
-
-	var repeatConfig *client.EscalationPathRepeatConfigV2
-	if !data.RepeatConfig.IsNull() && !data.RepeatConfig.IsUnknown() {
-		var rc IncidentEscalationPathRepeatConfig
-		resp.Diagnostics.Append(data.RepeatConfig.As(ctx, &rc, basetypes.ObjectAsOptions{})...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-		repeatConfig = &client.EscalationPathRepeatConfigV2{
-			RepeatAfterSeconds:    int32(rc.RepeatAfterSeconds.ValueInt64()),
-			DelayRepeatOnActivity: rc.DelayRepeatOnActivity.ValueBool(),
-		}
-	}
-
-	pathPayload := r.toPathPayload(ctx, data.Path, &resp.Diagnostics)
+	workingHours, teamIDs, repeatConfig, pathPayload := r.toEscalationPathPayload(ctx, data, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/incident_escalation_path_resource.go
+++ b/internal/provider/incident_escalation_path_resource.go
@@ -633,32 +633,26 @@ func addEscalationPathValidateWarnings(result *client.EscalationsV2ValidatePathR
 
 // escalationPathValidateSettled reports whether every value the validate payload could
 // carry is known, other than the computed leaves the API fills in regardless.
+//
+// It walks the whole plan value in one pass rather than per-attribute: escalationPathLeafIsSafeUnknown
+// disambiguates a node's own "id" from a target's "id" by looking at the grandparent
+// attribute name ("path"/"then_path"/"else_path" vs "targets"), which only works when
+// every step's AttributePath is rooted at the plan object - walking a sub-value directly
+// would silently drop that leading step and misclassify a brand new node's id as unsafe.
 func escalationPathValidateSettled(plan tftypes.Value) bool {
-	var attributes map[string]tftypes.Value
-	if err := plan.As(&attributes); err != nil {
-		return false
-	}
-
 	settled := true
-	for _, key := range []string{"path", "working_hours", "team_ids", "repeat_config"} {
-		value, ok := attributes[key]
-		if !ok {
-			continue
+	err := tftypes.Walk(plan, func(steps *tftypes.AttributePath, v tftypes.Value) (bool, error) {
+		if v.IsKnown() {
+			return true, nil
 		}
-
-		err := tftypes.Walk(value, func(steps *tftypes.AttributePath, v tftypes.Value) (bool, error) {
-			if v.IsKnown() {
-				return true, nil
-			}
-			if escalationPathLeafIsSafeUnknown(steps) {
-				return false, nil
-			}
-			settled = false
+		if escalationPathLeafIsSafeUnknown(steps) {
 			return false, nil
-		})
-		if err != nil {
-			return false
 		}
+		settled = false
+		return false, nil
+	})
+	if err != nil {
+		return false
 	}
 
 	return settled

--- a/internal/provider/incident_escalation_path_resource_test.go
+++ b/internal/provider/incident_escalation_path_resource_test.go
@@ -682,6 +682,49 @@ func TestAccIncidentEscalationPathSelectedRotaIDValidation(t *testing.T) {
 	})
 }
 
+// TestAccIncidentEscalationPathTargetValidation exercises the plan-time validate call
+// itself: a target referencing a user ID that doesn't exist isn't something this provider
+// checks locally (unlike the schedule_mode/selected_rota_id pairing above, which is a
+// ValidateConfig diagnostic and never reaches the API), so a rejection here only happens
+// once ModifyPlan calls the API's validate endpoint. PlanOnly proves it fails during plan,
+// before Terraform would otherwise create anything.
+func TestAccIncidentEscalationPathTargetValidation(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccIncidentEscalationPathResourceConfigNonexistentUser(),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`does not exist`),
+			},
+		},
+	})
+}
+
+func testAccIncidentEscalationPathResourceConfigNonexistentUser() string {
+	return `
+resource "incident_escalation_path" "invalid_target" {
+  name = "invalid-target"
+
+  path = [
+    {
+      type = "level"
+      level = {
+        targets = [{
+          type    = "user"
+          id      = "01HKZWAAAAAAAAAAAAAAAAAAA1"
+          urgency = "high"
+        }]
+        time_to_ack_seconds = 300
+      }
+    }
+  ]
+
+  team_ids = []
+}`
+}
+
 func testAccIncidentEscalationPathResourceConfigMissingSelectedRotaID() string {
 	return `
 resource "incident_escalation_path" "invalid_missing_rota" {


### PR DESCRIPTION
ModifyPlan now asks the API whether the planned escalation path would be accepted, mirroring the pattern already used by `incident_alert_source` / `alert_source_beta`. A 422 fails the plan with the API's own message; anything else (endpoint not deployed, unsettled values) warns or skips rather than failing the plan.

- Regenerated the client for the new `EscalationsV2ValidatePath` endpoint.
- Refactored the Create/Update/ModifyPlan payload building into one shared helper.
- Added unit tests covering accept/reject/warn/settled-gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches on-call escalation configuration at plan time; behavior is additive (earlier validation) but mis-handled API outages could warn instead of catching bad configs.
> 
> **Overview**
> **`incident_escalation_path` now calls the API during `ModifyPlan`** so invalid configs fail at plan time with the API’s own message (e.g. missing `selected_rota_id`) instead of mid-apply. Valid configs with no practical effect (empty `if_else` branches) come back as **plan warnings**, not errors.
> 
> The check follows the same pattern as alert-source validation: **422 fails the plan**; other failures (endpoint missing, timeouts, API errors) **warn** and do not block planning. It is skipped on destroy, when plan equals state, and when path values are still unknown (except safe computed fields like `schedule_mode` and node `id`).
> 
> Create/update payload construction is **refactored into `toEscalationPathPayload`**, shared with the validate call. The client is regenerated for **`EscalationsV2ValidatePath`**, with unit tests for accept/reject/warn/skip cases. Escalation-path data source docs now list the **`escalation_path` node type** in generated schema text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acf371edb07f8107ca53a40aa07f3238460260f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->