### PR TITLE
Changelog for v6.8.0, cut for adding rate limit sharding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## v6.8.0
+
 - Add `rate_limit_sharding` to `incident_alert_source` and `incident_alert_source_beta`, which splits a source's ingest rate limit into per-value buckets instead of applying one limit to the whole source. Set `rate_limit_sharding = { rate_limit_shard_key_path = "$.metadata.team" }` to give each distinct value at that JSON path its own allowance, so one noisy sender can't exhaust the source for everyone else. Remove the block to go back to a single limit. Not every source type supports it - the ones we fetch from over an API rather than receive a payload from don't - and a path set on one of those is rejected at plan time.
 
 ## v6.7.1


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change to CHANGELOG.md with no runtime or configuration behavior impact.
> 
> **Overview**
> This PR **cuts the v6.8.0 changelog section** by moving the release note out of `Unreleased` and under a new **`## v6.8.0`** heading.
> 
> The entry documents **`rate_limit_sharding`** on **`incident_alert_source`** and **`incident_alert_source_beta`**: optional per-shard ingest rate limits keyed by a JSON path (for example `$.metadata.team`), with plan-time rejection when the source type does not support sharding. **No provider or schema code changes** appear in this diff—only release documentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29e706066c82af0e41189b0965ecc62cb3693453. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->