### PR TITLE
Default escalation path ack_mode to first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+- `incident_escalation_path` levels now default `ack_mode` to `first`, not `all`. An ack by
+  one responder cancels the other escalations on the same level. Set `ack_mode = "all"` to
+  keep the old behaviour. This is a breaking change: a path that does not set `ack_mode`
+  shows a diff on the next plan, and applying that diff changes how the level behaves.
+
 ## v6.3.0
 
 - `incident_user` lookups by `email` now resolve to the single active user when

--- a/internal/provider/incident_escalation_path_resource.go
+++ b/internal/provider/incident_escalation_path_resource.go
@@ -356,7 +356,7 @@ func (r *IncidentEscalationPathResource) getPathSchema(depth int) schema.NestedA
 							"EscalationPathNodeLevelV2", "ack_mode"),
 						Optional: true,
 						Computed: true,
-						Default:  stringdefault.StaticString("all"),
+						Default:  stringdefault.StaticString("first"),
 					},
 				},
 			},


### PR DESCRIPTION
## What

Levels on `incident_escalation_path` defaulted `ack_mode` to `all`. This defaults them to `first` instead, so an ack by one responder cancels the other escalations on the same level unless the config asks for `all`.

One line in `internal/provider/incident_escalation_path_resource.go`, plus a CHANGELOG entry.

## Heads up: this is a breaking change

`ack_mode` is `Optional + Computed` with a static `Default`, so Terraform writes the default into state rather than leaving it to the API. Every existing level that omits `ack_mode` currently holds `"all"` in state. After this ships:

1. The next plan shows `ack_mode: "all" -> "first"` on those levels.
2. Applying that plan changes real escalation behaviour, not just state.

Users who want the old behaviour set `ack_mode = "all"` explicitly.

There is no state-migration path around this while the default is static. If we'd rather the new default applied only to newly-created levels, that needs a plan modifier that leaves a known prior-state value alone, instead of a `Default` — happy to switch it if that's preferred.

## Testing

`go build ./internal/provider/` passes. Nothing in the test suite asserts on `ack_mode`, so no tests needed updating. Docs weren't regenerated because `tfplugindocs` doesn't render defaults for this schema — `docs/resources/escalation_path.md` only carries the description text, which is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changing the default alters on-call escalation semantics for existing paths on apply, with no automatic state migration for levels that relied on the implicit `"all"` default.
> 
> **Overview**
> **Breaking change:** `incident_escalation_path` level nodes now default **`ack_mode`** to **`first`** instead of **`all`**. With **`first`**, a single responder acknowledgement cancels the other escalations on that level; **`all`** still requires every target on the level to ack.
> 
> Because **`ack_mode`** is optional, computed, and uses a static schema default, Terraform already stores **`"all"`** in state for levels that omit it. After upgrading, **`terraform plan`** will show **`ack_mode`** changing **`"all"` → `"first"`** on those levels, and **apply** updates live on-call behaviour—not just state. To keep the previous behaviour, set **`ack_mode = "all"`** explicitly on affected levels.
> 
> The unreleased **CHANGELOG** documents this migration expectation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 099ee5b17c64fd7dbf0a2ad2f0f8eaf370017ab1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->