### PR TITLE
Changelog for v6.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## v6.4.1
+
 - Document `next_on_call` on `incident_schedule_sync_rule`: the resource example now shows syncing a Slack user group with the people on the next upcoming shift, and the schema lists it as a valid `sync_type`.
 - Correct the documented description of `auto_resolve_incident_alerts` on `incident_alert_source` and `incident_alert_source_beta`. It controls whether alerts from the source keep counting down to auto-resolve while they're attached to an incident, and has no effect without `auto_resolve_timeout_minutes`.
 


### PR DESCRIPTION
Cuts v6.4.1 from the two docs fixes in `Unreleased`: `next_on_call` on `incident_schedule_sync_rule` (#476) and the corrected `auto_resolve_incident_alerts` description (#478).

Patch, not minor: both are documentation only. #476 changed one `MarkdownDescription` string — `next_on_call` was already an accepted `sync_type` — and #478 corrects a description the API schema owns. No schema or behaviour change in either.

Worth releasing on its own: registry docs are pinned to released versions, so neither fix reaches anyone until we tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changelog-only release bookkeeping with no runtime or schema changes in this diff.
> 
> **Overview**
> **Adds a `v6.4.1` section** to `CHANGELOG.md` and moves the two items that were under **Unreleased** into that release.
> 
> Those entries record **documentation-only** fixes already merged elsewhere: **`next_on_call`** on `incident_schedule_sync_rule` (example + schema docs), and a corrected **`auto_resolve_incident_alerts`** description on `incident_alert_source` / `incident_alert_source_beta`. This PR does not change provider code or schema—only release notes so registry docs tied to tagged versions can pick up the fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbb027d77b5155e83d7da0e50370621f70565c44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->