### PR TITLE
Document next_on_call on incident_schedule_sync_rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Document `next_on_call` on `incident_schedule_sync_rule`: the resource example now shows syncing a Slack user group with the people on the next upcoming shift, and the schema lists it as a valid `sync_type`.
+
 ## v6.4.0
 
 - Add `incident_escalation_path_beta`, which writes an escalation path as a flat map of named sequences, with no limit on how deeply it branches. This resource is beta: its schema may change in ways that aren't backwards compatible while we settle the design. `incident_escalation_path` is unchanged and not deprecated - don't point both at the same escalation path, as each would plan to undo the other's changes.

--- a/docs/resources/schedule_sync_rule.md
+++ b/docs/resources/schedule_sync_rule.md
@@ -39,6 +39,13 @@ resource "incident_schedule_sync_rule" "platform_all_users" {
   sync_type               = "all_users"
 }
 
+# Sync the people on the next upcoming shift, rather than whoever is on call now
+resource "incident_schedule_sync_rule" "platform_next_oncall" {
+  schedule_id             = incident_schedule.platform.id
+  schedule_sync_target_id = incident_schedule_sync_target.platform_next_oncall.id
+  sync_type               = "next_on_call"
+}
+
 # Scope a rule to a single rotation. Without rotation_id a rule covers every
 # rotation on the schedule; set it to sync only one. To feed a group from
 # several rotations, create one rule per rotation pointing at the same target.
@@ -72,7 +79,7 @@ resource "incident_schedule_sync_rule" "platform_oncall_with_manager" {
 - `schedule_sync_target_id` (String) The sync target ID this rule links to
 - `sync_type` (String) Which schedule members sync to the user group
 
-Valid values: `all_users`, `on_call`.
+Valid values: `all_users`, `next_on_call`, `on_call`.
 
 ### Optional
 

--- a/examples/resources/incident_schedule_sync_rule/resource.tf
+++ b/examples/resources/incident_schedule_sync_rule/resource.tf
@@ -24,6 +24,13 @@ resource "incident_schedule_sync_rule" "platform_all_users" {
   sync_type               = "all_users"
 }
 
+# Sync the people on the next upcoming shift, rather than whoever is on call now
+resource "incident_schedule_sync_rule" "platform_next_oncall" {
+  schedule_id             = incident_schedule.platform.id
+  schedule_sync_target_id = incident_schedule_sync_target.platform_next_oncall.id
+  sync_type               = "next_on_call"
+}
+
 # Scope a rule to a single rotation. Without rotation_id a rule covers every
 # rotation on the schedule; set it to sync only one. To feed a group from
 # several rotations, create one rule per rotation pointing at the same target.

--- a/internal/provider/incident_schedule_sync_rule_resource.go
+++ b/internal/provider/incident_schedule_sync_rule_resource.go
@@ -64,7 +64,7 @@ func (r *IncidentScheduleSyncRuleResource) Schema(ctx context.Context, req resou
 			},
 			"sync_type": schema.StringAttribute{
 				Required:            true,
-				MarkdownDescription: apischema.Docstring("ScheduleSyncRuleV2", "sync_type") + "\n\nValid values: `all_users`, `on_call`.",
+				MarkdownDescription: apischema.Docstring("ScheduleSyncRuleV2", "sync_type") + "\n\nValid values: `all_users`, `next_on_call`, `on_call`.",
 			},
 			"rotation_id": schema.StringAttribute{
 				Optional:            true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`next_on_call` has been a valid `sync_type` on schedule sync rules (API + Terraform client) since the core change that added it, but the Terraform resource example and schema only showed `on_call` and `all_users`. Same documentation gap as the product docs: a customer asking “can I sync a Slack user group with the next on-call person?” would not find it here.

## Changes

- `examples/resources/incident_schedule_sync_rule/resource.tf` — add a `platform_next_oncall` example with `sync_type = "next_on_call"`.
- Resource schema `Valid values` now include `next_on_call` (and the generated registry docs page).
- Changelog under Unreleased.

No behaviour change: create/update already pass `sync_type` through as the API enum, which includes `next_on_call`.

## Test plan

- [x] Example and generated `docs/resources/schedule_sync_rule.md` stay in sync (`Tests / generate` passed)
- [x] CI green on this branch (build, generate, acceptance tests for Terraform 1.14/1.15 and OpenTofu)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5ee5f311-f10d-4bd4-9590-0734151e4246?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ee5f311-f10d-4bd4-9590-0734151e4246&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

