### PR TITLE
Changelog for v6.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## v6.6.0
+
 - Add support for the `escalation_path` node type on `incident_escalation_path` and `incident_escalation_path_beta`. A node can now hand the escalation over to another escalation path, which continues from that path's first node - useful for a shared last-resort path, or for routing out of hours to a different team. Write it as `type = "escalation_path"` with `escalation_path = { escalation_path_id = ... }`. Paths that already use a reassignment node, such as one built in the dashboard, can now be imported and managed alongside the rest of your config.
 
 ## v6.5.0


### PR DESCRIPTION
Cuts the unreleased `escalation_path` node type entry under `## v6.6.0`, ready for the `v6.6.0` tag.

Minor rather than patch: this adds a node type to `incident_escalation_path` and `incident_escalation_path_beta` rather than fixing an existing one.

Once this merges, the release is `git tag v6.6.0` on master and `git push --tags`, which fires `.github/workflows/release.yml` and publishes to the Terraform registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog edit with no runtime or Terraform behavior changes in this PR.
> 
> **Overview**
> Prepares the **v6.6.0** release in `CHANGELOG.md` by adding a `## v6.6.0` section and moving the previously unreleased note out of **Unreleased**.
> 
> That note documents the new **`escalation_path` node type** on `incident_escalation_path` and `incident_escalation_path_beta` (`type = "escalation_path"` with `escalation_path = { escalation_path_id = ... }`), including import of dashboard paths that use reassignment nodes. **Unreleased** is left empty aside from the header.
> 
> There are **no provider or schema code changes** in this diff—only changelog versioning ahead of tagging `v6.6.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24cac34aabc2a6025a9e58d94e2043df71d1ecf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->