### PR TITLE
Show a team-owned workflow in the incident_workflow example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Document `owning_team_ids` on `incident_workflow`: the resource example now shows a workflow owned by a team, with the team's ID resolved through the catalog by name rather than hardcoded. Teams are catalog entries, so this is a `incident_catalog_type` lookup for the Team type plus an `incident_catalog_entry` lookup for the team itself.
 - Add the `incident_workflow` data source, which reads an existing workflow by `id`. It returns the workflow's full definition - `steps`, `expressions`, `condition_groups`, `form_fields`, `once_for` and `delay` included - not just its name and trigger, so you can reference the pieces of a workflow built in the dashboard from elsewhere in your config without importing it as a resource.
 - Add the `incident_status` data source, which looks up an existing incident status by `id` or by `name`. This lets you reference the statuses incident.io manages for you, such as Triage or Closed, which can't be created as an `incident_status` resource.
 

--- a/docs/resources/workflow.md
+++ b/docs/resources/workflow.md
@@ -16,6 +16,18 @@ We'd generally recommend building workflows in our [web dashboard](https://app.i
 ## Example Usage
 
 ```terraform
+# Teams are catalog entries, so an owning team is resolved through the catalog
+# rather than by pasting in its ID. The identifier is matched against entry
+# names, external IDs and aliases, so the team's name is enough.
+data "incident_catalog_type" "team" {
+  name = "Team"
+}
+
+data "incident_catalog_entry" "platform" {
+  catalog_type_id = data.incident_catalog_type.team.id
+  identifier      = "Platform"
+}
+
 # This is a workflow that automatically assigns the incident lead role to the user who acked an escalation.
 resource "incident_workflow" "autoassign_incident_lead" {
   name    = "Auto-assign incident leader"
@@ -65,6 +77,11 @@ resource "incident_workflow" "autoassign_incident_lead" {
   once_for = [
     # "Incident"
     "incident",
+  ]
+  # Teams that own this workflow. It's a set, so more than one team can own a
+  # workflow and the order doesn't matter.
+  owning_team_ids = [
+    data.incident_catalog_entry.platform.id,
   ]
   include_private_incidents = false
   continue_on_step_error    = false

--- a/examples/resources/incident_workflow/resource.tf
+++ b/examples/resources/incident_workflow/resource.tf
@@ -1,3 +1,15 @@
+# Teams are catalog entries, so an owning team is resolved through the catalog
+# rather than by pasting in its ID. The identifier is matched against entry
+# names, external IDs and aliases, so the team's name is enough.
+data "incident_catalog_type" "team" {
+  name = "Team"
+}
+
+data "incident_catalog_entry" "platform" {
+  catalog_type_id = data.incident_catalog_type.team.id
+  identifier      = "Platform"
+}
+
 # This is a workflow that automatically assigns the incident lead role to the user who acked an escalation.
 resource "incident_workflow" "autoassign_incident_lead" {
   name    = "Auto-assign incident leader"
@@ -47,6 +59,11 @@ resource "incident_workflow" "autoassign_incident_lead" {
   once_for = [
     # "Incident"
     "incident",
+  ]
+  # Teams that own this workflow. It's a set, so more than one team can own a
+  # workflow and the order doesn't matter.
+  owning_team_ids = [
+    data.incident_catalog_entry.platform.id,
   ]
   include_private_incidents = false
   continue_on_step_error    = false

--- a/internal/provider/incident_workflow_resource_test.go
+++ b/internal/provider/incident_workflow_resource_test.go
@@ -380,6 +380,111 @@ resource "incident_workflow" "example" {
 	})
 }
 
+// TestAccIncidentWorkflowResourceOwningTeamFromCatalog covers the pattern the resource
+// example uses: teams are catalog entries, so the owning team is resolved through the
+// catalog by name rather than by pasting in an ID that differs between workspaces.
+func TestAccIncidentWorkflowResourceOwningTeamFromCatalog(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIncidentWorkflowResourceConfigOwningTeamFromCatalog(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// The name lookup resolves to the team we provisioned...
+					resource.TestCheckResourceAttrPair(
+						"data.incident_catalog_entry.owner_team", "id",
+						"incident_catalog_entry.owner_team", "id"),
+					// ...and that is what the workflow ends up owned by.
+					resource.TestCheckResourceAttr("incident_workflow.example", "owning_team_ids.#", "1"),
+					resource.TestCheckResourceAttrPair(
+						"incident_workflow.example", "owning_team_ids.0",
+						"data.incident_catalog_entry.owner_team", "id"),
+				),
+			},
+			// The owning team survives an import round-trip.
+			{
+				ResourceName:      "incident_workflow.example",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// testAccIncidentWorkflowResourceConfigOwningTeamFromCatalog renders a workflow owned by a
+// team that is looked up by name, mirroring examples/resources/incident_workflow/resource.tf.
+//
+// The data source needs depends_on: its config is fully known at plan time, so without it
+// Terraform would read the entry before the resource above has created it, and the lookup
+// would fail with a not-found.
+func testAccIncidentWorkflowResourceConfigOwningTeamFromCatalog() string {
+	return testRunTemplate("incident_workflow_owning_team_from_catalog", `
+data "incident_catalog_type" "team" {
+  name = {{ quote .TeamTypeName }}
+}
+
+resource "incident_catalog_entry" "owner_team" {
+  catalog_type_id  = data.incident_catalog_type.team.id
+  external_id      = {{ quote .TeamExternalID }}
+  name             = {{ quote .TeamName }}
+  attribute_values = []
+}
+
+data "incident_catalog_entry" "owner_team" {
+  catalog_type_id = data.incident_catalog_type.team.id
+  identifier      = {{ quote .TeamName }}
+
+  depends_on = [incident_catalog_entry.owner_team]
+}
+
+resource "incident_workflow" "example" {
+  name    = {{ quote .WorkflowName }}
+  trigger = "incident.updated"
+  condition_groups = [
+    {
+      conditions = [
+        {
+          subject        = "incident.status.category"
+          operation      = "one_of"
+          param_bindings = [{ array_value = [{ literal = "open" }] }]
+        }
+      ]
+    }
+  ]
+  steps = [
+    {
+      id   = "01HXVEA7Y0VWQBJB4F2X8WNRW6"
+      name = "incident.create_follow_ups"
+      param_bindings = [
+        { value = { reference = "incident" } },
+        { array_value = [{ literal = "Write postmortem" }] },
+        {}
+      ]
+    }
+  ]
+  expressions               = []
+  once_for                  = ["incident"]
+  owning_team_ids           = [data.incident_catalog_entry.owner_team.id]
+  include_private_incidents = false
+  continue_on_step_error    = false
+  runs_on_incidents         = "newly_created"
+  runs_on_incident_modes    = ["standard"]
+  state                     = "draft"
+}
+`, struct {
+		TeamTypeName   string
+		TeamName       string
+		TeamExternalID string
+		WorkflowName   string
+	}{
+		TeamTypeName:   teamTypeName(),
+		TeamName:       StableSuffix("Terraform Workflow Owning Team Lookup"),
+		TeamExternalID: StableSuffix("tf-workflow-owning-team-lookup"),
+		WorkflowName:   StableSuffix("Owning team from catalog workflow"),
+	})
+}
+
 // TestAccIncidentWorkflowResourceFormFields checks that form_fields round-trips on a
 // manually triggered workflow: unset reads back as absent, fields are applied and
 // re-read (with a server-generated id), and both `[]` and omitting the attribute

--- a/internal/provider/incident_workflow_resource_test.go
+++ b/internal/provider/incident_workflow_resource_test.go
@@ -720,7 +720,7 @@ func TestAccIncidentWorkflowResourceFormFieldIDsFollowKeys(t *testing.T) {
 func testAccIncidentWorkflowConfigFormFields(formFields string) string {
 	return testRunTemplate("incident_workflow_form_fields", `
 resource "incident_workflow" "example" {
-  name    = "Form fields workflow"
+  name    = {{ stableSuffix "Form fields workflow" | quote }}
   trigger = "manual"
   condition_groups = []
   steps = [


### PR DESCRIPTION
Adds `owning_team_ids` to the `incident_workflow` example, with the team resolved through the catalog, and covers that shape in an acceptance test.

## Why

`owning_team_ids` has been on the resource for a while, but nothing in the docs showed how to actually get a team ID. Teams are catalog entries, so the answer isn't obvious — there's no `incident_team` data source to reach for, and the schema docs just say "IDs of the teams that own this workflow".

The example now shows the full path:

```hcl
data "incident_catalog_type" "team" {
  name = "Team"
}

data "incident_catalog_entry" "platform" {
  catalog_type_id = data.incident_catalog_type.team.id
  identifier      = "Platform"
}

resource "incident_workflow" "autoassign_incident_lead" {
  # ...
  owning_team_ids = [data.incident_catalog_entry.platform.id]
}
```

`identifier` is matched by the API against entry names, external IDs and aliases, so the team's name is enough — no ULID to go and find, and nothing workspace-specific pinned into the config.

## Testing

Adds `TestAccIncidentWorkflowResourceOwningTeamFromCatalog`, which provisions a Team catalog entry, looks it up by name, and asserts the workflow ends up owned by that exact ID — then imports to check it survives a round-trip.

This shape wasn't covered before: the existing `TestAccIncidentWorkflowResourceOwningTeamIDs` references `incident_catalog_entry` *resources* directly, so the data source lookup the example recommends was untested.

One wrinkle worth knowing about, called out in a comment on the test: the data source needs `depends_on`. Its config is fully known at plan time, so without it Terraform reads the entry before the resource above has created it and the lookup fails with a not-found. That applies to anyone following this pattern for a team they also manage in Terraform — if the team already exists, `depends_on` isn't needed.

- `go build ./...`, `go vet`, `gofmt`, `terraform fmt -check -recursive` and the unit suite (`go test ./internal/provider/`) all pass
- I couldn't run the new acceptance test — no `INCIDENT_API_KEY` in this environment, so it needs a run against the test account. It assumes a `Team` catalog type exists there, which is what the existing owning-teams test already assumes via `teamTypeName()`.

Note this touches the same example file as #490, so whichever merges second will need a small conflict resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, examples, changelog, and acceptance tests only; no provider schema or runtime behavior changes.
> 
> **Overview**
> Documents how to set **`owning_team_ids`** on `incident_workflow` without hardcoding team ULIDs: resolve the **Team** catalog type with `incident_catalog_type`, then the team with `incident_catalog_entry` (by name, external ID, or alias).
> 
> The registry example (`docs/resources/workflow.md`) and `examples/resources/incident_workflow/resource.tf` now include that lookup and wire **`owning_team_ids`** on the auto-assign workflow. **CHANGELOG** records the pattern under Unreleased.
> 
> Adds acceptance test **`TestAccIncidentWorkflowResourceOwningTeamFromCatalog`**, which provisions a team entry, looks it up by identifier (with **`depends_on`** so the read does not run before create), asserts the workflow owns that ID, and verifies import. The form-fields test template now uses **`stableSuffix`** for the workflow name so parallel runs stay isolated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77fd8ceca66c5ecbbf1de76585d2cfb0bb6c5579. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->