### PR TITLE
Changelog for v6.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## v6.7.1
+
 - Fix `Provider produced inconsistent result after apply` on `incident_schedule` when a rotation version's `effective_from` or `handover_start_at` is written as anything other than a UTC timestamp at second precision. The API re-renders timestamps its own way, and the provider stored what came back, so a config saying `2025-06-01T12:00:00.000Z` (which is what the dashboard's Terraform export writes) or `2026-04-10T19:00:00-04:00` read back as a different string for the same moment. Rotations and their versions are sets, which Terraform correlates by raw value, so that was enough to fail the post-apply consistency check with `planned set element ... does not correlate with any element in actual` - leaving the change applied in incident.io but absent from state, and a plan that never settled. The provider now keeps the timestamp exactly as your config writes it whenever it means the same moment as the one the API returns.
 - Reject two `incident_schedule` rotations sharing an `id` at plan time. Versions of a rotation are entries sharing an `id` in the API, and the provider groups them back together by `id` when it reads a schedule, so a config that spells versions as separate `rotations` entries applied but read back as one rotation holding every version - failing the same post-apply consistency check, then planning a change on every run. The error now says so during `plan`, and points at listing the versions under the rotation's `versions` attribute.
 


### PR DESCRIPTION
Cuts the two unreleased entries under `## v6.7.1`, ready for the tag.

Patch rather than minor: both entries are bug fixes to `incident_schedule` with no new resources, data sources or attributes. The second one turns a config that previously applied-but-never-settled into a plan-time error, which is a behaviour change, but only for configs that were already broken.

Once this merges, the release is `git tag v6.7.1` on master and `git push --tags`, which fires `.github/workflows/release.yml` and publishes to the Terraform registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changelog-only change; behavior and risk belong to the already-implemented v6.7.1 fixes described in the new section, not this merge.
> 
> **Overview**
> **Release notes only** — no provider code changes. The two bullets that were under `## Unreleased` are moved into a new **`## v6.7.1`** section so the tag can ship with documented fixes.
> 
> That section documents patch **v6.7.1** for **`incident_schedule`**: preserving config-written timestamps for rotation version `effective_from` / `handover_start_at` when they denote the same instant as the API (fixing post-apply inconsistency on rotation sets), and failing **plan** when two `rotations` blocks reuse the same `id` instead of grouping versions under `versions`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d3478ab74fa7986a970ab5e48a0d0a6ce79db1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->