### PR TITLE
Document the values workflow parameters accept

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Document the values workflow parameters accept. `runs_on_incident_modes` and `operation_type` are fixed enums and now list their values (`standard`/`test`/`retrospective`, and the twelve expression operation types). `trigger`, `once_for`, condition `operation`, expression return `type` and form field `type` aren't fixed sets - they come from a registry we add to, or from your own configuration - so instead of a list that would go stale, they now say so and point at where to find the current values. This matters most for LLM-generated config, which otherwise has to guess.
 - Add the `incident_workflow` data source, which reads an existing workflow by `id`. It returns the workflow's full definition - `steps`, `expressions`, `condition_groups`, `form_fields`, `once_for` and `delay` included - not just its name and trigger, so you can reference the pieces of a workflow built in the dashboard from elsewhere in your config without importing it as a resource.
 
 ## v6.6.0

--- a/docs/data-sources/alert_sources.md
+++ b/docs/data-sources/alert_sources.md
@@ -243,7 +243,7 @@ Read-Only:
 - `cast` (Attributes) The cast target of this operation, set when the operation type is `cast` (see [below for nested schema](#nestedatt--alert_sources--template--expressions--operations--cast))
 - `filter` (Attributes) (see [below for nested schema](#nestedatt--alert_sources--template--expressions--operations--filter))
 - `navigate` (Attributes) (see [below for nested schema](#nestedatt--alert_sources--template--expressions--operations--navigate))
-- `operation_type` (String) The type of the operation
+- `operation_type` (String) The type of the operation. Possible values are: `navigate`, `filter`, `concatenate`, `count`, `min`, `max`, `sum`, `random`, `first`, `parse`, `branches`, `cast`.
 - `parse` (Attributes) (see [below for nested schema](#nestedatt--alert_sources--template--expressions--operations--parse))
 
 <a id="nestedatt--alert_sources--template--expressions--operations--branches"></a>
@@ -274,7 +274,7 @@ Read-Only:
 
 Read-Only:
 
-- `operation` (String)
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--alert_sources--template--expressions--operations--branches--branches--condition_groups--conditions--param_bindings))
 - `subject` (String)
 
@@ -341,7 +341,7 @@ Read-Only:
 Read-Only:
 
 - `array` (Boolean) Whether the return value should be single or multi-value
-- `type` (String) Expected return type of this expression (what to try casting the result to)
+- `type` (String) Expected return type of this expression (what to try casting the result to). This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Engine types include your own configuration - a custom field's type is identified by its ID - so build the expression in the dashboard and export it to get the right value.
 
 
 
@@ -358,7 +358,7 @@ Read-Only:
 Read-Only:
 
 - `array` (Boolean) Whether the return value should be single or multi-value
-- `type` (String) Expected return type of this expression (what to try casting the result to)
+- `type` (String) Expected return type of this expression (what to try casting the result to). This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Engine types include your own configuration - a custom field's type is identified by its ID - so build the expression in the dashboard and export it to get the right value.
 
 
 
@@ -381,7 +381,7 @@ Read-Only:
 
 Read-Only:
 
-- `operation` (String)
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--alert_sources--template--expressions--operations--filter--condition_groups--conditions--param_bindings))
 - `subject` (String)
 
@@ -437,7 +437,7 @@ Read-Only:
 Read-Only:
 
 - `array` (Boolean) Whether the return value should be single or multi-value
-- `type` (String) Expected return type of this expression (what to try casting the result to)
+- `type` (String) Expected return type of this expression (what to try casting the result to). This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Engine types include your own configuration - a custom field's type is identified by its ID - so build the expression in the dashboard and export it to get the right value.
 
 
 

--- a/docs/data-sources/workflow.md
+++ b/docs/data-sources/workflow.md
@@ -45,15 +45,15 @@ The order of the list is the order the fields appear in the form. (see [below fo
 - `include_private_escalations` (Boolean) Whether to include private escalations
 - `include_private_incidents` (Boolean, Deprecated) DEPRECATED: use `private_incident_scope` instead. `true` when the workflow runs on private incidents (a `private_incident_scope` of `all` or `owning_teams`), `false` when the scope is `none`.
 - `name` (String) Name provided by the user when creating the workflow
-- `once_for` (List of String) This workflow will run 'once for' a list of references
+- `once_for` (List of String) This workflow will run 'once for' a list of references. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. The references you can use come from the scope the trigger builds, which the workflow builder lists once you've chosen one.
 - `owning_team_ids` (Set of String) IDs of the teams that own this workflow
 - `private_incident_scope` (String) Which private incidents this workflow acts on: every private incident (all), those an owning team can see (owning_teams), or none. Possible values are: `all`, `owning_teams`, `none`.
-- `runs_on_incident_modes` (Set of String) Which incident modes should this workflow run on? By default, workflows only run on standard incidents, but can also be configured to run on test and retrospective incidents.
+- `runs_on_incident_modes` (Set of String) Which incident modes should this workflow run on? By default, workflows only run on standard incidents, but can also be configured to run on test and retrospective incidents. Possible values are: `standard`, `test`, `retrospective`.
 - `runs_on_incidents` (String) Which incidents should the workflow be applied to?. Possible values are: `newly_created`, `newly_created_and_active`.
 - `shortform` (String) The shortform used to trigger this workflow (only applicable for manual triggers)
 - `state` (String) What state this workflow is in. Possible values are: `active`, `disabled`, `draft`, `error`.
 - `steps` (Attributes List) Steps that are executed as part of the workflow (see [below for nested schema](#nestedatt--steps))
-- `trigger` (String) Unique name of the trigger
+- `trigger` (String) Unique name of the trigger. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Pick a trigger in the dashboard's workflow builder and use Export to Terraform to see its name.
 
 <a id="nestedatt--condition_groups"></a>
 ### Nested Schema for `condition_groups`
@@ -67,7 +67,7 @@ Read-Only:
 
 Read-Only:
 
-- `operation` (String)
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--condition_groups--conditions--param_bindings))
 - `subject` (String)
 
@@ -164,7 +164,7 @@ Read-Only:
 - `cast` (Attributes) The cast target of this operation, set when the operation type is `cast` (see [below for nested schema](#nestedatt--expressions--operations--cast))
 - `filter` (Attributes) (see [below for nested schema](#nestedatt--expressions--operations--filter))
 - `navigate` (Attributes) (see [below for nested schema](#nestedatt--expressions--operations--navigate))
-- `operation_type` (String) The type of the operation
+- `operation_type` (String) The type of the operation. Possible values are: `navigate`, `filter`, `concatenate`, `count`, `min`, `max`, `sum`, `random`, `first`, `parse`, `branches`, `cast`.
 - `parse` (Attributes) (see [below for nested schema](#nestedatt--expressions--operations--parse))
 
 <a id="nestedatt--expressions--operations--branches"></a>
@@ -195,7 +195,7 @@ Read-Only:
 
 Read-Only:
 
-- `operation` (String)
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--expressions--operations--branches--branches--condition_groups--conditions--param_bindings))
 - `subject` (String)
 
@@ -262,7 +262,7 @@ Read-Only:
 Read-Only:
 
 - `array` (Boolean) Whether the return value should be single or multi-value
-- `type` (String) Expected return type of this expression (what to try casting the result to)
+- `type` (String) Expected return type of this expression (what to try casting the result to). This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Engine types include your own configuration - a custom field's type is identified by its ID - so build the expression in the dashboard and export it to get the right value.
 
 
 
@@ -279,7 +279,7 @@ Read-Only:
 Read-Only:
 
 - `array` (Boolean) Whether the return value should be single or multi-value
-- `type` (String) Expected return type of this expression (what to try casting the result to)
+- `type` (String) Expected return type of this expression (what to try casting the result to). This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Engine types include your own configuration - a custom field's type is identified by its ID - so build the expression in the dashboard and export it to get the right value.
 
 
 
@@ -302,7 +302,7 @@ Read-Only:
 
 Read-Only:
 
-- `operation` (String)
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--expressions--operations--filter--condition_groups--conditions--param_bindings))
 - `subject` (String)
 
@@ -358,7 +358,7 @@ Read-Only:
 Read-Only:
 
 - `array` (Boolean) Whether the return value should be single or multi-value
-- `type` (String) Expected return type of this expression (what to try casting the result to)
+- `type` (String) Expected return type of this expression (what to try casting the result to). This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Engine types include your own configuration - a custom field's type is identified by its ID - so build the expression in the dashboard and export it to get the right value.
 
 
 

--- a/docs/resources/alert_route.md
+++ b/docs/resources/alert_route.md
@@ -309,7 +309,7 @@ Required:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--alert_sources--condition_groups--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 
@@ -355,7 +355,7 @@ Required:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--condition_groups--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 
@@ -495,7 +495,7 @@ Optional:
 
 Required:
 
-- `operation_type` (String) Indicates which operation type to execute
+- `operation_type` (String) The type of the operation. Possible values are: `navigate`, `filter`, `concatenate`, `count`, `min`, `max`, `sum`, `random`, `first`, `parse`, `branches`, `cast`.
 
 Optional:
 
@@ -533,7 +533,7 @@ Required:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--expressions--operations--branches--branches--condition_groups--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 
@@ -600,7 +600,7 @@ Optional:
 Required:
 
 - `array` (Boolean) Whether the return value should be single or multi-value
-- `type` (String) Expected return type of this expression (what to try casting the result to)
+- `type` (String) Expected return type of this expression (what to try casting the result to). This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Engine types include your own configuration - a custom field's type is identified by its ID - so build the expression in the dashboard and export it to get the right value.
 
 
 
@@ -617,7 +617,7 @@ Required:
 Required:
 
 - `array` (Boolean) Whether the return value should be single or multi-value
-- `type` (String) Expected return type of this expression (what to try casting the result to)
+- `type` (String) Expected return type of this expression (what to try casting the result to). This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Engine types include your own configuration - a custom field's type is identified by its ID - so build the expression in the dashboard and export it to get the right value.
 
 
 
@@ -640,7 +640,7 @@ Required:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--expressions--operations--filter--condition_groups--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 
@@ -696,7 +696,7 @@ Required:
 Required:
 
 - `array` (Boolean) Whether the return value should be single or multi-value
-- `type` (String) Expected return type of this expression (what to try casting the result to)
+- `type` (String) Expected return type of this expression (what to try casting the result to). This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Engine types include your own configuration - a custom field's type is identified by its ID - so build the expression in the dashboard and export it to get the right value.
 
 
 
@@ -774,7 +774,7 @@ Required:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--incident_config--condition_groups--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 
@@ -1070,7 +1070,7 @@ Required:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--channel_config--condition_groups--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 
@@ -1194,7 +1194,7 @@ Optional:
 
 - `grouping_keys` (Attributes Set) Which attributes should this alert route use to group alerts? Only set when grouping is enabled. (see [below for nested schema](#nestedatt--grouping_config--default--grouping_keys))
 - `window_seconds` (Number) How long the grouping window is, in seconds. Must be between 60 (1 minute) and 172800 (48 hours). Only set when grouping is enabled.
-- `window_type` (String) Controls how the grouping window behaves. 'rolling' keeps the window open for window_seconds after the most recent alert, so the group stays open as long as alerts keep arriving. 'fixed' opens the window when the first alert arrives and always closes window_seconds later, regardless of any subsequent alerts. Only set when grouping is enabled.. Possible values are: `rolling`, `fixed`.
+- `window_type` (String) Controls how the grouping window behaves. 'rolling' keeps the window open for window_seconds after the most recent alert, so the group stays open as long as alerts keep arriving. 'fixed' opens the window when the first alert arrives and always closes window_seconds later, regardless of any subsequent alerts. Only set when grouping is enabled. Possible values are: `rolling`, `fixed`.
 
 <a id="nestedatt--grouping_config--default--grouping_keys"></a>
 ### Nested Schema for `grouping_config.default.grouping_keys`
@@ -1496,7 +1496,7 @@ Required:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--message_config--destinations--condition_groups--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 

--- a/docs/resources/alert_source.md
+++ b/docs/resources/alert_source.md
@@ -233,7 +233,7 @@ Optional:
 
 Required:
 
-- `operation_type` (String) Indicates which operation type to execute
+- `operation_type` (String) The type of the operation. Possible values are: `navigate`, `filter`, `concatenate`, `count`, `min`, `max`, `sum`, `random`, `first`, `parse`, `branches`, `cast`.
 
 Optional:
 
@@ -271,7 +271,7 @@ Required:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--template--expressions--operations--branches--branches--condition_groups--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 
@@ -338,7 +338,7 @@ Optional:
 Required:
 
 - `array` (Boolean) Whether the return value should be single or multi-value
-- `type` (String) Expected return type of this expression (what to try casting the result to)
+- `type` (String) Expected return type of this expression (what to try casting the result to). This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Engine types include your own configuration - a custom field's type is identified by its ID - so build the expression in the dashboard and export it to get the right value.
 
 
 
@@ -355,7 +355,7 @@ Required:
 Required:
 
 - `array` (Boolean) Whether the return value should be single or multi-value
-- `type` (String) Expected return type of this expression (what to try casting the result to)
+- `type` (String) Expected return type of this expression (what to try casting the result to). This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Engine types include your own configuration - a custom field's type is identified by its ID - so build the expression in the dashboard and export it to get the right value.
 
 
 
@@ -378,7 +378,7 @@ Required:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--template--expressions--operations--filter--condition_groups--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 
@@ -434,7 +434,7 @@ Required:
 Required:
 
 - `array` (Boolean) Whether the return value should be single or multi-value
-- `type` (String) Expected return type of this expression (what to try casting the result to)
+- `type` (String) Expected return type of this expression (what to try casting the result to). This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Engine types include your own configuration - a custom field's type is identified by its ID - so build the expression in the dashboard and export it to get the right value.
 
 
 

--- a/docs/resources/escalation_path.md
+++ b/docs/resources/escalation_path.md
@@ -250,7 +250,7 @@ Optional:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 
@@ -343,7 +343,7 @@ Optional:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 
@@ -436,7 +436,7 @@ Optional:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 
@@ -529,7 +529,7 @@ Optional:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 
@@ -622,7 +622,7 @@ Optional:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 
@@ -1078,7 +1078,7 @@ Optional:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 
@@ -1627,7 +1627,7 @@ Optional:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 
@@ -1720,7 +1720,7 @@ Optional:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 
@@ -2176,7 +2176,7 @@ Optional:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 
@@ -2818,7 +2818,7 @@ Optional:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 
@@ -2911,7 +2911,7 @@ Optional:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 
@@ -3004,7 +3004,7 @@ Optional:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 
@@ -3460,7 +3460,7 @@ Optional:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 
@@ -4009,7 +4009,7 @@ Optional:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 
@@ -4102,7 +4102,7 @@ Optional:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 
@@ -4558,7 +4558,7 @@ Optional:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 
@@ -5293,7 +5293,7 @@ Optional:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 
@@ -5386,7 +5386,7 @@ Optional:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 
@@ -5479,7 +5479,7 @@ Optional:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 
@@ -5572,7 +5572,7 @@ Optional:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 
@@ -6028,7 +6028,7 @@ Optional:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 
@@ -6577,7 +6577,7 @@ Optional:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 
@@ -6670,7 +6670,7 @@ Optional:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 
@@ -7126,7 +7126,7 @@ Optional:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 
@@ -7768,7 +7768,7 @@ Optional:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 
@@ -7861,7 +7861,7 @@ Optional:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 
@@ -7954,7 +7954,7 @@ Optional:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 
@@ -8410,7 +8410,7 @@ Optional:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 
@@ -8959,7 +8959,7 @@ Optional:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 
@@ -9052,7 +9052,7 @@ Optional:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 
@@ -9508,7 +9508,7 @@ Optional:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 

--- a/docs/resources/maintenance_window.md
+++ b/docs/resources/maintenance_window.md
@@ -88,7 +88,7 @@ Required:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--alert_condition_groups--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 

--- a/docs/resources/workflow.md
+++ b/docs/resources/workflow.md
@@ -140,12 +140,12 @@ resource "incident_workflow" "page_execs" {
 - `continue_on_step_error` (Boolean) Whether to continue executing the workflow if a step fails
 - `expressions` (Attributes Set) The expressions to be prepared for use by steps and conditions (see [below for nested schema](#nestedatt--expressions))
 - `name` (String) Name provided by the user when creating the workflow
-- `once_for` (List of String) This workflow will run 'once for' a list of references
-- `runs_on_incident_modes` (Set of String) Which incident modes should this workflow run on? By default, workflows only run on standard incidents, but can also be configured to run on test and retrospective incidents.
+- `once_for` (List of String) This workflow will run 'once for' a list of references. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. The references you can use come from the scope the trigger builds, which the workflow builder lists once you've chosen one.
+- `runs_on_incident_modes` (Set of String) Which incident modes should this workflow run on? By default, workflows only run on standard incidents, but can also be configured to run on test and retrospective incidents. Possible values are: `standard`, `test`, `retrospective`.
 - `runs_on_incidents` (String) Which incidents should the workflow be applied to?. Possible values are: `newly_created`, `newly_created_and_active`.
 - `state` (String) What state this workflow is in. Possible values are: `active`, `disabled`, `draft`, `error`.
 - `steps` (Attributes List) Steps that are executed as part of the workflow (see [below for nested schema](#nestedatt--steps))
-- `trigger` (String) Unique name of the trigger
+- `trigger` (String) Unique name of the trigger. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Pick a trigger in the dashboard's workflow builder and use Export to Terraform to see its name.
 
 ### Optional
 
@@ -176,7 +176,7 @@ Required:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--condition_groups--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 
@@ -228,7 +228,7 @@ Optional:
 
 Required:
 
-- `operation_type` (String) Indicates which operation type to execute
+- `operation_type` (String) The type of the operation. Possible values are: `navigate`, `filter`, `concatenate`, `count`, `min`, `max`, `sum`, `random`, `first`, `parse`, `branches`, `cast`.
 
 Optional:
 
@@ -266,7 +266,7 @@ Required:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--expressions--operations--branches--branches--condition_groups--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 
@@ -333,7 +333,7 @@ Optional:
 Required:
 
 - `array` (Boolean) Whether the return value should be single or multi-value
-- `type` (String) Expected return type of this expression (what to try casting the result to)
+- `type` (String) Expected return type of this expression (what to try casting the result to). This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Engine types include your own configuration - a custom field's type is identified by its ID - so build the expression in the dashboard and export it to get the right value.
 
 
 
@@ -350,7 +350,7 @@ Required:
 Required:
 
 - `array` (Boolean) Whether the return value should be single or multi-value
-- `type` (String) Expected return type of this expression (what to try casting the result to)
+- `type` (String) Expected return type of this expression (what to try casting the result to). This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Engine types include your own configuration - a custom field's type is identified by its ID - so build the expression in the dashboard and export it to get the right value.
 
 
 
@@ -373,7 +373,7 @@ Required:
 
 Required:
 
-- `operation` (String) The logical operation to be applied
+- `operation` (String) The logical operation to be applied. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Which operations apply depends on the type of the subject you're comparing, so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject as you build the condition.
 - `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--expressions--operations--filter--condition_groups--conditions--param_bindings))
 - `subject` (String) The subject of the condition, on which the operation is applied
 
@@ -429,7 +429,7 @@ Required:
 Required:
 
 - `array` (Boolean) Whether the return value should be single or multi-value
-- `type` (String) Expected return type of this expression (what to try casting the result to)
+- `type` (String) Expected return type of this expression (what to try casting the result to). This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Engine types include your own configuration - a custom field's type is identified by its ID - so build the expression in the dashboard and export it to get the right value.
 
 
 
@@ -529,7 +529,7 @@ Required:
 - `key` (String) The key used to reference this field in the workflow scope
 - `required` (Boolean) Whether this field must be filled in when running the workflow
 - `title` (String) Human readable title shown in the form
-- `type` (String) The engine resource type of this field
+- `type` (String) The engine resource type of this field. This isn't a fixed list - it depends on your configuration and grows over time, so don't treat a value that isn't listed here as unsupported. Form field types are engine types, which include your own configuration, so build the form in the dashboard and export it to get the right value.
 
 Optional:
 

--- a/internal/apischema/schema.go
+++ b/internal/apischema/schema.go
@@ -61,3 +61,76 @@ func Docstring(definitionName, propertyName string) string {
 
 	return p.Value.Description
 }
+
+// EnumValues returns the values the schema allows for a property, in the order it lists
+// them. Validation that reads the enum from here can't fall behind the API and start
+// rejecting a value it has since started accepting.
+//
+// For an array property the enum sits on the items rather than the property itself -
+// runs_on_incident_modes is ArrayOf(WorkflowIncidentMode) in the API design - so fall
+// back to the item enum, which is the set an element may take.
+func EnumValues(definitionName, propertyName string) []string {
+	property := Property(definitionName, propertyName).Value
+
+	enum := property.Enum
+	if len(enum) == 0 && property.Items != nil && property.Items.Value != nil {
+		enum = property.Items.Value.Enum
+	}
+
+	values := []string{}
+	for _, value := range enum {
+		if valueAsString, ok := value.(string); ok {
+			values = append(values, valueAsString)
+		}
+	}
+
+	return values
+}
+
+// EnumValuesDescription reuses the documentation string from the API schema, and then
+// appends the possible values of the enum.
+func EnumValuesDescription(definitionName, propertyName string) string {
+	values := EnumValues(definitionName, propertyName)
+	if len(values) == 0 {
+		panic(fmt.Sprintf("%s.%s has no enum values: use Docstring or DynamicValuesDescription", definitionName, propertyName))
+	}
+
+	quoted := []string{}
+	for _, value := range values {
+		quoted = append(quoted, "`"+value+"`")
+	}
+
+	return fmt.Sprintf("%s. Possible values are: %s.", sentence(Docstring(definitionName, propertyName)), strings.Join(quoted, ", "))
+}
+
+// DynamicValuesDescription documents an attribute whose valid values aren't a fixed
+// enum: they come from a registry we add to regularly, or from the organisation's own
+// configuration. Listing them in the schema would either go stale or force a provider
+// upgrade every time we add one, so we say where to find the current set instead.
+//
+// The wording deliberately tells the reader the set can grow, so that neither a person
+// nor an agent treats a value it doesn't mention as unsupported.
+func DynamicValuesDescription(definitionName, propertyName, whereToLook string) string {
+	return DescribeDynamicValues(Docstring(definitionName, propertyName), whereToLook)
+}
+
+// DescribeDynamicValues is DynamicValuesDescription for an attribute the schema has no
+// docstring for, such as ConditionV2.operation, where the provider supplies its own.
+func DescribeDynamicValues(description, whereToLook string) string {
+	caveat := fmt.Sprintf("This isn't a fixed list - it depends on your configuration and grows over "+
+		"time, so don't treat a value that isn't listed here as unsupported. %s", whereToLook)
+
+	// Not every property in the schema carries a description, and prefixing the caveat
+	// with an empty one leaves a stray ". " at the front.
+	if sentence(description) == "" {
+		return caveat
+	}
+
+	return fmt.Sprintf("%s. %s", sentence(description), caveat)
+}
+
+// sentence trims a trailing full stop so appending another sentence doesn't leave "..",
+// since some schema docstrings end in one and some don't.
+func sentence(description string) string {
+	return strings.TrimRight(strings.TrimSpace(description), ".")
+}

--- a/internal/apischema/schema_test.go
+++ b/internal/apischema/schema_test.go
@@ -1,0 +1,80 @@
+package apischema
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEnumValues_ArrayItems covers the case this helper exists for: runs_on_incident_modes
+// is ArrayOf(WorkflowIncidentMode) in the API design, so the enum lands on the items
+// rather than the property, and reading only the property's own enum finds nothing.
+func TestEnumValues_ArrayItems(t *testing.T) {
+	assert.Equal(t,
+		[]string{"standard", "test", "retrospective"},
+		EnumValues("WorkflowV2", "runs_on_incident_modes"))
+}
+
+func TestEnumValues_Scalar(t *testing.T) {
+	assert.Equal(t,
+		[]string{"active", "disabled", "draft", "error"},
+		EnumValues("WorkflowV2", "state"))
+}
+
+// A property that genuinely has no enum must come back empty rather than panicking, so
+// callers can tell the difference between "fixed set" and "dynamic".
+func TestEnumValues_NotAnEnum(t *testing.T) {
+	assert.Empty(t, EnumValues("WorkflowV2", "once_for"))
+}
+
+func TestEnumValuesDescription(t *testing.T) {
+	description := EnumValuesDescription("ExpressionOperationV2", "operation_type")
+
+	assert.Equal(t,
+		"The type of the operation. Possible values are: `navigate`, `filter`, `concatenate`, "+
+			"`count`, `min`, `max`, `sum`, `random`, `first`, `parse`, `branches`, `cast`.",
+		description)
+}
+
+// The runs_on_incident_modes docstring ends in a full stop and the state one doesn't, so
+// the helper has to normalise or one of them renders "..".
+func TestEnumValuesDescription_NoDoubleFullStop(t *testing.T) {
+	for _, property := range []string{"runs_on_incident_modes", "state", "runs_on_incidents"} {
+		description := EnumValuesDescription("WorkflowV2", property)
+
+		assert.NotContains(t, description, "..", "property %s", property)
+		assert.True(t, strings.Contains(description, "Possible values are:"), "property %s", property)
+	}
+}
+
+// Documenting a property that isn't an enum is a mistake we want to hear about at
+// startup, not one that silently ships a description promising values it can't list.
+func TestEnumValuesDescription_PanicsWithoutEnum(t *testing.T) {
+	require.Panics(t, func() {
+		EnumValuesDescription("WorkflowV2", "once_for")
+	})
+}
+
+func TestDynamicValuesDescription(t *testing.T) {
+	description := DynamicValuesDescription("TriggerSlimV2", "name", "Look it up in the dashboard.")
+
+	assert.Equal(t,
+		"Unique name of the trigger. This isn't a fixed list - it depends on your configuration and "+
+			"grows over time, so don't treat a value that isn't listed here as unsupported. "+
+			"Look it up in the dashboard.",
+		description)
+}
+
+// ConditionV2.operation has no description in the schema. Prefixing the caveat with an
+// empty string used to render a stray ". " at the front of the docs.
+func TestDescribeDynamicValues_EmptyDescription(t *testing.T) {
+	assert.Empty(t, Docstring("ConditionV2", "operation"),
+		"this test is meaningless if the schema has since gained a description here")
+
+	description := DescribeDynamicValues(Docstring("ConditionV2", "operation"), "Look it up.")
+
+	assert.False(t, strings.HasPrefix(description, "."), "got: %s", description)
+	assert.True(t, strings.HasPrefix(description, "This isn't a fixed list"), "got: %s", description)
+}

--- a/internal/provider/helpers.go
+++ b/internal/provider/helpers.go
@@ -1,38 +1,28 @@
 package provider
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/incident-io/terraform-provider-incident/internal/apischema"
 )
 
-// EnumValuesDescription reuses the documentation string from the API schema, and then appends the possible values of the enum.
+// EnumValuesDescription documents an attribute whose values are a fixed enum in the API
+// schema. See apischema.EnumValuesDescription.
 func EnumValuesDescription(definitionName string, propertyName string) string {
-	enumValues := []string{}
-	for _, enum := range apischema.Property(definitionName, propertyName).Value.Enum {
-		enumAsString, _ := enum.(string)
-		enumValues = append(enumValues, "`"+enumAsString+"`")
-	}
-
-	return fmt.Sprintf("%s. Possible values are: %s.", apischema.Docstring(definitionName, propertyName), strings.Join(enumValues, ", "))
+	return apischema.EnumValuesDescription(definitionName, propertyName)
 }
 
-// enumValues returns the values the API schema allows for a property, in the order it
-// lists them. Validation that reads the enum from here can't fall behind the API and
-// start rejecting a value it has since started accepting.
-func enumValues(definitionName string, propertyName string) []string {
-	values := []string{}
-	for _, enum := range apischema.Property(definitionName, propertyName).Value.Enum {
-		if enumAsString, ok := enum.(string); ok {
-			values = append(values, enumAsString)
-		}
-	}
+// DynamicValuesDescription documents an attribute whose values aren't a fixed enum. See
+// apischema.DynamicValuesDescription.
+func DynamicValuesDescription(definitionName string, propertyName string, whereToLook string) string {
+	return apischema.DynamicValuesDescription(definitionName, propertyName, whereToLook)
+}
 
-	return values
+// enumValues returns the values the API schema allows for a property. See
+// apischema.EnumValues.
+func enumValues(definitionName string, propertyName string) []string {
+	return apischema.EnumValues(definitionName, propertyName)
 }
 
 // knownString returns the value of a string attribute, and false when it's missing, null

--- a/internal/provider/incident_workflow_data_source.go
+++ b/internal/provider/incident_workflow_data_source.go
@@ -74,7 +74,7 @@ func (d *IncidentWorkflowDataSource) Schema(ctx context.Context, req datasource.
 				Computed:            true,
 			},
 			"trigger": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("TriggerSlimV2", "name"),
+				MarkdownDescription: DynamicValuesDescription("TriggerSlimV2", "name", models.WhereToFindTriggers),
 				Computed:            true,
 			},
 			"condition_groups": models.ConditionGroupsDataSourceAttribute(),
@@ -98,7 +98,7 @@ func (d *IncidentWorkflowDataSource) Schema(ctx context.Context, req datasource.
 			},
 			"expressions": models.ExpressionsDataSourceAttribute(),
 			"once_for": schema.ListAttribute{
-				MarkdownDescription: apischema.Docstring("WorkflowV2", "once_for"),
+				MarkdownDescription: DynamicValuesDescription("WorkflowV2", "once_for", models.WhereToFindOnceFor),
 				Computed:            true,
 				ElementType:         types.StringType,
 			},
@@ -143,7 +143,7 @@ func (d *IncidentWorkflowDataSource) Schema(ctx context.Context, req datasource.
 				Computed:            true,
 			},
 			"runs_on_incident_modes": schema.SetAttribute{
-				MarkdownDescription: apischema.Docstring("WorkflowV2", "runs_on_incident_modes"),
+				MarkdownDescription: EnumValuesDescription("WorkflowV2", "runs_on_incident_modes"),
 				Computed:            true,
 				ElementType:         types.StringType,
 			},

--- a/internal/provider/incident_workflow_resource.go
+++ b/internal/provider/incident_workflow_resource.go
@@ -115,7 +115,7 @@ We'd generally recommend building workflows in our [web dashboard](https://app.i
 				Optional:            true,
 			},
 			"trigger": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("TriggerSlimV2", "name"),
+				MarkdownDescription: DynamicValuesDescription("TriggerSlimV2", "name", models.WhereToFindTriggers),
 				Required:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
@@ -142,7 +142,7 @@ We'd generally recommend building workflows in our [web dashboard](https://app.i
 			},
 			"expressions": models.ExpressionsAttribute(),
 			"once_for": schema.ListAttribute{
-				MarkdownDescription: apischema.Docstring("WorkflowV2", "once_for"),
+				MarkdownDescription: DynamicValuesDescription("WorkflowV2", "once_for", models.WhereToFindOnceFor),
 				Required:            true,
 				ElementType:         types.StringType,
 			},
@@ -190,7 +190,7 @@ We'd generally recommend building workflows in our [web dashboard](https://app.i
 				Required:            true,
 			},
 			"runs_on_incident_modes": schema.SetAttribute{
-				MarkdownDescription: apischema.Docstring("WorkflowV2", "runs_on_incident_modes"),
+				MarkdownDescription: EnumValuesDescription("WorkflowV2", "runs_on_incident_modes"),
 				Required:            true,
 				ElementType:         types.StringType,
 			},
@@ -223,7 +223,7 @@ We'd generally recommend building workflows in our [web dashboard](https://app.i
 							Required:            true,
 						},
 						"type": schema.StringAttribute{
-							MarkdownDescription: apischema.Docstring("WorkflowFormFieldV2", "type"),
+							MarkdownDescription: DynamicValuesDescription("WorkflowFormFieldV2", "type", models.WhereToFindFormFieldTypes),
 							Required:            true,
 						},
 						"description": schema.StringAttribute{

--- a/internal/provider/models/dynamic_values.go
+++ b/internal/provider/models/dynamic_values.go
@@ -1,0 +1,22 @@
+package models
+
+// Where to point people for the values of an attribute that isn't a fixed enum. The
+// dashboard is the source of truth for all of these, and its "Export to Terraform" emits
+// config using the exact values, so it doubles as a way to discover them.
+//
+// The condition and expression wording is shared by every resource built on the engine -
+// escalation paths and maintenance windows as well as workflows - so keep it generic
+// rather than naming the workflow builder.
+const (
+	WhereToFindTriggers = "Pick a trigger in the dashboard's workflow builder and use Export to " +
+		"Terraform to see its name."
+	WhereToFindOnceFor = "The references you can use come from the scope the trigger builds, which the " +
+		"workflow builder lists once you've chosen one."
+	WhereToFindOperations = "Which operations apply depends on the type of the subject you're comparing, " +
+		"so a string and a timestamp offer different ones. The dashboard lists the valid ones for a subject " +
+		"as you build the condition."
+	WhereToFindReturnTypes = "Engine types include your own configuration - a custom field's type is " +
+		"identified by its ID - so build the expression in the dashboard and export it to get the right value."
+	WhereToFindFormFieldTypes = "Form field types are engine types, which include your own configuration, " +
+		"so build the form in the dashboard and export it to get the right value."
+)

--- a/internal/provider/models/engine.go
+++ b/internal/provider/models/engine.go
@@ -419,7 +419,7 @@ func ConditionsAttribute() schema.ListNestedAttribute {
 		NestedObject: schema.NestedAttributeObject{
 			Attributes: map[string]schema.Attribute{
 				"operation": schema.StringAttribute{
-					MarkdownDescription: "The logical operation to be applied",
+					MarkdownDescription: apischema.DescribeDynamicValues("The logical operation to be applied", WhereToFindOperations),
 					Required:            true,
 				},
 				"param_bindings": ParamBindingsAttribute(),
@@ -454,7 +454,7 @@ func ReturnsAttribute() schema.SingleNestedAttribute {
 				Required:            true,
 			},
 			"type": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("ReturnsMetaV2", "type"),
+				MarkdownDescription: apischema.DynamicValuesDescription("ReturnsMetaV2", "type", WhereToFindReturnTypes),
 				Required:            true,
 			},
 		},
@@ -540,7 +540,7 @@ func ExpressionsAttribute() schema.SetNestedAttribute {
 								},
 							},
 							"operation_type": schema.StringAttribute{
-								MarkdownDescription: "Indicates which operation type to execute",
+								MarkdownDescription: apischema.EnumValuesDescription("ExpressionOperationV2", "operation_type"),
 								Required:            true,
 							},
 							"parse": schema.SingleNestedAttribute{

--- a/internal/provider/models/engine_datasource.go
+++ b/internal/provider/models/engine_datasource.go
@@ -57,7 +57,7 @@ func ConditionsDataSourceAttribute() schema.ListNestedAttribute {
 		NestedObject: schema.NestedAttributeObject{
 			Attributes: map[string]schema.Attribute{
 				"operation": schema.StringAttribute{
-					MarkdownDescription: apischema.Docstring("ConditionV2", "operation"),
+					MarkdownDescription: apischema.DescribeDynamicValues("The logical operation to be applied", WhereToFindOperations),
 					Computed:            true,
 				},
 				"param_bindings": ParamBindingsDataSourceAttribute(),
@@ -92,7 +92,7 @@ func ReturnsDataSourceAttribute() schema.SingleNestedAttribute {
 				Computed:            true,
 			},
 			"type": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("ReturnsMetaV2", "type"),
+				MarkdownDescription: apischema.DynamicValuesDescription("ReturnsMetaV2", "type", WhereToFindReturnTypes),
 				Computed:            true,
 			},
 		},
@@ -179,7 +179,7 @@ func ExpressionsDataSourceAttribute() schema.SetNestedAttribute {
 								},
 							},
 							"operation_type": schema.StringAttribute{
-								MarkdownDescription: apischema.Docstring("ExpressionOperationV2", "operation_type"),
+								MarkdownDescription: apischema.EnumValuesDescription("ExpressionOperationV2", "operation_type"),
 								Computed:            true,
 							},
 							"parse": schema.SingleNestedAttribute{


### PR DESCRIPTION
Starts on [PD-21840](https://linear.app/incident-io/issue/PD-21840/chunk-5-document-workflow-enum-parameters) (chunk 5 of the Terraform workflows spec). Several workflow parameters read as bare strings in the registry docs, so both people and LLMs have to guess what's valid.

## The split

Lisa's review comments on the spec are the useful thing here: most of the parameters on the ticket **aren't** fixed enums, and documenting them as such would be wrong. So this separates them.

**Fixed enums, now listed:**

- `runs_on_incident_modes` → `standard`, `test`, `retrospective`. This one needed a helper change: it's `ArrayOf(WorkflowIncidentMode)` in the API design, so the enum sits on the array *items* and the existing helper read only the property's own enum and found nothing.
- `operation_type` → the twelve expression operation types. The enum was already in the schema; nothing read it.

**Dynamic, now honest about it.** `trigger` (registry we add to often), `once_for` (references from the trigger's scope), condition `operation` (depends on the subject's type), expression return `type` and form field `type` (engine types, which include an org's own custom field IDs). Per Lisa — *"as long as the docs say something like 'this list can grow, don't assume if it's not here it's fucked'"* — these now say the set isn't fixed and point at where to find current values, rather than carrying a list that goes stale or forces a provider upgrade each time we add one.

No client-side validation was added for the dynamic ones, matching the conclusion in the thread.

```
- `trigger` (String) Unique name of the trigger. This isn't a fixed list - it depends on your
  configuration and grows over time, so don't treat a value that isn't listed here as
  unsupported. Pick a trigger in the dashboard's workflow builder and use Export to Terraform
  to see its name.
```

## Incidental fixes

- The enum helpers move to `apischema` so `models/` can use them (provider imports models, so it couldn't go the other way).
- Descriptions now trim a trailing full stop before appending, which was rendering `incidents.. Possible values are:` on `runs_on_incident_modes`.
- `ConditionV2.operation` has no description in the schema, which rendered a stray leading `". "`. `DescribeDynamicValues` now handles an empty base.
- `EnumValuesDescription` panics if asked to document a property with no enum, rather than silently promising values it can't list.

## Blast radius

The condition and expression models are shared, so the `operation` and return-`type` wording also lands on `alert_route`, `alert_source`, `escalation_path` and `maintenance_window`. That's intended — the wording is deliberately dashboard-generic rather than naming the workflow builder — but it's why the docs diff is wider than the workflow pages.

## Not covered

`operations` (Attributes List) from the ticket isn't an enum at all — it's the list of operations, whose `operation_type` this PR documents. Lisa's suggestion of exposing `ListResources`/`ListTriggers`/`ListSteps` publicly and pointing the docs at those is a server-side change and isn't here; once those exist, the guidance strings in `models/dynamic_values.go` are the single place to update.

## Testing

New unit tests in `internal/apischema` cover the array-item enum fallback, the double-full-stop fix, the empty-description case, and the panic. `go build`, `go vet`, `gofmt`, `terraform fmt -check -recursive` and the full unit suite pass. No acceptance tests needed — this is schema descriptions only, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema MarkdownDescription and CHANGELOG only; no API calls, validation, or resource behavior changes.
> 
> **Overview**
> Improves **Terraform registry docs** for workflow and shared engine attributes by distinguishing fixed API enums from open-ended values, mainly to help authors and LLM-generated config pick valid strings.
> 
> **Fixed enums** now append **Possible values are:** from the embedded API schema. That includes **`runs_on_incident_modes`** (`standard`, `test`, `retrospective`) via a new **`EnumValues`** helper that reads enums on **array item** schemas, and **`operation_type`** on expression operations (all twelve types). **`incident_workflow`** resource and data source use these for trigger-related fields where appropriate.
> 
> **Dynamic parameters** (`trigger`, `once_for`, condition **`operation`**, expression return **`type`**, form field **`type`**) get **`DynamicValuesDescription`** text: the set is not fixed, it can grow, and the dashboard (especially Export to Terraform) is where to find current values. Shared wording lives in **`models/dynamic_values.go`** and flows through **`models/engine.go`** / **`engine_datasource.go`**, which is why **`alert_route`**, **`alert_source`**, **`escalation_path`**, and **`maintenance_window`** docs change too.
> 
> Enum/doc helpers move into **`internal/apischema`** (with unit tests); provider **`helpers.go`** delegates. Minor doc formatting fixes: no double full stops, no leading `". "` when the API has no base description, and **`EnumValuesDescription`** panics if used on a non-enum property.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc8ced2a3455d5480ccb5692bba43de81526f779. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->