### PR TITLE
Changelog for v6.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## Unreleased
 
-- Add the `cast` operation to `expressions` on `incident_alert_route`, `incident_alert_source` and `incident_workflow`. An expression exported from the dashboard that casts a value could not be applied: the provider had no `cast` attribute, so it sent the operation with no options and the API rejected it with `expressions.N.operations.M.cast: Must be provided`. Write it as `cast = { returns = { type = "...", array = false } }`. The API doesn't echo cast options back on reads, so we rebuild them from the operation's own returns, which hold the same values.
-- Add support for `form_fields` on `incident_workflow`, letting you define the fields shown to a user when they manually trigger a workflow. The value a user provides is available in the workflow scope under `workflow_form.<key>`. Each form field has a `key`, `title`, `type`, `array` and `required` setting, plus an optional `description` and a computed `id`. Form fields only apply to manual triggers. Either `form_fields = []` or omitting the attribute clears any existing fields.
+## v6.5.0
+
+- Add the `cast` operation to `expressions` on `incident_alert_route`, `incident_alert_source` and `incident_workflow`. An expression exported from the dashboard that casts a value could not be applied: the provider had no `cast` attribute, so it sent the operation with no options and the API rejected it with `expressions.N.operations.M.cast: Must be provided`. Write it as `cast = { returns = { type = "...", array = false } }`.
+- Add `form_fields` to `incident_workflow`, letting you define the fields shown to someone who manually triggers a workflow. The value they provide is available in the workflow scope under `workflow_form.<key>`. Each field has a `key`, `title`, `type`, `array` and `required` setting, plus an optional `description`. Form fields only apply to manual triggers, and either `form_fields = []` or omitting the attribute clears any existing fields.
 
 ## v6.4.1
 


### PR DESCRIPTION
Cuts a v6.5.0 release from what's currently in `Unreleased`: the `cast` operation on engine expressions (#482) and `form_fields` on `incident_workflow` (#481).

Minor bump — two new schema attributes, no breaking changes. Both trimmed slightly on the way in: the `cast` entry drops the note about rebuilding options from the operation's own returns, and the `form_fields` entry drops the computed `id`, as neither is something you'd act on. Dependency bumps aren't changelogged, matching v6.4.0 and v6.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changelog-only change with no runtime or schema impact.
> 
> **Overview**
> **Promotes the current `Unreleased` notes into a `v6.5.0` section** and leaves `Unreleased` empty for the next cycle.
> 
> The two bullets document provider features already shipped in prior work: **`cast` on engine `expressions`** (`incident_alert_route`, `incident_alert_source`, `incident_workflow`) and **`form_fields` on `incident_workflow`**. Compared to the draft under `Unreleased`, the published text is slightly shorter—the `cast` item no longer mentions rebuilding cast options on read, and the `form_fields` item drops the computed `id` and tightens wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef33baec9ea98a9d1025d0865bbd38c23544196f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->