### PR TITLE
Remove the stale Loom embed from the workflow docs

### DIFF
--- a/docs/resources/workflow.md
+++ b/docs/resources/workflow.md
@@ -4,14 +4,14 @@ page_title: "incident_workflow Resource - terraform-provider-incident"
 subcategory: ""
 description: |-
   This resource is used to manage Workflows.
-  We'd generally recommend building workflows in our web dashboard https://app.incident.io/~/workflows, and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing workflow and copy the resulting Terraform without persisting it. You can learn more in this Loom https://www.loom.com/share/b833d7d0fd114d6ba3f24d8c72e5208f?sid=c6d3cc3f-aa93-44ba-b12d-a0a4cbe09448.
+  We'd generally recommend building workflows in our web dashboard https://app.incident.io/~/workflows, and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing workflow and copy the resulting Terraform without persisting it.
 ---
 
 # incident_workflow (Resource)
 
 This resource is used to manage Workflows.
 
-We'd generally recommend building workflows in our [web dashboard](https://app.incident.io/~/workflows), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing workflow and copy the resulting Terraform without persisting it. You can learn more in this [Loom](https://www.loom.com/share/b833d7d0fd114d6ba3f24d8c72e5208f?sid=c6d3cc3f-aa93-44ba-b12d-a0a4cbe09448).
+We'd generally recommend building workflows in our [web dashboard](https://app.incident.io/~/workflows), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing workflow and copy the resulting Terraform without persisting it.
 
 ## Example Usage
 

--- a/internal/provider/incident_workflow_resource.go
+++ b/internal/provider/incident_workflow_resource.go
@@ -93,7 +93,7 @@ func (r *IncidentWorkflowResource) Schema(ctx context.Context, req resource.Sche
 	resp.Schema = schema.Schema{
 		MarkdownDescription: `This resource is used to manage Workflows.
 
-We'd generally recommend building workflows in our [web dashboard](https://app.incident.io/~/workflows), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing workflow and copy the resulting Terraform without persisting it. You can learn more in this [Loom](https://www.loom.com/share/b833d7d0fd114d6ba3f24d8c72e5208f?sid=c6d3cc3f-aa93-44ba-b12d-a0a4cbe09448).`,
+We'd generally recommend building workflows in our [web dashboard](https://app.incident.io/~/workflows), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing workflow and copy the resulting Terraform without persisting it.`,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				MarkdownDescription: apischema.Docstring("WorkflowV2", "id"),


### PR DESCRIPTION
The `incident_workflow` resource description links out to a Loom that's now over two years old. This removes that sentence and regenerates the docs.

Source of truth is the schema `MarkdownDescription` in `internal/provider/incident_workflow_resource.go`; `docs/resources/workflow.md` is the `make generate` output (the description appears twice there — frontmatter and body).

Part of [PD-21830](https://linear.app/incident-io/issue/PD-21830/chunk-2-clean-up-the-workflow-terraform-docs). The other half of that ticket — the stale `must be a ULID` step-ID guidance — is deliberately left out, since it's sequenced after chunk 7 decides whether the ULID requirement is relaxed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime or schema behavior changes.
> 
> **Overview**
> Removes the outdated **Loom** tutorial link from the `incident_workflow` resource documentation while keeping the guidance to use the web dashboard and **Export** flow for Terraform.
> 
> The change is made in the schema **`MarkdownDescription`** in `incident_workflow_resource.go`, and **`docs/resources/workflow.md`** is updated via doc generation (frontmatter `description` and the intro paragraph).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdaae438d6c8e9f258b8042af9967629e400364d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->