### PR TITLE
Add shorthands for a param binding's value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 ## Unreleased
 
+- Add `value_literal`, `value_reference`, `expression_ref` and `values` as shorthands for a param binding's value, wherever bindings appear. `param_bindings = [{ value = { reference = "incident.url" } }]` becomes `param_bindings = [{ value_reference = "incident.url" }]`; `value` and `array_value` keep working, and setting more than one form is rejected at plan time.
 - Add `concatenate` to expression operations, which adds the values behind another reference to the current value. Configs using it previously failed to apply.
-
+- Fix `Provider produced inconsistent result after apply` on `incident_alert_source` when a template expression uses an operation alias such as `one_of`. The API returns the canonical name, and the provider stored that instead of what the config wrote.
 - Expose `rank` on the `incident_status` data source. Statuses are ordered in the dashboard by this value, and the API already returns it; lookups by `id` or `name` now include it so you can sort or compare statuses without a second call.
-
 - `incident_incident_role` can now be looked up by `name` as well as by `id`, so you no longer have to pin a role ID that differs between workspaces. Set exactly one of the two; setting both is rejected at plan time. The `incident_workflow` example now uses this to resolve the incident lead role instead of hardcoding its ID.
 
 ## v6.8.0

--- a/docs/data-sources/alert_sources.md
+++ b/docs/data-sources/alert_sources.md
@@ -212,7 +212,11 @@ Read-Only:
 Read-Only:
 
 - `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--alert_sources--template--expressions--else_branch--result--array_value))
+- `expression_ref` (String)
 - `value` (Attributes) (see [below for nested schema](#nestedatt--alert_sources--template--expressions--else_branch--result--value))
+- `value_literal` (String)
+- `value_reference` (String)
+- `values` (List of String)
 
 <a id="nestedatt--alert_sources--template--expressions--else_branch--result--array_value"></a>
 ### Nested Schema for `alert_sources.template.expressions.else_branch.result.array_value`
@@ -285,7 +289,11 @@ Read-Only:
 Read-Only:
 
 - `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--alert_sources--template--expressions--operations--branches--branches--condition_groups--conditions--param_bindings--array_value))
+- `expression_ref` (String)
 - `value` (Attributes) (see [below for nested schema](#nestedatt--alert_sources--template--expressions--operations--branches--branches--condition_groups--conditions--param_bindings--value))
+- `value_literal` (String)
+- `value_reference` (String)
+- `values` (List of String)
 
 <a id="nestedatt--alert_sources--template--expressions--operations--branches--branches--condition_groups--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `alert_sources.template.expressions.operations.branches.branches.condition_groups.conditions.param_bindings.array_value`
@@ -314,7 +322,11 @@ Read-Only:
 Read-Only:
 
 - `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--alert_sources--template--expressions--operations--branches--branches--result--array_value))
+- `expression_ref` (String)
 - `value` (Attributes) (see [below for nested schema](#nestedatt--alert_sources--template--expressions--operations--branches--branches--result--value))
+- `value_literal` (String)
+- `value_reference` (String)
+- `values` (List of String)
 
 <a id="nestedatt--alert_sources--template--expressions--operations--branches--branches--result--array_value"></a>
 ### Nested Schema for `alert_sources.template.expressions.operations.branches.branches.result.array_value`
@@ -400,7 +412,11 @@ Read-Only:
 Read-Only:
 
 - `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--alert_sources--template--expressions--operations--filter--condition_groups--conditions--param_bindings--array_value))
+- `expression_ref` (String)
 - `value` (Attributes) (see [below for nested schema](#nestedatt--alert_sources--template--expressions--operations--filter--condition_groups--conditions--param_bindings--value))
+- `value_literal` (String)
+- `value_reference` (String)
+- `values` (List of String)
 
 <a id="nestedatt--alert_sources--template--expressions--operations--filter--condition_groups--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `alert_sources.template.expressions.operations.filter.condition_groups.conditions.param_bindings.array_value`
@@ -467,7 +483,11 @@ Read-Only:
 Read-Only:
 
 - `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--alert_sources--template--visible_to_teams--array_value))
+- `expression_ref` (String)
 - `value` (Attributes) (see [below for nested schema](#nestedatt--alert_sources--template--visible_to_teams--value))
+- `value_literal` (String)
+- `value_reference` (String)
+- `values` (List of String)
 
 <a id="nestedatt--alert_sources--template--visible_to_teams--array_value"></a>
 ### Nested Schema for `alert_sources.template.visible_to_teams.array_value`

--- a/docs/data-sources/escalation_path.md
+++ b/docs/data-sources/escalation_path.md
@@ -93,8 +93,12 @@ Read-Only:
 
 Read-Only:
 
-- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--conditions--param_bindings--array_value))
-- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--conditions--param_bindings--value))
+- `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String)
+- `value` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--conditions--param_bindings--value))
+- `value_literal` (String)
+- `value_reference` (String)
+- `values` (List of String)
 
 <a id="nestedatt--path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.conditions.param_bindings.array_value`
@@ -182,8 +186,12 @@ Read-Only:
 
 Read-Only:
 
-- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--conditions--param_bindings--array_value))
-- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String)
+- `value` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String)
+- `value_reference` (String)
+- `values` (List of String)
 
 <a id="nestedatt--path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.conditions.param_bindings.array_value`
@@ -271,8 +279,12 @@ Read-Only:
 
 Read-Only:
 
-- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
-- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String)
+- `value` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String)
+- `value_reference` (String)
+- `values` (List of String)
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
@@ -360,8 +372,12 @@ Read-Only:
 
 Read-Only:
 
-- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
-- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String)
+- `value` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String)
+- `value_reference` (String)
+- `values` (List of String)
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
@@ -449,8 +465,12 @@ Read-Only:
 
 Read-Only:
 
-- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
-- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String)
+- `value` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String)
+- `value_reference` (String)
+- `values` (List of String)
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
@@ -854,8 +874,12 @@ Read-Only:
 
 Read-Only:
 
-- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
-- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String)
+- `value` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String)
+- `value_reference` (String)
+- `values` (List of String)
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
@@ -1337,8 +1361,12 @@ Read-Only:
 
 Read-Only:
 
-- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
-- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String)
+- `value` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String)
+- `value_reference` (String)
+- `values` (List of String)
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
@@ -1426,8 +1454,12 @@ Read-Only:
 
 Read-Only:
 
-- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
-- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String)
+- `value` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String)
+- `value_reference` (String)
+- `values` (List of String)
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
@@ -1831,8 +1863,12 @@ Read-Only:
 
 Read-Only:
 
-- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
-- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String)
+- `value` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String)
+- `value_reference` (String)
+- `values` (List of String)
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
@@ -2392,8 +2428,12 @@ Read-Only:
 
 Read-Only:
 
-- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
-- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String)
+- `value` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String)
+- `value_reference` (String)
+- `values` (List of String)
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
@@ -2481,8 +2521,12 @@ Read-Only:
 
 Read-Only:
 
-- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
-- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String)
+- `value` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String)
+- `value_reference` (String)
+- `values` (List of String)
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
@@ -2570,8 +2614,12 @@ Read-Only:
 
 Read-Only:
 
-- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
-- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String)
+- `value` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String)
+- `value_reference` (String)
+- `values` (List of String)
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
@@ -2975,8 +3023,12 @@ Read-Only:
 
 Read-Only:
 
-- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
-- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String)
+- `value` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String)
+- `value_reference` (String)
+- `values` (List of String)
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
@@ -3458,8 +3510,12 @@ Read-Only:
 
 Read-Only:
 
-- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
-- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String)
+- `value` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String)
+- `value_reference` (String)
+- `values` (List of String)
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
@@ -3547,8 +3603,12 @@ Read-Only:
 
 Read-Only:
 
-- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
-- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String)
+- `value` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String)
+- `value_reference` (String)
+- `values` (List of String)
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
@@ -3952,8 +4012,12 @@ Read-Only:
 
 Read-Only:
 
-- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
-- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String)
+- `value` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String)
+- `value_reference` (String)
+- `values` (List of String)
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
@@ -4591,8 +4655,12 @@ Read-Only:
 
 Read-Only:
 
-- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--conditions--param_bindings--array_value))
-- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String)
+- `value` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String)
+- `value_reference` (String)
+- `values` (List of String)
 
 <a id="nestedatt--path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.conditions.param_bindings.array_value`
@@ -4680,8 +4748,12 @@ Read-Only:
 
 Read-Only:
 
-- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
-- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String)
+- `value` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String)
+- `value_reference` (String)
+- `values` (List of String)
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
@@ -4769,8 +4841,12 @@ Read-Only:
 
 Read-Only:
 
-- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
-- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String)
+- `value` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String)
+- `value_reference` (String)
+- `values` (List of String)
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
@@ -4858,8 +4934,12 @@ Read-Only:
 
 Read-Only:
 
-- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
-- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String)
+- `value` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String)
+- `value_reference` (String)
+- `values` (List of String)
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
@@ -5263,8 +5343,12 @@ Read-Only:
 
 Read-Only:
 
-- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
-- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String)
+- `value` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String)
+- `value_reference` (String)
+- `values` (List of String)
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
@@ -5746,8 +5830,12 @@ Read-Only:
 
 Read-Only:
 
-- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
-- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String)
+- `value` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String)
+- `value_reference` (String)
+- `values` (List of String)
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
@@ -5835,8 +5923,12 @@ Read-Only:
 
 Read-Only:
 
-- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
-- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String)
+- `value` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String)
+- `value_reference` (String)
+- `values` (List of String)
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
@@ -6240,8 +6332,12 @@ Read-Only:
 
 Read-Only:
 
-- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
-- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String)
+- `value` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String)
+- `value_reference` (String)
+- `values` (List of String)
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
@@ -6801,8 +6897,12 @@ Read-Only:
 
 Read-Only:
 
-- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
-- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String)
+- `value` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String)
+- `value_reference` (String)
+- `values` (List of String)
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
@@ -6890,8 +6990,12 @@ Read-Only:
 
 Read-Only:
 
-- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
-- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String)
+- `value` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String)
+- `value_reference` (String)
+- `values` (List of String)
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
@@ -6979,8 +7083,12 @@ Read-Only:
 
 Read-Only:
 
-- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
-- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String)
+- `value` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String)
+- `value_reference` (String)
+- `values` (List of String)
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
@@ -7384,8 +7492,12 @@ Read-Only:
 
 Read-Only:
 
-- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
-- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String)
+- `value` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String)
+- `value_reference` (String)
+- `values` (List of String)
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
@@ -7867,8 +7979,12 @@ Read-Only:
 
 Read-Only:
 
-- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
-- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String)
+- `value` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String)
+- `value_reference` (String)
+- `values` (List of String)
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
@@ -7956,8 +8072,12 @@ Read-Only:
 
 Read-Only:
 
-- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
-- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String)
+- `value` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String)
+- `value_reference` (String)
+- `values` (List of String)
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
@@ -8361,8 +8481,12 @@ Read-Only:
 
 Read-Only:
 
-- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
-- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String)
+- `value` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String)
+- `value_reference` (String)
+- `values` (List of String)
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.conditions.param_bindings.array_value`

--- a/docs/data-sources/workflow.md
+++ b/docs/data-sources/workflow.md
@@ -77,7 +77,11 @@ Read-Only:
 Read-Only:
 
 - `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--condition_groups--conditions--param_bindings--array_value))
+- `expression_ref` (String)
 - `value` (Attributes) (see [below for nested schema](#nestedatt--condition_groups--conditions--param_bindings--value))
+- `value_literal` (String)
+- `value_reference` (String)
+- `values` (List of String)
 
 <a id="nestedatt--condition_groups--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `condition_groups.conditions.param_bindings.array_value`
@@ -133,7 +137,11 @@ Read-Only:
 Read-Only:
 
 - `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--expressions--else_branch--result--array_value))
+- `expression_ref` (String)
 - `value` (Attributes) (see [below for nested schema](#nestedatt--expressions--else_branch--result--value))
+- `value_literal` (String)
+- `value_reference` (String)
+- `values` (List of String)
 
 <a id="nestedatt--expressions--else_branch--result--array_value"></a>
 ### Nested Schema for `expressions.else_branch.result.array_value`
@@ -206,7 +214,11 @@ Read-Only:
 Read-Only:
 
 - `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--expressions--operations--branches--branches--condition_groups--conditions--param_bindings--array_value))
+- `expression_ref` (String)
 - `value` (Attributes) (see [below for nested schema](#nestedatt--expressions--operations--branches--branches--condition_groups--conditions--param_bindings--value))
+- `value_literal` (String)
+- `value_reference` (String)
+- `values` (List of String)
 
 <a id="nestedatt--expressions--operations--branches--branches--condition_groups--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `expressions.operations.branches.branches.condition_groups.conditions.param_bindings.array_value`
@@ -235,7 +247,11 @@ Read-Only:
 Read-Only:
 
 - `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--expressions--operations--branches--branches--result--array_value))
+- `expression_ref` (String)
 - `value` (Attributes) (see [below for nested schema](#nestedatt--expressions--operations--branches--branches--result--value))
+- `value_literal` (String)
+- `value_reference` (String)
+- `values` (List of String)
 
 <a id="nestedatt--expressions--operations--branches--branches--result--array_value"></a>
 ### Nested Schema for `expressions.operations.branches.branches.result.array_value`
@@ -321,7 +337,11 @@ Read-Only:
 Read-Only:
 
 - `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--expressions--operations--filter--condition_groups--conditions--param_bindings--array_value))
+- `expression_ref` (String)
 - `value` (Attributes) (see [below for nested schema](#nestedatt--expressions--operations--filter--condition_groups--conditions--param_bindings--value))
+- `value_literal` (String)
+- `value_reference` (String)
+- `values` (List of String)
 
 <a id="nestedatt--expressions--operations--filter--condition_groups--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `expressions.operations.filter.condition_groups.conditions.param_bindings.array_value`
@@ -403,7 +423,11 @@ Read-Only:
 Read-Only:
 
 - `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--steps--param_bindings--array_value))
+- `expression_ref` (String)
 - `value` (Attributes) (see [below for nested schema](#nestedatt--steps--param_bindings--value))
+- `value_literal` (String)
+- `value_reference` (String)
+- `values` (List of String)
 
 <a id="nestedatt--steps--param_bindings--array_value"></a>
 ### Nested Schema for `steps.param_bindings.array_value`

--- a/docs/resources/alert_route.md
+++ b/docs/resources/alert_route.md
@@ -319,7 +319,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--alert_sources--condition_groups--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--alert_sources--condition_groups--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--alert_sources--condition_groups--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `alert_sources.condition_groups.conditions.param_bindings.array_value`
@@ -365,7 +369,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--condition_groups--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--condition_groups--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--condition_groups--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `condition_groups.conditions.param_bindings.array_value`
@@ -414,7 +422,11 @@ Optional:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--escalation_config--escalation_targets--escalation_paths--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--escalation_config--escalation_targets--escalation_paths--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--escalation_config--escalation_targets--escalation_paths--array_value"></a>
 ### Nested Schema for `escalation_config.escalation_targets.escalation_paths.array_value`
@@ -441,7 +453,11 @@ Optional:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--escalation_config--escalation_targets--users--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--escalation_config--escalation_targets--users--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--escalation_config--escalation_targets--users--array_value"></a>
 ### Nested Schema for `escalation_config.escalation_targets.users.array_value`
@@ -544,7 +560,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--expressions--operations--branches--branches--condition_groups--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--expressions--operations--branches--branches--condition_groups--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--expressions--operations--branches--branches--condition_groups--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `expressions.operations.branches.branches.condition_groups.conditions.param_bindings.array_value`
@@ -573,7 +593,11 @@ Optional:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--expressions--operations--branches--branches--result--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--expressions--operations--branches--branches--result--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--expressions--operations--branches--branches--result--array_value"></a>
 ### Nested Schema for `expressions.operations.branches.branches.result.array_value`
@@ -659,7 +683,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--expressions--operations--filter--condition_groups--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--expressions--operations--filter--condition_groups--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--expressions--operations--filter--condition_groups--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `expressions.operations.filter.condition_groups.conditions.param_bindings.array_value`
@@ -723,7 +751,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--expressions--else_branch--result--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--expressions--else_branch--result--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--expressions--else_branch--result--array_value"></a>
 ### Nested Schema for `expressions.else_branch.result.array_value`
@@ -793,7 +825,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--incident_config--condition_groups--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--incident_config--condition_groups--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--incident_config--condition_groups--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `incident_config.condition_groups.conditions.param_bindings.array_value`
@@ -911,7 +947,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--incident_config--template--custom_fields--binding--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--incident_config--template--custom_fields--binding--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--incident_config--template--custom_fields--binding--array_value"></a>
 ### Nested Schema for `incident_config.template.custom_fields.binding.array_value`
@@ -939,7 +979,11 @@ Optional:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--incident_config--template--incident_mode--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--incident_config--template--incident_mode--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--incident_config--template--incident_mode--array_value"></a>
 ### Nested Schema for `incident_config.template.incident_mode.array_value`
@@ -966,7 +1010,11 @@ Optional:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--incident_config--template--incident_type--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--incident_config--template--incident_type--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--incident_config--template--incident_type--array_value"></a>
 ### Nested Schema for `incident_config.template.incident_type.array_value`
@@ -1004,7 +1052,11 @@ Optional:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--incident_config--template--severity--binding--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--incident_config--template--severity--binding--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--incident_config--template--severity--binding--array_value"></a>
 ### Nested Schema for `incident_config.template.severity.binding.array_value`
@@ -1032,7 +1084,11 @@ Optional:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--incident_config--template--start_in_triage--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--incident_config--template--start_in_triage--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--incident_config--template--start_in_triage--array_value"></a>
 ### Nested Schema for `incident_config.template.start_in_triage.array_value`
@@ -1089,7 +1145,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--channel_config--condition_groups--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--channel_config--condition_groups--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--channel_config--condition_groups--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `channel_config.condition_groups.conditions.param_bindings.array_value`
@@ -1126,7 +1186,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--channel_config--ms_teams_targets--binding--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--channel_config--ms_teams_targets--binding--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--channel_config--ms_teams_targets--binding--array_value"></a>
 ### Nested Schema for `channel_config.ms_teams_targets.binding.array_value`
@@ -1162,7 +1226,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--channel_config--slack_targets--binding--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--channel_config--slack_targets--binding--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--channel_config--slack_targets--binding--array_value"></a>
 ### Nested Schema for `channel_config.slack_targets.binding.array_value`
@@ -1303,7 +1371,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--incident_template--custom_fields--binding--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--incident_template--custom_fields--binding--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--incident_template--custom_fields--binding--array_value"></a>
 ### Nested Schema for `incident_template.custom_fields.binding.array_value`
@@ -1331,7 +1403,11 @@ Optional:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--incident_template--incident_mode--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--incident_template--incident_mode--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--incident_template--incident_mode--array_value"></a>
 ### Nested Schema for `incident_template.incident_mode.array_value`
@@ -1358,7 +1434,11 @@ Optional:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--incident_template--incident_type--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--incident_template--incident_type--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--incident_template--incident_type--array_value"></a>
 ### Nested Schema for `incident_template.incident_type.array_value`
@@ -1396,7 +1476,11 @@ Optional:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--incident_template--severity--binding--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--incident_template--severity--binding--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--incident_template--severity--binding--array_value"></a>
 ### Nested Schema for `incident_template.severity.binding.array_value`
@@ -1424,7 +1508,11 @@ Optional:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--incident_template--start_in_triage--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--incident_template--start_in_triage--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--incident_template--start_in_triage--array_value"></a>
 ### Nested Schema for `incident_template.start_in_triage.array_value`
@@ -1451,7 +1539,11 @@ Optional:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--incident_template--workspace--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--incident_template--workspace--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--incident_template--workspace--array_value"></a>
 ### Nested Schema for `incident_template.workspace.array_value`
@@ -1515,7 +1607,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--message_config--destinations--condition_groups--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--message_config--destinations--condition_groups--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--message_config--destinations--condition_groups--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `message_config.destinations.condition_groups.conditions.param_bindings.array_value`
@@ -1556,7 +1652,11 @@ Optional:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--message_config--destinations--ms_teams_targets--binding--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--message_config--destinations--ms_teams_targets--binding--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--message_config--destinations--ms_teams_targets--binding--array_value"></a>
 ### Nested Schema for `message_config.destinations.ms_teams_targets.binding.array_value`
@@ -1596,7 +1696,11 @@ Optional:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--message_config--destinations--slack_targets--binding--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--message_config--destinations--slack_targets--binding--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--message_config--destinations--slack_targets--binding--array_value"></a>
 ### Nested Schema for `message_config.destinations.slack_targets.binding.array_value`
@@ -1625,7 +1729,11 @@ Optional:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--message_config--template--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--message_config--template--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--message_config--template--array_value"></a>
 ### Nested Schema for `message_config.template.array_value`
@@ -1653,7 +1761,11 @@ Optional:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--message_template--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--message_template--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--message_template--array_value"></a>
 ### Nested Schema for `message_template.array_value`

--- a/docs/resources/alert_source.md
+++ b/docs/resources/alert_source.md
@@ -283,7 +283,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--template--expressions--operations--branches--branches--condition_groups--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--template--expressions--operations--branches--branches--condition_groups--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--template--expressions--operations--branches--branches--condition_groups--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `template.expressions.operations.branches.branches.condition_groups.conditions.param_bindings.array_value`
@@ -312,7 +316,11 @@ Optional:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--template--expressions--operations--branches--branches--result--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--template--expressions--operations--branches--branches--result--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--template--expressions--operations--branches--branches--result--array_value"></a>
 ### Nested Schema for `template.expressions.operations.branches.branches.result.array_value`
@@ -398,7 +406,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--template--expressions--operations--filter--condition_groups--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--template--expressions--operations--filter--condition_groups--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--template--expressions--operations--filter--condition_groups--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `template.expressions.operations.filter.condition_groups.conditions.param_bindings.array_value`
@@ -462,7 +474,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--template--expressions--else_branch--result--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--template--expressions--else_branch--result--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--template--expressions--else_branch--result--array_value"></a>
 ### Nested Schema for `template.expressions.else_branch.result.array_value`
@@ -500,7 +516,11 @@ Optional:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--template--visible_to_teams--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--template--visible_to_teams--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--template--visible_to_teams--array_value"></a>
 ### Nested Schema for `template.visible_to_teams.array_value`

--- a/docs/resources/escalation_path.md
+++ b/docs/resources/escalation_path.md
@@ -262,7 +262,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.conditions.param_bindings.array_value`
@@ -357,7 +361,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.conditions.param_bindings.array_value`
@@ -452,7 +460,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
@@ -547,7 +559,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
@@ -642,7 +658,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
@@ -1104,7 +1124,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
@@ -1659,7 +1683,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
@@ -1754,7 +1782,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
@@ -2216,7 +2248,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
@@ -2864,7 +2900,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
@@ -2959,7 +2999,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
@@ -3054,7 +3098,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
@@ -3516,7 +3564,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
@@ -4071,7 +4123,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
@@ -4166,7 +4222,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
@@ -4628,7 +4688,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
@@ -5369,7 +5433,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.conditions.param_bindings.array_value`
@@ -5464,7 +5532,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
@@ -5559,7 +5631,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
@@ -5654,7 +5730,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
@@ -6116,7 +6196,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
@@ -6671,7 +6755,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
@@ -6766,7 +6854,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
@@ -7228,7 +7320,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
@@ -7876,7 +7972,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
@@ -7971,7 +8071,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
@@ -8066,7 +8170,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
@@ -8528,7 +8636,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
@@ -9083,7 +9195,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
@@ -9178,7 +9294,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
@@ -9640,7 +9760,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.conditions.param_bindings.array_value`

--- a/docs/resources/maintenance_window.md
+++ b/docs/resources/maintenance_window.md
@@ -98,7 +98,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--alert_condition_groups--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--alert_condition_groups--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--alert_condition_groups--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `alert_condition_groups.conditions.param_bindings.array_value`
@@ -135,7 +139,11 @@ Optional:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--escalation_targets--escalation_paths--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--escalation_targets--escalation_paths--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--escalation_targets--escalation_paths--array_value"></a>
 ### Nested Schema for `escalation_targets.escalation_paths.array_value`
@@ -162,7 +170,11 @@ Optional:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--escalation_targets--users--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--escalation_targets--users--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--escalation_targets--users--array_value"></a>
 ### Nested Schema for `escalation_targets.users.array_value`

--- a/docs/resources/workflow.md
+++ b/docs/resources/workflow.md
@@ -654,7 +654,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--condition_groups--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--condition_groups--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--condition_groups--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `condition_groups.conditions.param_bindings.array_value`
@@ -745,7 +749,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--expressions--operations--branches--branches--condition_groups--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--expressions--operations--branches--branches--condition_groups--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--expressions--operations--branches--branches--condition_groups--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `expressions.operations.branches.branches.condition_groups.conditions.param_bindings.array_value`
@@ -774,7 +782,11 @@ Optional:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--expressions--operations--branches--branches--result--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--expressions--operations--branches--branches--result--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--expressions--operations--branches--branches--result--array_value"></a>
 ### Nested Schema for `expressions.operations.branches.branches.result.array_value`
@@ -860,7 +872,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--expressions--operations--filter--condition_groups--conditions--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--expressions--operations--filter--condition_groups--conditions--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--expressions--operations--filter--condition_groups--conditions--param_bindings--array_value"></a>
 ### Nested Schema for `expressions.operations.filter.condition_groups.conditions.param_bindings.array_value`
@@ -924,7 +940,11 @@ Required:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--expressions--else_branch--result--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--expressions--else_branch--result--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--expressions--else_branch--result--array_value"></a>
 ### Nested Schema for `expressions.else_branch.result.array_value`
@@ -966,7 +986,11 @@ Optional:
 Optional:
 
 - `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--steps--param_bindings--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--steps--param_bindings--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
 
 <a id="nestedatt--steps--param_bindings--array_value"></a>
 ### Nested Schema for `steps.param_bindings.array_value`

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.25.0
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-timetypes v0.5.0
+	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.31.0
 	github.com/hashicorp/terraform-plugin-log v0.11.0
 	github.com/hashicorp/terraform-plugin-testing v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -155,6 +155,8 @@ github.com/hashicorp/terraform-plugin-framework v1.19.0 h1:q0bwyhxAOR3vfdgbk9ipl
 github.com/hashicorp/terraform-plugin-framework v1.19.0/go.mod h1:YRXOBu0jvs7xp4AThBbX4mAzYaMJ1JgtFH//oGKxwLc=
 github.com/hashicorp/terraform-plugin-framework-timetypes v0.5.0 h1:v3DapR8gsp3EM8fKMh6up9cJUFQ2iRaFsYLP8UJnCco=
 github.com/hashicorp/terraform-plugin-framework-timetypes v0.5.0/go.mod h1:c3PnGE9pHBDfdEVG9t1S1C9ia5LW+gkFR0CygXlM8ak=
+github.com/hashicorp/terraform-plugin-framework-validators v0.19.0 h1:Zz3iGgzxe/1XBkooZCewS0nJAaCFPFPHdNJd8FgE4Ow=
+github.com/hashicorp/terraform-plugin-framework-validators v0.19.0/go.mod h1:GBKTNGbGVJohU03dZ7U8wHqc2zYnMUawgCN+gC0itLc=
 github.com/hashicorp/terraform-plugin-go v0.31.0 h1:0Fz2r9DQ+kNNl6bx8HRxFd1TfMKUvnrOtvJPmp3Z0q8=
 github.com/hashicorp/terraform-plugin-go v0.31.0/go.mod h1:A88bDhd/cW7FnwqxQRz3slT+QY6yzbHKc6AOTtmdeS8=
 github.com/hashicorp/terraform-plugin-log v0.11.0 h1:WjhcpZIVqP8YRe83+dIZXncwSgtu4vh27i23G33PUQY=

--- a/internal/provider/escalation_path_binding_spelling_test.go
+++ b/internal/provider/escalation_path_binding_spelling_test.go
@@ -1,0 +1,88 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/incident-io/terraform-provider-incident/v6/internal/client"
+	"github.com/incident-io/terraform-provider-incident/v6/internal/provider/jsontypes"
+	"github.com/incident-io/terraform-provider-incident/v6/internal/provider/models"
+)
+
+// A path is held as a types.List, so keeping a condition's binding spelling means decoding the
+// prior state back into nodes. This covers that decode and the reconciliation it feeds: without
+// either, a config writing `value_literal` under if_else fails the apply as an inconsistent
+// result.
+func TestEscalationPathKeepsAConditionsBindingSpelling(t *testing.T) {
+	ctx := context.Background()
+	r := &IncidentEscalationPathResource{}
+	var diags diag.Diagnostics
+
+	ep := client.EscalationPathV2{
+		Id:   "01ABC",
+		Name: "Paged by severity",
+		Path: []client.EscalationPathNodeV2{
+			{
+				Id:   "node-if-else",
+				Type: client.EscalationPathNodeV2TypeIfElse,
+				IfElse: &client.EscalationPathNodeIfElseV2{
+					Conditions: []client.ConditionV2{
+						{
+							Subject:   client.ConditionSubjectV2{Reference: "incident.severity"},
+							Operation: client.ConditionOperationV2{Value: "is"},
+							ParamBindings: []client.EngineParamBindingV2{
+								{Value: &client.EngineParamBindingValueV2{Literal: lo.ToPtr("high")}},
+							},
+						},
+					},
+					ThenPath: []client.EscalationPathNodeV2{{
+						Id:    "node-then",
+						Type:  client.EscalationPathNodeV2TypeLevel,
+						Level: &client.EscalationPathNodeLevelV2{},
+					}},
+					ElsePath: []client.EscalationPathNodeV2{{
+						Id:    "node-else",
+						Type:  client.EscalationPathNodeV2TypeLevel,
+						Level: &client.EscalationPathNodeLevelV2{},
+					}},
+				},
+			},
+		},
+	}
+
+	onImport := r.buildModel(ctx, ep, nil, &diags)
+	require.False(t, diags.HasError(), "buildModel: %#v", diags)
+
+	nodes := priorPathNodes(ctx, onImport.Path, pathSchemaDepth)
+	require.Len(t, nodes, 1, "the prior state has to decode back into nodes")
+	require.NotNil(t, nodes[0].IfElse)
+	require.Len(t, nodes[0].IfElse.Conditions, 1)
+
+	// Stand in for a config that wrote the shorthand rather than the long form.
+	nodes[0].IfElse.Conditions[0].ParamBindings = models.IncidentEngineParamBindings{
+		{ValueLiteral: jsontypes.NewNormalizedJSONOrStringValue("high")},
+	}
+	prior := &IncidentEscalationPathResourceModel{
+		Path: types.ListValueMust(
+			types.ObjectType{AttrTypes: nodeAttrTypes(pathSchemaDepth)},
+			lo.Map(nodes, func(node IncidentEscalationPathNode, _ int) attr.Value {
+				return nodeToObject(ctx, node, pathSchemaDepth, &diags)
+			}),
+		),
+	}
+
+	reread := priorPathNodes(ctx, r.buildModel(ctx, ep, prior, &diags).Path, pathSchemaDepth)
+	require.False(t, diags.HasError(), "buildModel with a prior: %#v", diags)
+	require.Len(t, reread, 1)
+
+	binding := reread[0].IfElse.Conditions[0].ParamBindings[0]
+	assert.Equal(t, "high", binding.ValueLiteral.ValueString(), "should keep the shorthand")
+	assert.Nil(t, binding.Value, "and not also report the long form")
+}

--- a/internal/provider/escalation_path_reassignment_test.go
+++ b/internal/provider/escalation_path_reassignment_test.go
@@ -54,7 +54,7 @@ func TestEscalationPathReassignmentRoundTrip(t *testing.T) {
 	}
 
 	var diags diag.Diagnostics
-	model := r.buildModel(ctx, ep, &diags)
+	model := r.buildModel(ctx, ep, nil, &diags)
 	if diags.HasError() {
 		t.Fatalf("buildModel produced errors: %#v", diags)
 	}

--- a/internal/provider/incident_alert_source_resource.go
+++ b/internal/provider/incident_alert_source_resource.go
@@ -702,7 +702,7 @@ func (r *IncidentAlertSourceResource) Create(ctx context.Context, req resource.C
 	planAutoResolveIncidentAlerts := data.AutoResolveIncidentAlerts
 	planEmailOptions := data.EmailOptions
 
-	data = models.AlertSourceResourceModel{}.FromAPI(result.JSON200.AlertSource)
+	data = models.AlertSourceResourceModel{}.FromAPIWithPlan(result.JSON200.AlertSource, &data)
 
 	// When auto_resolve_timeout_minutes isn't set, the API ignores
 	// auto_resolve_incident_alerts and won't return it. Preserve the
@@ -751,7 +751,7 @@ func (r *IncidentAlertSourceResource) Read(ctx context.Context, req resource.Rea
 	stateAutoResolveIncidentAlerts := data.AutoResolveIncidentAlerts
 	stateEmailOptions := data.EmailOptions
 
-	data = models.AlertSourceResourceModel{}.FromAPI(result.JSON200.AlertSource)
+	data = models.AlertSourceResourceModel{}.FromAPIWithPlan(result.JSON200.AlertSource, &data)
 
 	// When auto_resolve_timeout_minutes isn't set, the API ignores
 	// auto_resolve_incident_alerts and won't return it. Preserve the
@@ -832,7 +832,7 @@ func (r *IncidentAlertSourceResource) Update(ctx context.Context, req resource.U
 	planAutoResolveIncidentAlerts := data.AutoResolveIncidentAlerts
 	planEmailOptions := data.EmailOptions
 
-	data = models.AlertSourceResourceModel{}.FromAPI(result.JSON200.AlertSource)
+	data = models.AlertSourceResourceModel{}.FromAPIWithPlan(result.JSON200.AlertSource, &data)
 
 	// When auto_resolve_timeout_minutes isn't set, the API ignores
 	// auto_resolve_incident_alerts and won't return it. Preserve the

--- a/internal/provider/incident_escalation_path_data_source.go
+++ b/internal/provider/incident_escalation_path_data_source.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/incident-io/terraform-provider-incident/v6/internal/apischema"
 	"github.com/incident-io/terraform-provider-incident/v6/internal/client"
-	"github.com/incident-io/terraform-provider-incident/v6/internal/provider/jsontypes"
+	"github.com/incident-io/terraform-provider-incident/v6/internal/provider/models"
 )
 
 var (
@@ -360,44 +360,14 @@ func (d *IncidentEscalationPathDataSource) getPathSchema(depth int) schema.Neste
 								Computed:            true,
 								MarkdownDescription: "The logical operation to be applied",
 							},
+							// Shared with the resources, because this data source builds its model
+							// with the resource's buildModel: a shorter attribute list here fails
+							// the read with a value conversion error.
 							"param_bindings": schema.ListNestedAttribute{
 								Computed:            true,
 								MarkdownDescription: apischema.Docstring("ConditionV2", "param_bindings"),
 								NestedObject: schema.NestedAttributeObject{
-									Attributes: map[string]schema.Attribute{
-										"array_value": schema.ListNestedAttribute{
-											Computed:            true,
-											MarkdownDescription: "The array of literal or reference parameter values",
-											NestedObject: schema.NestedAttributeObject{
-												Attributes: map[string]schema.Attribute{
-													"literal": schema.StringAttribute{
-														CustomType:          jsontypes.NormalizedJSONOrStringType{},
-														Computed:            true,
-														MarkdownDescription: apischema.Docstring("EngineParamBindingValueV2", "literal"),
-													},
-													"reference": schema.StringAttribute{
-														Computed:            true,
-														MarkdownDescription: apischema.Docstring("EngineParamBindingValueV2", "reference"),
-													},
-												},
-											},
-										},
-										"value": schema.SingleNestedAttribute{
-											Computed:            true,
-											MarkdownDescription: "The literal or reference parameter value",
-											Attributes: map[string]schema.Attribute{
-												"literal": schema.StringAttribute{
-													CustomType:          jsontypes.NormalizedJSONOrStringType{},
-													Computed:            true,
-													MarkdownDescription: apischema.Docstring("EngineParamBindingValueV2", "literal"),
-												},
-												"reference": schema.StringAttribute{
-													Computed:            true,
-													MarkdownDescription: apischema.Docstring("EngineParamBindingValueV2", "reference"),
-												},
-											},
-										},
-									},
+									Attributes: models.ParamBindingDataSourceAttributes(),
 								},
 							},
 							"subject": schema.StringAttribute{
@@ -491,7 +461,7 @@ func (d *IncidentEscalationPathDataSource) Read(ctx context.Context, req datasou
 
 	// Reuse the resource's buildModel function for consistency
 	resource := &IncidentEscalationPathResource{}
-	modelResp := resource.buildModel(ctx, *escalationPath, &resp.Diagnostics)
+	modelResp := resource.buildModel(ctx, *escalationPath, nil, &resp.Diagnostics)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &modelResp)...)
 }

--- a/internal/provider/incident_escalation_path_data_source_test.go
+++ b/internal/provider/incident_escalation_path_data_source_test.go
@@ -2,11 +2,98 @@ package provider
 
 import (
 	"bytes"
+	"context"
 	"testing"
 	"text/template"
 
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/incident-io/terraform-provider-incident/v6/internal/client"
 )
+
+// TestIncidentEscalationPathDataSourceSchemaMatchesModel guards the seam between the data source
+// schema and IncidentEscalationPathResourceModel, the same way the workflow data source's test
+// does: Read reuses the resource's buildModel, so an attribute the schema forgets fails every
+// escalation path read rather than only the paths using it.
+func TestIncidentEscalationPathDataSourceSchemaMatchesModel(t *testing.T) {
+	ctx := context.Background()
+
+	resp := &datasource.SchemaResponse{}
+	(&IncidentEscalationPathDataSource{}).Schema(ctx, datasource.SchemaRequest{}, resp)
+	require.False(t, resp.Diagnostics.HasError(), "schema: %s", resp.Diagnostics)
+
+	// Everything the API can hand back, so a nested attribute missing from the schema shows up
+	// as an error rather than an untouched null.
+	ep := client.EscalationPathV2{
+		Id:      "01M0TAR6EMNDC7BVA45RZDE5KM",
+		Name:    "Paged by severity",
+		TeamIds: []string{"01G0J1EXE7AXZ2C93K61WBPYEH"},
+		Path: []client.EscalationPathNodeV2{
+			{
+				Id:   "start",
+				Type: client.EscalationPathNodeV2TypeIfElse,
+				IfElse: &client.EscalationPathNodeIfElseV2{
+					Conditions: []client.ConditionV2{
+						{
+							Subject:   client.ConditionSubjectV2{Reference: "incident.severity"},
+							Operation: client.ConditionOperationV2{Value: "one_of"},
+							ParamBindings: []client.EngineParamBindingV2{
+								{ArrayValue: &[]client.EngineParamBindingValueV2{{Literal: lo.ToPtr("high")}}},
+								{Value: &client.EngineParamBindingValueV2{Reference: lo.ToPtr("incident.severity")}},
+							},
+						},
+					},
+					ThenPath: []client.EscalationPathNodeV2{{
+						Id:   "then-level",
+						Type: client.EscalationPathNodeV2TypeLevel,
+						Level: &client.EscalationPathNodeLevelV2{
+							Targets: []client.EscalationPathTargetV2{{
+								Id:      "01G0J1EXE7AXZ2C93K61WBPYEH",
+								Type:    client.EscalationPathTargetV2TypeSchedule,
+								Urgency: client.EscalationPathTargetV2UrgencyHigh,
+							}},
+							TimeToAckSeconds: lo.ToPtr(int64(300)),
+						},
+					}},
+					ElsePath: []client.EscalationPathNodeV2{{
+						Id:    "else-delay",
+						Type:  client.EscalationPathNodeV2TypeDelay,
+						Delay: &client.EscalationPathNodeDelayV2{DelaySeconds: lo.ToPtr(int64(120))},
+					}},
+				},
+			},
+		},
+		WorkingHours: &[]client.WeekdayIntervalConfigV2{{
+			Id:       "UK",
+			Name:     "UK",
+			Timezone: "Europe/London",
+			WeekdayIntervals: []client.WeekdayIntervalV2{
+				{StartTime: "09:00", EndTime: "17:00", Weekday: client.WeekdayIntervalV2WeekdayMonday},
+			},
+		}},
+		RepeatConfig: &client.EscalationPathRepeatConfigV2{
+			RepeatAfterSeconds:    300,
+			DelayRepeatOnActivity: true,
+		},
+	}
+
+	var diags diag.Diagnostics
+	model := (&IncidentEscalationPathResource{}).buildModel(ctx, ep, nil, &diags)
+	require.False(t, diags.HasError(), "buildModel: %s", diags)
+
+	state := tfsdk.State{
+		Schema: resp.Schema,
+		Raw:    tftypes.NewValue(resp.Schema.Type().TerraformType(ctx), nil),
+	}
+	assert.False(t, state.Set(ctx, model).HasError(), "setting state from the resource model")
+}
 
 func TestAccIncidentEscalationPathDataSource(t *testing.T) {
 	resource.Test(t, resource.TestCase{

--- a/internal/provider/incident_escalation_path_resource.go
+++ b/internal/provider/incident_escalation_path_resource.go
@@ -733,7 +733,7 @@ func (r *IncidentEscalationPathResource) Create(ctx context.Context, req resourc
 	claimResource(ctx, r.client, result.JSON201.EscalationPath.Id, &resp.Diagnostics, client.ManagedResourcesCreateManagedResourcePayloadV2ResourceTypeEscalationPath, r.terraformVersion)
 
 	tflog.Trace(ctx, fmt.Sprintf("created an escalation path resource with id=%s", result.JSON201.EscalationPath.Id))
-	data = r.buildModel(ctx, result.JSON201.EscalationPath, &resp.Diagnostics)
+	data = r.buildModel(ctx, result.JSON201.EscalationPath, data, &resp.Diagnostics)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -765,7 +765,7 @@ func (r *IncidentEscalationPathResource) Read(ctx context.Context, req resource.
 		return
 	}
 
-	data = r.buildModel(ctx, result.JSON200.EscalationPath, &resp.Diagnostics)
+	data = r.buildModel(ctx, result.JSON200.EscalationPath, data, &resp.Diagnostics)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -803,7 +803,7 @@ func (r *IncidentEscalationPathResource) Update(ctx context.Context, req resourc
 
 	claimResource(ctx, r.client, result.JSON200.EscalationPath.Id, &resp.Diagnostics, client.ManagedResourcesCreateManagedResourcePayloadV2ResourceTypeEscalationPath, r.terraformVersion)
 
-	data = r.buildModel(ctx, result.JSON200.EscalationPath, &resp.Diagnostics)
+	data = r.buildModel(ctx, result.JSON200.EscalationPath, data, &resp.Diagnostics)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -826,11 +826,18 @@ func (r *IncidentEscalationPathResource) ImportState(ctx context.Context, req re
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
-func (r *IncidentEscalationPathResource) buildModel(ctx context.Context, ep client.EscalationPathV2, diags *diag.Diagnostics) *IncidentEscalationPathResourceModel {
+// buildModel converts the API response into the model. prior is the plan (create/update) or the
+// prior state (read), and nil on import; it lets a condition keep the spelling the config used.
+func (r *IncidentEscalationPathResource) buildModel(ctx context.Context, ep client.EscalationPathV2, prior *IncidentEscalationPathResourceModel, diags *diag.Diagnostics) *IncidentEscalationPathResourceModel {
+	priorPath := types.ListNull(types.ObjectType{AttrTypes: nodeAttrTypes(pathSchemaDepth)})
+	if prior != nil {
+		priorPath = prior.Path
+	}
+
 	return &IncidentEscalationPathResourceModel{
 		ID:           types.StringValue(ep.Id),
 		Name:         types.StringValue(ep.Name),
-		Path:         r.toPathModel(ctx, ep.Path, pathSchemaDepth, diags),
+		Path:         r.toPathModel(ctx, ep.Path, priorPath, pathSchemaDepth, diags),
 		WorkingHours: escalationPathWorkingHoursFromAPI(ctx, ep.WorkingHours, diags),
 		RepeatConfig: escalationPathRepeatConfigFromAPI(ep.RepeatConfig),
 		TeamIDs:      escalationPathTeamIDsFromAPI(ep.TeamIds),
@@ -865,28 +872,73 @@ func targetsFromAPI(ctx context.Context, targets []client.EscalationPathTargetV2
 	return list
 }
 
-func (r *IncidentEscalationPathResource) toPathModel(ctx context.Context, nodes []client.EscalationPathNodeV2, depth int, diags *diag.Diagnostics) types.List {
+// priorPathNodes decodes the prior state back into nodes. Only conditions need the prior, and
+// they live under if_else, which the schema drops at depth 0 — where the struct's own if_else
+// field would fail the decode anyway (see nodeToObject).
+func priorPathNodes(ctx context.Context, prior types.List, depth int) []IncidentEscalationPathNode {
+	if depth == 0 || prior.IsNull() || prior.IsUnknown() {
+		return nil
+	}
+
+	nodes := []IncidentEscalationPathNode{}
+	if prior.ElementsAs(ctx, &nodes, false).HasError() {
+		return nil
+	}
+
+	return nodes
+}
+
+// priorNodeFor matches by ID, falling back to position for a node whose ID the API has only just
+// minted and the plan therefore left unknown.
+func priorNodeFor(priorNodes []IncidentEscalationPathNode, id string, idx int) (IncidentEscalationPathNode, bool) {
+	for _, node := range priorNodes {
+		if node.ID.ValueString() == id {
+			return node, true
+		}
+	}
+
+	if idx < len(priorNodes) {
+		return priorNodes[idx], true
+	}
+
+	return IncidentEscalationPathNode{}, false
+}
+
+func (r *IncidentEscalationPathResource) toPathModel(ctx context.Context, nodes []client.EscalationPathNodeV2, prior types.List, depth int, diags *diag.Diagnostics) types.List {
 	elemType := types.ObjectType{AttrTypes: nodeAttrTypes(depth)}
+	priorNodes := priorPathNodes(ctx, prior, depth)
+	emptyPath := types.ListNull(types.ObjectType{AttrTypes: nodeAttrTypes(depth - 1)})
 
 	out := []IncidentEscalationPathNode{}
-	for _, node := range nodes {
+	for idx, node := range nodes {
+		priorNode, hasPrior := priorNodeFor(priorNodes, node.Id, idx)
+
 		elem := IncidentEscalationPathNode{
 			ID:   types.StringValue(node.Id),
 			Type: types.StringValue(string(node.Type)),
 		}
 		if node.IfElse != nil {
+			conditions := lo.Map(node.IfElse.Conditions, func(cond client.ConditionV2, _ int) models.IncidentEngineCondition {
+				return models.IncidentEngineCondition{
+					Subject:   types.StringValue(cond.Subject.Reference),
+					Operation: types.StringValue(cond.Operation.Value),
+					ParamBindings: lo.Map(cond.ParamBindings, func(pb client.EngineParamBindingV2, _ int) models.IncidentEngineParamBinding {
+						return models.IncidentEngineParamBinding{}.FromAPI(pb)
+					}),
+				}
+			})
+
+			priorThenPath, priorElsePath := emptyPath, emptyPath
+			if hasPrior && priorNode.IfElse != nil {
+				models.IncidentEngineConditions(conditions).
+					ReconcileSpelling(priorNode.IfElse.Conditions)
+				priorThenPath, priorElsePath = priorNode.IfElse.ThenPath, priorNode.IfElse.ElsePath
+			}
+
 			elem.IfElse = &IncidentEscalationPathNodeIfElse{
-				Conditions: lo.Map(node.IfElse.Conditions, func(cond client.ConditionV2, _ int) models.IncidentEngineCondition {
-					return models.IncidentEngineCondition{
-						Subject:   types.StringValue(cond.Subject.Reference),
-						Operation: types.StringValue(cond.Operation.Value),
-						ParamBindings: lo.Map(cond.ParamBindings, func(pb client.EngineParamBindingV2, _ int) models.IncidentEngineParamBinding {
-							return models.IncidentEngineParamBinding{}.FromAPI(pb)
-						}),
-					}
-				}),
-				ThenPath: r.toPathModel(ctx, node.IfElse.ThenPath, depth-1, diags),
-				ElsePath: r.toPathModel(ctx, node.IfElse.ElsePath, depth-1, diags),
+				Conditions: conditions,
+				ThenPath:   r.toPathModel(ctx, node.IfElse.ThenPath, priorThenPath, depth-1, diags),
+				ElsePath:   r.toPathModel(ctx, node.IfElse.ElsePath, priorElsePath, depth-1, diags),
 			}
 		}
 		elem.Level = levelFromAPI(ctx, node.Level, diags)

--- a/internal/provider/incident_escalation_path_roundtrip_test.go
+++ b/internal/provider/incident_escalation_path_roundtrip_test.go
@@ -92,7 +92,7 @@ func TestEscalationPathRoundTrip(t *testing.T) {
 	}
 
 	var diags diag.Diagnostics
-	model := r.buildModel(ctx, ep, &diags)
+	model := r.buildModel(ctx, ep, nil, &diags)
 	if diags.HasError() {
 		t.Fatalf("buildModel produced errors: %#v", diags)
 	}
@@ -182,7 +182,7 @@ func TestEscalationPathRetryConfigRoundTrip(t *testing.T) {
 	}
 
 	var diags diag.Diagnostics
-	model := r.buildModel(ctx, ep, &diags)
+	model := r.buildModel(ctx, ep, nil, &diags)
 	if diags.HasError() {
 		t.Fatalf("buildModel produced errors: %#v", diags)
 	}

--- a/internal/provider/incident_maintenance_window_resource.go
+++ b/internal/provider/incident_maintenance_window_resource.go
@@ -469,7 +469,17 @@ func (r *IncidentMaintenanceWindowResource) buildModel(mw client.MaintenanceWind
 	model.IncidentID = types.StringPointerValue(mw.IncidentId)
 
 	if prior != nil {
-		model.AlertConditionGroups.ReconcileOperations(prior.AlertConditionGroups)
+		model.AlertConditionGroups.ReconcileSpelling(prior.AlertConditionGroups)
+
+		for i := range model.EscalationTargets {
+			if i >= len(prior.EscalationTargets) {
+				break
+			}
+
+			target, priorTarget := &model.EscalationTargets[i], prior.EscalationTargets[i]
+			target.EscalationPaths = models.ReconcileBindingSpelling(target.EscalationPaths, priorTarget.EscalationPaths)
+			target.Users = models.ReconcileBindingSpelling(target.Users, priorTarget.Users)
+		}
 	}
 
 	return model

--- a/internal/provider/models/alert_route_v2_model.go
+++ b/internal/provider/models/alert_route_v2_model.go
@@ -64,7 +64,7 @@ func reconcileAlertSourceOperations(applied, plan []AlertRouteAlertSourceModel) 
 
 	for i := range applied {
 		if planned, ok := planByAlertSourceID[applied[i].AlertSourceID.ValueString()]; ok {
-			applied[i].ConditionGroups.ReconcileOperations(planned.ConditionGroups)
+			applied[i].ConditionGroups.ReconcileSpelling(planned.ConditionGroups)
 		}
 	}
 }
@@ -80,9 +80,62 @@ type AlertRouteChannelConfigModel struct {
 func reconcileChannelConfigOperations(applied, plan []AlertRouteChannelConfigModel) {
 	for i := range applied {
 		if i < len(plan) {
-			applied[i].ConditionGroups.ReconcileOperations(plan[i].ConditionGroups)
+			applied[i].ConditionGroups.ReconcileSpelling(plan[i].ConditionGroups)
+			reconcileChannelTargetSpelling(applied[i].SlackTargets, plan[i].SlackTargets)
+			reconcileChannelTargetSpelling(applied[i].MsTeamsTargets, plan[i].MsTeamsTargets)
 		}
 	}
+}
+
+func reconcileChannelTargetSpelling(applied, plan *AlertRouteChannelTargetModel) {
+	if applied == nil || plan == nil {
+		return
+	}
+
+	applied.Binding = ReconcileBindingSpelling(applied.Binding, plan.Binding)
+}
+
+// reconcileEscalationConfigSpelling falls back to position: escalation targets are a list.
+func reconcileEscalationConfigSpelling(applied, plan *AlertRouteEscalationConfigModel) {
+	if applied == nil || plan == nil {
+		return
+	}
+
+	for i := range applied.EscalationTargets {
+		if i >= len(plan.EscalationTargets) {
+			break
+		}
+
+		target, planned := &applied.EscalationTargets[i], plan.EscalationTargets[i]
+		target.EscalationPaths = ReconcileBindingSpelling(target.EscalationPaths, planned.EscalationPaths)
+		target.Users = ReconcileBindingSpelling(target.Users, planned.Users)
+	}
+}
+
+// reconcileCustomFieldSpelling correlates by ID, not position: custom_fields is a set.
+func reconcileCustomFieldSpelling(applied, plan []AlertRouteCustomFieldModel) {
+	planByCustomFieldID := map[string]AlertRouteCustomFieldModel{}
+	for _, field := range plan {
+		planByCustomFieldID[field.CustomFieldID.ValueString()] = field
+	}
+
+	for i := range applied {
+		if planned, ok := planByCustomFieldID[applied[i].CustomFieldID.ValueString()]; ok {
+			applied[i].Binding = ReconcileBindingSpelling(applied[i].Binding, planned.Binding)
+		}
+	}
+}
+
+func reconcileIncidentTemplateSpelling(applied, plan *AlertRouteIncidentTemplateModel) {
+	if applied == nil || plan == nil {
+		return
+	}
+
+	applied.IncidentMode = ReconcileBindingSpelling(applied.IncidentMode, plan.IncidentMode)
+	applied.IncidentType = ReconcileBindingSpelling(applied.IncidentType, plan.IncidentType)
+	applied.StartInTriage = ReconcileBindingSpelling(applied.StartInTriage, plan.StartInTriage)
+	applied.Workspace = ReconcileBindingSpelling(applied.Workspace, plan.Workspace)
+	reconcileCustomFieldSpelling(applied.CustomFields, plan.CustomFields)
 }
 
 type AlertRouteChannelTargetModel struct {
@@ -243,32 +296,12 @@ type AlertRouteSeverityModel struct {
 	Binding       *IncidentEngineParamBinding `tfsdk:"binding"`
 }
 
-// SeverityBindingAttrTypes returns the attribute types for the severity binding nested object.
-func SeverityBindingAttrTypes() map[string]attr.Type {
-	return map[string]attr.Type{
-		"array_value": types.ListType{
-			ElemType: types.ObjectType{
-				AttrTypes: map[string]attr.Type{
-					"literal":   jsontypes.NormalizedJSONOrStringType{},
-					"reference": types.StringType,
-				},
-			},
-		},
-		"value": types.ObjectType{
-			AttrTypes: map[string]attr.Type{
-				"literal":   jsontypes.NormalizedJSONOrStringType{},
-				"reference": types.StringType,
-			},
-		},
-	}
-}
-
 // SeverityAttrTypes returns the attribute types for the severity object.
 func SeverityAttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
 		"merge_strategy": types.StringType,
 		"binding": types.ObjectType{
-			AttrTypes: SeverityBindingAttrTypes(),
+			AttrTypes: ParamBindingAttrTypes(),
 		},
 	}
 }
@@ -278,94 +311,27 @@ func SeverityObjectNull() types.Object {
 	return types.ObjectNull(SeverityAttrTypes())
 }
 
-// SeverityFromAPI converts an API severity response to a types.Object.
-// If planSeverity is provided and is null, we preserve the null to avoid drift
-// when the user hasn't configured severity but the API returns defaults.
-func SeverityFromAPI(severity *client.AlertRouteSeverityBindingV2) types.Object {
+// SeverityFromAPI converts an API severity response to a types.Object. plan is the planned
+// severity, so the binding can keep the spelling the config used.
+func SeverityFromAPI(severity *client.AlertRouteSeverityBindingV2, plan types.Object) types.Object {
 	if severity == nil {
 		return SeverityObjectNull()
 	}
 
-	// Build the binding object
-	var bindingObj types.Object
+	binding := types.ObjectNull(ParamBindingAttrTypes())
 	if severity.Binding != nil {
-		binding := IncidentEngineParamBinding{}.FromAPI(*severity.Binding)
-
-		// Build array_value list
-		var arrayValueList types.List
-		if len(binding.ArrayValue) > 0 {
-			arrayValues := make([]attr.Value, len(binding.ArrayValue))
-			for i, v := range binding.ArrayValue {
-				valueObj, _ := types.ObjectValue(
-					map[string]attr.Type{
-						"literal":   jsontypes.NormalizedJSONOrStringType{},
-						"reference": types.StringType,
-					},
-					map[string]attr.Value{
-						"literal":   v.Literal,
-						"reference": v.Reference,
-					},
-				)
-				arrayValues[i] = valueObj
-			}
-			arrayValueList, _ = types.ListValue(
-				types.ObjectType{
-					AttrTypes: map[string]attr.Type{
-						"literal":   jsontypes.NormalizedJSONOrStringType{},
-						"reference": types.StringType,
-					},
-				},
-				arrayValues,
-			)
-		} else {
-			arrayValueList = types.ListNull(types.ObjectType{
-				AttrTypes: map[string]attr.Type{
-					"literal":   jsontypes.NormalizedJSONOrStringType{},
-					"reference": types.StringType,
-				},
-			})
+		applied := IncidentEngineParamBinding{}.FromAPI(*severity.Binding)
+		if !plan.IsNull() && !plan.IsUnknown() {
+			prior := ParamBindingFromObject(plan.Attributes()["binding"])
+			applied = applied.ReconcileSpelling(prior)
 		}
-
-		// Build value object
-		var valueObj types.Object
-		if binding.Value != nil {
-			valueObj, _ = types.ObjectValue(
-				map[string]attr.Type{
-					"literal":   jsontypes.NormalizedJSONOrStringType{},
-					"reference": types.StringType,
-				},
-				map[string]attr.Value{
-					"literal":   binding.Value.Literal,
-					"reference": binding.Value.Reference,
-				},
-			)
-		} else {
-			valueObj = types.ObjectNull(map[string]attr.Type{
-				"literal":   jsontypes.NormalizedJSONOrStringType{},
-				"reference": types.StringType,
-			})
-		}
-
-		bindingObj, _ = types.ObjectValue(
-			SeverityBindingAttrTypes(),
-			map[string]attr.Value{
-				"array_value": arrayValueList,
-				"value":       valueObj,
-			},
-		)
-	} else {
-		bindingObj = types.ObjectNull(SeverityBindingAttrTypes())
+		binding = applied.ToObject()
 	}
 
-	severityObj, _ := types.ObjectValue(
-		SeverityAttrTypes(),
-		map[string]attr.Value{
-			"merge_strategy": types.StringValue(string(severity.MergeStrategy)),
-			"binding":        bindingObj,
-		},
-	)
-
-	return severityObj
+	return types.ObjectValueMust(SeverityAttrTypes(), map[string]attr.Value{
+		"merge_strategy": types.StringValue(string(severity.MergeStrategy)),
+		"binding":        binding,
+	})
 }
 
 // SeverityToPayload extracts severity data from types.Object and converts to API payload.
@@ -604,7 +570,11 @@ func (AlertRouteResourceModel) FromAPIV2WithPlan(apiModel client.AlertRouteV2, p
 
 	result.IncidentTemplate.Summary = &summaryBinding
 
-	result.IncidentTemplate.Severity = SeverityFromAPI(apiModel.IncidentTemplate.Severity)
+	planSeverity := SeverityObjectNull()
+	if plan != nil && plan.IncidentTemplate != nil {
+		planSeverity = plan.IncidentTemplate.Severity
+	}
+	result.IncidentTemplate.Severity = SeverityFromAPI(apiModel.IncidentTemplate.Severity, planSeverity)
 
 	if apiModel.IncidentTemplate.IncidentMode != nil && apiModel.IncidentTemplate.IncidentMode.Binding != nil {
 		binding := IncidentEngineParamBinding{}.FromAPI(*apiModel.IncidentTemplate.IncidentMode.Binding)
@@ -675,13 +645,16 @@ func (AlertRouteResourceModel) FromAPIV2WithPlan(apiModel client.AlertRouteV2, p
 	}
 
 	if plan != nil {
-		result.ConditionGroups.ReconcileOperations(plan.ConditionGroups)
+		result.ConditionGroups.ReconcileSpelling(plan.ConditionGroups)
 		reconcileAlertSourceOperations(result.AlertSources, plan.AlertSources)
 		reconcileChannelConfigOperations(result.ChannelConfig, plan.ChannelConfig)
 		if result.IncidentConfig != nil && plan.IncidentConfig != nil {
-			result.IncidentConfig.ConditionGroups.ReconcileOperations(plan.IncidentConfig.ConditionGroups)
+			result.IncidentConfig.ConditionGroups.ReconcileSpelling(plan.IncidentConfig.ConditionGroups)
 		}
-		result.Expressions.ReconcileOperations(plan.Expressions)
+		result.Expressions.ReconcileSpelling(plan.Expressions)
+		result.MessageTemplate = ReconcileBindingSpelling(result.MessageTemplate, plan.MessageTemplate)
+		reconcileEscalationConfigSpelling(result.EscalationConfig, plan.EscalationConfig)
+		reconcileIncidentTemplateSpelling(result.IncidentTemplate, plan.IncidentTemplate)
 	}
 
 	return result

--- a/internal/provider/models/alert_route_v3_model.go
+++ b/internal/provider/models/alert_route_v3_model.go
@@ -122,9 +122,19 @@ type AlertRouteV3ChannelConfigModel struct {
 func reconcileDestinationOperations(applied, plan []AlertRouteV3ChannelConfigModel) {
 	for i := range applied {
 		if i < len(plan) {
-			applied[i].ConditionGroups.ReconcileOperations(plan[i].ConditionGroups)
+			applied[i].ConditionGroups.ReconcileSpelling(plan[i].ConditionGroups)
+			reconcileV3ChannelTargetSpelling(applied[i].SlackTargets, plan[i].SlackTargets)
+			reconcileV3ChannelTargetSpelling(applied[i].MsTeamsTargets, plan[i].MsTeamsTargets)
 		}
 	}
+}
+
+func reconcileV3ChannelTargetSpelling(applied, plan *AlertRouteV3ChannelTargetModel) {
+	if applied == nil || plan == nil {
+		return
+	}
+
+	applied.Binding = ReconcileBindingSpelling(applied.Binding, plan.Binding)
 }
 
 type AlertRouteV3ChannelTargetModel struct {
@@ -187,12 +197,12 @@ func expressionsToV3Payload(expressions IncidentEngineExpressions) []client.Expr
 
 // severityFromAPIV3 reuses the v2 severity reconciliation logic by converting
 // the v3 severity binding (structurally identical) to its v2 form.
-func severityFromAPIV3(severity *client.AlertRouteSeverityBindingV3) types.Object {
+func severityFromAPIV3(severity *client.AlertRouteSeverityBindingV3, plan types.Object) types.Object {
 	if severity == nil {
 		return SeverityObjectNull()
 	}
 
-	return SeverityFromAPI(convertEngineType[*client.AlertRouteSeverityBindingV2](severity))
+	return SeverityFromAPI(convertEngineType[*client.AlertRouteSeverityBindingV2](severity), plan)
 }
 
 func severityToPayloadV3(ctx context.Context, severityObj types.Object) *client.AlertRouteSeverityBindingPayloadV3 {
@@ -399,15 +409,19 @@ func (AlertRouteResourceModel) FromAPIV3WithPlan(apiModel client.AlertRouteV3, p
 	}
 
 	if plan != nil {
-		result.ConditionGroups.ReconcileOperations(plan.ConditionGroups)
+		result.ConditionGroups.ReconcileSpelling(plan.ConditionGroups)
 		reconcileAlertSourceOperations(result.AlertSources, plan.AlertSources)
 		if plan.MessageConfig != nil {
 			reconcileDestinationOperations(result.MessageConfig.Destinations, plan.MessageConfig.Destinations)
 		}
 		if result.IncidentConfig != nil && plan.IncidentConfig != nil {
-			result.IncidentConfig.ConditionGroups.ReconcileOperations(plan.IncidentConfig.ConditionGroups)
+			result.IncidentConfig.ConditionGroups.ReconcileSpelling(plan.IncidentConfig.ConditionGroups)
 		}
-		result.Expressions.ReconcileOperations(plan.Expressions)
+		result.Expressions.ReconcileSpelling(plan.Expressions)
+		if result.MessageConfig != nil && plan.MessageConfig != nil {
+			result.MessageConfig.Template = ReconcileBindingSpelling(result.MessageConfig.Template, plan.MessageConfig.Template)
+		}
+		reconcileEscalationConfigSpelling(result.EscalationConfig, plan.EscalationConfig)
 	}
 
 	return result
@@ -462,7 +476,11 @@ func incidentTemplateFromAPIV3(apiTemplate *client.AlertRouteIncidentTemplateV3,
 	}
 	template.Summary = &summaryBinding
 
-	template.Severity = severityFromAPIV3(apiTemplate.Severity)
+	planSeverity := SeverityObjectNull()
+	if plan != nil {
+		planSeverity = plan.Severity
+	}
+	template.Severity = severityFromAPIV3(apiTemplate.Severity, planSeverity)
 
 	if apiTemplate.IncidentMode != nil && apiTemplate.IncidentMode.Binding != nil {
 		binding := paramBindingFromV3(*apiTemplate.IncidentMode.Binding)
@@ -519,6 +537,13 @@ func incidentTemplateFromAPIV3(apiTemplate *client.AlertRouteIncidentTemplateV3,
 	// nil so an omitted optional stays null and doesn't produce drift.
 	if len(template.CustomFields) == 0 && plan != nil && plan.CustomFields != nil {
 		template.CustomFields = []AlertRouteCustomFieldModel{}
+	}
+
+	if plan != nil {
+		template.IncidentMode = ReconcileBindingSpelling(template.IncidentMode, plan.IncidentMode)
+		template.IncidentType = ReconcileBindingSpelling(template.IncidentType, plan.IncidentType)
+		template.StartInTriage = ReconcileBindingSpelling(template.StartInTriage, plan.StartInTriage)
+		reconcileCustomFieldSpelling(template.CustomFields, plan.CustomFields)
 	}
 
 	return template

--- a/internal/provider/models/alert_source_v1_model.go
+++ b/internal/provider/models/alert_source_v1_model.go
@@ -30,6 +30,12 @@ type AlertSourceResourceModel struct {
 }
 
 func (AlertSourceResourceModel) FromAPI(source client.AlertSourceV2) AlertSourceResourceModel {
+	return AlertSourceResourceModel{}.FromAPIWithPlan(source, nil)
+}
+
+// FromAPIWithPlan is FromAPI with the planned value to hand, so the template's expressions and
+// bindings keep the spelling the config used. plan is nil on import.
+func (AlertSourceResourceModel) FromAPIWithPlan(source client.AlertSourceV2, plan *AlertSourceResourceModel) AlertSourceResourceModel {
 	var emailAddress *string
 	if source.EmailOptions != nil {
 		emailAddress = &source.EmailOptions.EmailAddress
@@ -50,7 +56,7 @@ func (AlertSourceResourceModel) FromAPI(source client.AlertSourceV2) AlertSource
 		owningTeamIDs, _ = types.SetValue(types.StringType, teamIDValues)
 	}
 
-	return AlertSourceResourceModel{
+	result := AlertSourceResourceModel{
 		ID:             types.StringValue(source.Id),
 		Name:           types.StringValue(source.Name),
 		SourceType:     types.StringValue(string(source.SourceType)),
@@ -74,6 +80,14 @@ func (AlertSourceResourceModel) FromAPI(source client.AlertSourceV2) AlertSource
 		AutoResolveTimeoutMinutes: types.Int64PointerValue(source.AutoResolveTimeoutMinutes),
 		AutoResolveIncidentAlerts: types.BoolPointerValue(source.AutoResolveIncidentAlerts),
 	}
+
+	if plan != nil && plan.Template != nil {
+		result.Template.Expressions.ReconcileSpelling(plan.Template.Expressions)
+		result.Template.VisibleToTeams = ReconcileBindingSpelling(
+			result.Template.VisibleToTeams, plan.Template.VisibleToTeams)
+	}
+
+	return result
 }
 
 type AlertTemplateModel struct {

--- a/internal/provider/models/binding_sugar_test.go
+++ b/internal/provider/models/binding_sugar_test.go
@@ -1,0 +1,236 @@
+package models
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/incident-io/terraform-provider-incident/v6/internal/client"
+	"github.com/incident-io/terraform-provider-incident/v6/internal/provider/jsontypes"
+)
+
+func literal(s string) jsontypes.NormalizedJSONOrString {
+	return jsontypes.NewNormalizedJSONOrStringValue(s)
+}
+
+// Each shorthand has to fold onto exactly the payload its long form produces, or the two
+// spellings would mean different things to the API.
+func TestParamBindingShorthandsResolveToTheLongForm(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		shorthand IncidentEngineParamBinding
+		longForm  IncidentEngineParamBinding
+	}{
+		{
+			name:      "value_literal",
+			shorthand: IncidentEngineParamBinding{ValueLiteral: literal("high")},
+			longForm: IncidentEngineParamBinding{Value: &IncidentEngineParamBindingValue{
+				Literal: literal("high"), Reference: types.StringNull(),
+			}},
+		},
+		{
+			name:      "value_reference",
+			shorthand: IncidentEngineParamBinding{ValueReference: types.StringValue("incident.url")},
+			longForm: IncidentEngineParamBinding{Value: &IncidentEngineParamBindingValue{
+				Literal: jsontypes.NewNormalizedJSONOrStringNull(), Reference: types.StringValue("incident.url"),
+			}},
+		},
+		{
+			name:      "expression_ref",
+			shorthand: IncidentEngineParamBinding{ExpressionRef: types.StringValue("team")},
+			longForm: IncidentEngineParamBinding{Value: &IncidentEngineParamBindingValue{
+				Literal:   jsontypes.NewNormalizedJSONOrStringNull(),
+				Reference: types.StringValue(`expressions["team"]`),
+			}},
+		},
+		{
+			name:      "values",
+			shorthand: IncidentEngineParamBinding{Values: []jsontypes.NormalizedJSONOrString{literal("a"), literal("b")}},
+			longForm: IncidentEngineParamBinding{ArrayValue: []IncidentEngineParamBindingValue{
+				{Literal: literal("a"), Reference: types.StringNull()},
+				{Literal: literal("b"), Reference: types.StringNull()},
+			}},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.longForm.resolved(), tc.shorthand.resolved(),
+				"the shorthand and its long form must resolve identically")
+			assert.Equal(t, tc.longForm.ToPayload(), tc.shorthand.ToPayload(),
+				"and so must reach the API as the same payload")
+		})
+	}
+}
+
+// FromAPI never sets a shorthand, and leaving them at the Go zero value has to mean null: every
+// null check in resolved, IsEmpty and the reconciliation reads a binding the API just built.
+// The framework picks ValueStateNull as 0 to make that so, and this pins it.
+func TestFromAPILeavesTheShorthandsNull(t *testing.T) {
+	binding := IncidentEngineParamBinding{}.FromAPI(client.EngineParamBindingV2{
+		Value: &client.EngineParamBindingValueV2{Literal: lo.ToPtr("high")},
+	})
+
+	assert.True(t, binding.ValueLiteral.IsNull(), "value_literal")
+	assert.True(t, binding.ValueReference.IsNull(), "value_reference")
+	assert.True(t, binding.ExpressionRef.IsNull(), "expression_ref")
+	assert.Empty(t, binding.Values, "values")
+
+	for _, value := range []attr.Value{binding.ValueLiteral, binding.ValueReference, binding.ExpressionRef} {
+		assert.False(t, value.IsUnknown(), "a zero-value shorthand must be null, not unknown")
+	}
+}
+
+// An unknown shorthand is not a value. ValueString reads the empty string off an unknown, so
+// treating one as set would turn expression_ref into `expressions[""]`.
+func TestResolvedTreatsAnUnknownShorthandAsUnset(t *testing.T) {
+	for name, binding := range map[string]IncidentEngineParamBinding{
+		"value_literal":   {ValueLiteral: jsontypes.NewNormalizedJSONOrStringUnknown()},
+		"value_reference": {ValueReference: types.StringUnknown()},
+		"expression_ref":  {ExpressionRef: types.StringUnknown()},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, IncidentEngineParamBinding{}, binding.resolved())
+		})
+	}
+}
+
+// A read only ever sees the long forms, so without this a config using a shorthand fails the
+// apply as an inconsistent result.
+func TestReconcileSpellingKeepsTheConfigsShorthand(t *testing.T) {
+	fromAPI := IncidentEngineParamBinding{Value: &IncidentEngineParamBindingValue{
+		Literal: literal("high"), Reference: types.StringNull(),
+	}}
+
+	t.Run("prior used the shorthand", func(t *testing.T) {
+		prior := IncidentEngineParamBinding{ValueLiteral: literal("high")}
+
+		got := fromAPI.ReconcileSpelling(prior)
+		assert.Equal(t, prior, got, "should hand back the shorthand the config wrote")
+	})
+
+	t.Run("prior used the long form", func(t *testing.T) {
+		got := fromAPI.ReconcileSpelling(fromAPI)
+		assert.Equal(t, fromAPI, got, "should leave a long-form config alone")
+	})
+
+	// The prior is only preferred when it still means what came back. A value that genuinely
+	// changed elsewhere has to win, or the read would hide real drift.
+	t.Run("value changed", func(t *testing.T) {
+		prior := IncidentEngineParamBinding{ValueLiteral: literal("low")}
+
+		got := fromAPI.ReconcileSpelling(prior)
+		assert.Equal(t, fromAPI, got, "should report the API's value, not the stale shorthand")
+	})
+}
+
+// The API re-encodes a JSON literal, so the comparison has to be the semantic one
+// NormalizedJSONOrString provides. Byte comparison would read a difference in key order as a
+// changed value, drop the shorthand, and fail the apply — the failure this type exists to prevent.
+func TestReconcileSpellingComparesJSONSemantically(t *testing.T) {
+	fromAPI := IncidentEngineParamBinding{Value: &IncidentEngineParamBindingValue{
+		Literal:   literal(`{"a":1,"b":2}`),
+		Reference: types.StringNull(),
+	}}
+
+	t.Run("same JSON, different key order", func(t *testing.T) {
+		prior := IncidentEngineParamBinding{ValueLiteral: literal(`{"b":2,"a":1}`)}
+
+		assert.Equal(t, prior, fromAPI.ReconcileSpelling(prior), "should keep the config's shorthand")
+	})
+
+	t.Run("different JSON", func(t *testing.T) {
+		prior := IncidentEngineParamBinding{ValueLiteral: literal(`{"a":1,"b":3}`)}
+
+		assert.Equal(t, fromAPI, fromAPI.ReconcileSpelling(prior), "should report the API's value")
+	})
+
+	// A null literal and an empty string are different values, and ValueString() flattens both to
+	// "" — so the null check has to come before the string comparison.
+	t.Run("null literal is not an empty one", func(t *testing.T) {
+		prior := IncidentEngineParamBinding{Values: []jsontypes.NormalizedJSONOrString{literal("")}}
+		empty := IncidentEngineParamBinding{ArrayValue: []IncidentEngineParamBindingValue{
+			{Literal: jsontypes.NewNormalizedJSONOrStringNull(), Reference: types.StringNull()},
+		}}
+
+		assert.Equal(t, empty, empty.ReconcileSpelling(prior))
+	})
+}
+
+// Bindings are a list, correlated positionally, and a prior shorter than the read must not panic
+// or misalign the entries it does cover.
+func TestReconcileSpellingOverAList(t *testing.T) {
+	fromAPI := IncidentEngineParamBindings{
+		{Value: &IncidentEngineParamBindingValue{Literal: literal("one"), Reference: types.StringNull()}},
+		{Value: &IncidentEngineParamBindingValue{Literal: literal("two"), Reference: types.StringNull()}},
+	}
+	prior := IncidentEngineParamBindings{
+		{ValueLiteral: literal("one")},
+	}
+
+	got := fromAPI.ReconcileSpelling(prior)
+
+	assert.Equal(t, prior[0], got[0], "the covered entry keeps its shorthand")
+	assert.NotNil(t, got[1].Value, "the uncovered entry keeps the API's long form")
+	assert.True(t, got[1].ValueLiteral.IsNull())
+}
+
+// A binding held as a types.Object has to survive the trip through it, shorthands included:
+// alert route severity reads and writes its binding that way, and a lost attribute there fails
+// the apply rather than showing up as a diff.
+func TestBindingSurvivesTheObjectRoundTrip(t *testing.T) {
+	for name, binding := range map[string]IncidentEngineParamBinding{
+		"empty": {},
+		"value": {Value: &IncidentEngineParamBindingValue{
+			Literal: literal("high"), Reference: types.StringNull(),
+		}},
+		"array_value": {ArrayValue: []IncidentEngineParamBindingValue{
+			{Literal: literal("a"), Reference: types.StringNull()},
+			{Literal: jsontypes.NewNormalizedJSONOrStringNull(), Reference: types.StringValue("incident.url")},
+		}},
+		"value_literal":   {ValueLiteral: literal("high")},
+		"value_reference": {ValueReference: types.StringValue("incident.url")},
+		"expression_ref":  {ExpressionRef: types.StringValue("team")},
+		"values":          {Values: []jsontypes.NormalizedJSONOrString{literal("a"), literal("b")}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			obj := binding.ToObject()
+
+			assert.Equal(t, ParamBindingAttrTypes(), obj.AttributeTypes(context.Background()),
+				"the object must carry every attribute the schema declares")
+			assert.Equal(t, binding, ParamBindingFromObject(obj))
+		})
+	}
+}
+
+// ReconcileBindingSpelling covers the standalone bindings, where nil on either side means there
+// is nothing to reconcile against.
+func TestReconcileBindingSpellingHandlesNil(t *testing.T) {
+	applied := &IncidentEngineParamBinding{Value: &IncidentEngineParamBindingValue{
+		Literal: literal("high"), Reference: types.StringNull(),
+	}}
+	prior := &IncidentEngineParamBinding{ValueLiteral: literal("high")}
+
+	assert.Equal(t, prior, ReconcileBindingSpelling(applied, prior))
+	assert.Equal(t, applied, ReconcileBindingSpelling(applied, nil))
+	assert.Nil(t, ReconcileBindingSpelling(nil, prior))
+}
+
+// IsEmpty decides whether a trailing binding is padding the API added, so it has to count the
+// shorthands too — otherwise `values = ["a"]` in the last position reads as empty and is trimmed.
+func TestIsEmptyCountsTheShorthands(t *testing.T) {
+	assert.True(t, IncidentEngineParamBinding{}.IsEmpty())
+
+	for name, binding := range map[string]IncidentEngineParamBinding{
+		"value_literal":   {ValueLiteral: literal("x")},
+		"value_reference": {ValueReference: types.StringValue("incident.url")},
+		"expression_ref":  {ExpressionRef: types.StringValue("team")},
+		"values":          {Values: []jsontypes.NormalizedJSONOrString{literal("x")}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.False(t, binding.IsEmpty())
+		})
+	}
+}

--- a/internal/provider/models/engine.go
+++ b/internal/provider/models/engine.go
@@ -1,8 +1,12 @@
 package models
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/samber/lo"
 
@@ -20,14 +24,123 @@ func ParamBindingValueAttrTypes() map[string]attr.Type {
 	}
 }
 
-// ParamBindingAttrTypes returns the attribute types for a param binding object.
+// ParamBindingAttrTypes returns the attribute types for a param binding object. It has to list
+// every attribute ParamBindingAttributes declares, including the shorthands: a binding built as
+// an object from a shorter list fails at apply with "struct defines fields not found in object".
 func ParamBindingAttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
 		"array_value": types.ListType{
 			ElemType: types.ObjectType{AttrTypes: ParamBindingValueAttrTypes()},
 		},
 		"value": types.ObjectType{AttrTypes: ParamBindingValueAttrTypes()},
+
+		"value_literal":   jsontypes.NormalizedJSONOrStringType{},
+		"value_reference": types.StringType,
+		"expression_ref":  types.StringType,
+		"values":          types.ListType{ElemType: jsontypes.NormalizedJSONOrStringType{}},
 	}
+}
+
+// ToObject renders a binding as an object, and ParamBindingFromObject reads one back. Alert route
+// severity holds its binding as a types.Object rather than a struct, and going through here keeps
+// the attribute list in one place.
+func (binding IncidentEngineParamBinding) ToObject() types.Object {
+	valueType := types.ObjectType{AttrTypes: ParamBindingValueAttrTypes()}
+
+	arrayValue := types.ListNull(valueType)
+	if len(binding.ArrayValue) > 0 {
+		arrayValue = types.ListValueMust(valueType, lo.Map(binding.ArrayValue,
+			func(v IncidentEngineParamBindingValue, _ int) attr.Value { return v.ToObject() }))
+	}
+
+	value := types.ObjectNull(ParamBindingValueAttrTypes())
+	if binding.Value != nil {
+		value = binding.Value.ToObject()
+	}
+
+	values := types.ListNull(jsontypes.NormalizedJSONOrStringType{})
+	if len(binding.Values) > 0 {
+		values = types.ListValueMust(jsontypes.NormalizedJSONOrStringType{}, lo.Map(binding.Values,
+			func(v jsontypes.NormalizedJSONOrString, _ int) attr.Value { return v }))
+	}
+
+	return types.ObjectValueMust(ParamBindingAttrTypes(), map[string]attr.Value{
+		"array_value":     arrayValue,
+		"value":           value,
+		"value_literal":   binding.ValueLiteral,
+		"value_reference": binding.ValueReference,
+		"expression_ref":  binding.ExpressionRef,
+		"values":          values,
+	})
+}
+
+func ParamBindingFromObject(value attr.Value) IncidentEngineParamBinding {
+	obj, ok := value.(types.Object)
+	if !ok || obj.IsNull() || obj.IsUnknown() {
+		return IncidentEngineParamBinding{}
+	}
+
+	attrs := obj.Attributes()
+	binding := IncidentEngineParamBinding{
+		ValueLiteral:   stringOrJSONAttr(attrs["value_literal"]),
+		ValueReference: stringAttr(attrs["value_reference"]),
+		ExpressionRef:  stringAttr(attrs["expression_ref"]),
+	}
+
+	if value, ok := attrs["value"].(types.Object); ok && !value.IsNull() {
+		binding.Value = lo.ToPtr(paramBindingValueFromObject(value))
+	}
+	if arrayValue, ok := attrs["array_value"].(types.List); ok {
+		for _, elem := range arrayValue.Elements() {
+			if value, ok := elem.(types.Object); ok {
+				binding.ArrayValue = append(binding.ArrayValue, paramBindingValueFromObject(value))
+			}
+		}
+	}
+	if values, ok := attrs["values"].(types.List); ok {
+		for _, elem := range values.Elements() {
+			binding.Values = append(binding.Values, stringOrJSONAttr(elem))
+		}
+	}
+
+	return binding
+}
+
+func (v IncidentEngineParamBindingValue) ToObject() types.Object {
+	return types.ObjectValueMust(ParamBindingValueAttrTypes(), map[string]attr.Value{
+		"literal":   v.Literal,
+		"reference": v.Reference,
+	})
+}
+
+func paramBindingValueFromObject(obj types.Object) IncidentEngineParamBindingValue {
+	attrs := obj.Attributes()
+
+	return IncidentEngineParamBindingValue{
+		Literal:   stringOrJSONAttr(attrs["literal"]),
+		Reference: stringAttr(attrs["reference"]),
+	}
+}
+
+// isSet reports whether a config actually gave this attribute a value.
+func isSet(value attr.Value) bool {
+	return !value.IsNull() && !value.IsUnknown()
+}
+
+func stringAttr(value attr.Value) types.String {
+	if str, ok := value.(types.String); ok {
+		return str
+	}
+
+	return types.StringNull()
+}
+
+func stringOrJSONAttr(value attr.Value) jsontypes.NormalizedJSONOrString {
+	if str, ok := value.(jsontypes.NormalizedJSONOrString); ok {
+		return str
+	}
+
+	return jsontypes.NewNormalizedJSONOrStringNull()
 }
 
 // ConditionAttrTypes returns the attribute types for a single condition object.
@@ -69,26 +182,18 @@ var serverOperationNormalisations = map[string]string{
 	"contains": "name_contains",   // CatalogEntry subjects
 }
 
-// ReconcileOperations restores the planned operation wherever the API returned
-// the canonical form of an alias we sent (ONC-12602). Condition groups are lists,
-// so we correlate positionally and require the subject to match.
-func (groups IncidentEngineConditionGroups) ReconcileOperations(plan IncidentEngineConditionGroups) {
+// ReconcileSpelling restores what the config wrote wherever the API answers with something that
+// means the same thing: the operation, where the API returned the canonical form of an alias we
+// sent (ONC-12602), and each param binding, where the API only ever reports the two long forms.
+//
+// Condition groups are lists, so we correlate positionally and require the subject to match.
+func (groups IncidentEngineConditionGroups) ReconcileSpelling(plan IncidentEngineConditionGroups) {
 	for gi := range groups {
 		if gi >= len(plan) {
 			break
 		}
-		for ci := range groups[gi].Conditions {
-			if ci >= len(plan[gi].Conditions) {
-				break
-			}
 
-			planned := plan[gi].Conditions[ci]
-			applied := groups[gi].Conditions[ci]
-			if applied.Subject.Equal(planned.Subject) &&
-				serverOperationNormalisations[planned.Operation.ValueString()] == applied.Operation.ValueString() {
-				groups[gi].Conditions[ci].Operation = planned.Operation
-			}
-		}
+		groups[gi].Conditions.ReconcileSpelling(plan[gi].Conditions)
 	}
 }
 
@@ -100,6 +205,26 @@ func (IncidentEngineConditions) FromAPI(conditions []client.ConditionV2) Inciden
 		out = append(out, IncidentEngineCondition{}.FromAPI(cond))
 	}
 	return out
+}
+
+// ReconcileSpelling correlates positionally and requires the subject to match, so a condition
+// that moved is left with whatever the API said.
+func (conditions IncidentEngineConditions) ReconcileSpelling(plan IncidentEngineConditions) {
+	for ci := range conditions {
+		if ci >= len(plan) {
+			break
+		}
+
+		planned, applied := plan[ci], conditions[ci]
+		if !applied.Subject.Equal(planned.Subject) {
+			continue
+		}
+
+		if serverOperationNormalisations[planned.Operation.ValueString()] == applied.Operation.ValueString() {
+			conditions[ci].Operation = planned.Operation
+		}
+		conditions[ci].ParamBindings = applied.ParamBindings.ReconcileSpelling(planned.ParamBindings)
+	}
 }
 
 type IncidentEngineCondition struct {
@@ -128,6 +253,77 @@ func (IncidentEngineParamBindings) FromAPI(pbs []client.EngineParamBindingV2) In
 	return out
 }
 
+// ReconcileSpelling puts back the shorthand the config used: a read only sees the stored form, so
+// `value_literal = "x"` would otherwise read back as `value = { literal = "x" }` and fail the
+// apply as an inconsistent result.
+//
+// The prior only wins while it still means what came back, so genuine drift isn't hidden.
+func (binding IncidentEngineParamBinding) ReconcileSpelling(prior IncidentEngineParamBinding) IncidentEngineParamBinding {
+	if binding.meansTheSameAs(prior) {
+		return prior
+	}
+
+	return binding
+}
+
+func (binding IncidentEngineParamBinding) meansTheSameAs(other IncidentEngineParamBinding) bool {
+	resolved, otherResolved := binding.resolved(), other.resolved()
+
+	if (resolved.Value == nil) != (otherResolved.Value == nil) {
+		return false
+	}
+	if resolved.Value != nil && !resolved.Value.meansTheSameAs(*otherResolved.Value) {
+		return false
+	}
+	if len(resolved.ArrayValue) != len(otherResolved.ArrayValue) {
+		return false
+	}
+	for idx := range resolved.ArrayValue {
+		if !resolved.ArrayValue[idx].meansTheSameAs(otherResolved.ArrayValue[idx]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// meansTheSameAs compares literals the way NormalizedJSONOrString compares them in state, rather
+// than byte for byte. The API re-encodes a JSON literal, so a difference in key order or escaping
+// would otherwise read as a changed value and drop the shorthand the config wrote.
+func (v IncidentEngineParamBindingValue) meansTheSameAs(other IncidentEngineParamBindingValue) bool {
+	if !v.Reference.Equal(other.Reference) {
+		return false
+	}
+	if v.Literal.IsNull() != other.Literal.IsNull() || v.Literal.IsUnknown() != other.Literal.IsUnknown() {
+		return false
+	}
+
+	return jsontypes.JSONStringsEqual(v.Literal.ValueString(), other.Literal.ValueString())
+}
+
+// ReconcileBindingSpelling is ReconcileSpelling for the standalone bindings a resource holds as a
+// pointer, rather than as part of a list.
+func ReconcileBindingSpelling(applied, prior *IncidentEngineParamBinding) *IncidentEngineParamBinding {
+	if applied == nil || prior == nil {
+		return applied
+	}
+
+	return lo.ToPtr(applied.ReconcileSpelling(*prior))
+}
+
+// ReconcileSpelling correlates positionally: param bindings are a list, and the API returns them
+// in the order it was given them.
+func (pbs IncidentEngineParamBindings) ReconcileSpelling(prior IncidentEngineParamBindings) IncidentEngineParamBindings {
+	for idx := range pbs {
+		if idx >= len(prior) {
+			break
+		}
+		pbs[idx] = pbs[idx].ReconcileSpelling(prior[idx])
+	}
+
+	return pbs
+}
+
 // TrimAppendedEmpty drops trailing empty bindings the API padded onto a step that has
 // gained params, beyond the priorLen we sent. Stopping at priorLen keeps a configured
 // empty binding, which means "skip this optional param".
@@ -140,13 +336,63 @@ func (pbs IncidentEngineParamBindings) TrimAppendedEmpty(priorLen int) IncidentE
 	return out
 }
 
+// A binding has two forms the API understands, `value` and `array_value`, and four shorthands.
+// The shorthands carry no meaning of their own: ToPayload folds them onto the two real forms, and
+// a read puts back whichever spelling the config used, because Terraform compares the spelling
+// and not the meaning.
 type IncidentEngineParamBinding struct {
 	ArrayValue []IncidentEngineParamBindingValue `tfsdk:"array_value"`
 	Value      *IncidentEngineParamBindingValue  `tfsdk:"value"`
+
+	ValueLiteral   jsontypes.NormalizedJSONOrString   `tfsdk:"value_literal"`
+	ValueReference types.String                       `tfsdk:"value_reference"`
+	ExpressionRef  types.String                       `tfsdk:"expression_ref"`
+	Values         []jsontypes.NormalizedJSONOrString `tfsdk:"values"`
 }
 
 func (binding IncidentEngineParamBinding) IsEmpty() bool {
-	return binding.Value == nil && len(binding.ArrayValue) == 0
+	return binding.Value == nil && len(binding.ArrayValue) == 0 &&
+		binding.ValueLiteral.IsNull() && binding.ValueReference.IsNull() &&
+		binding.ExpressionRef.IsNull() && len(binding.Values) == 0
+}
+
+// resolved folds the shorthands onto the two forms the API understands, so a shorthand and the
+// long form it stands for are the same binding from here on.
+// An unknown shorthand counts as unset, so the value it stands for stays unknown rather than
+// becoming whatever ValueString reads off an unknown, which is the empty string.
+func (binding IncidentEngineParamBinding) resolved() IncidentEngineParamBinding {
+	switch {
+	case isSet(binding.ValueLiteral):
+		return IncidentEngineParamBinding{Value: &IncidentEngineParamBindingValue{
+			Literal:   binding.ValueLiteral,
+			Reference: types.StringNull(),
+		}}
+
+	case isSet(binding.ValueReference):
+		return IncidentEngineParamBinding{Value: &IncidentEngineParamBindingValue{
+			Literal:   jsontypes.NewNormalizedJSONOrStringNull(),
+			Reference: binding.ValueReference,
+		}}
+
+	case isSet(binding.ExpressionRef):
+		return IncidentEngineParamBinding{Value: &IncidentEngineParamBindingValue{
+			Literal:   jsontypes.NewNormalizedJSONOrStringNull(),
+			Reference: types.StringValue(ExpressionReference(binding.ExpressionRef.ValueString())),
+		}}
+
+	case len(binding.Values) > 0:
+		values := []IncidentEngineParamBindingValue{}
+		for _, literal := range binding.Values {
+			values = append(values, IncidentEngineParamBindingValue{
+				Literal:   literal,
+				Reference: types.StringNull(),
+			})
+		}
+
+		return IncidentEngineParamBinding{ArrayValue: values}
+	}
+
+	return IncidentEngineParamBinding{ArrayValue: binding.ArrayValue, Value: binding.Value}
 }
 
 func (IncidentEngineParamBinding) FromAPI(pb client.EngineParamBindingV2) IncidentEngineParamBinding {
@@ -193,7 +439,7 @@ type IncidentEngineExpressions []IncidentEngineExpression
 
 // ReconcileOperations does the same for filter and branch conditions. Expressions
 // are a set, so we correlate by reference rather than position.
-func (expressions IncidentEngineExpressions) ReconcileOperations(plan IncidentEngineExpressions) {
+func (expressions IncidentEngineExpressions) ReconcileSpelling(plan IncidentEngineExpressions) {
 	planByReference := map[string]IncidentEngineExpression{}
 	for _, expression := range plan {
 		planByReference[expression.Reference.ValueString()] = expression
@@ -205,6 +451,11 @@ func (expressions IncidentEngineExpressions) ReconcileOperations(plan IncidentEn
 			continue
 		}
 
+		if expressions[ei].ElseBranch != nil && planExpression.ElseBranch != nil {
+			expressions[ei].ElseBranch.Result = expressions[ei].ElseBranch.Result.
+				ReconcileSpelling(planExpression.ElseBranch.Result)
+		}
+
 		for oi := range expressions[ei].Operations {
 			if oi >= len(planExpression.Operations) {
 				break
@@ -214,7 +465,7 @@ func (expressions IncidentEngineExpressions) ReconcileOperations(plan IncidentEn
 			planOp := planExpression.Operations[oi]
 
 			if op.Filter != nil && planOp.Filter != nil {
-				op.Filter.ConditionGroups.ReconcileOperations(planOp.Filter.ConditionGroups)
+				op.Filter.ConditionGroups.ReconcileSpelling(planOp.Filter.ConditionGroups)
 			}
 
 			if op.Branches != nil && planOp.Branches != nil {
@@ -222,7 +473,9 @@ func (expressions IncidentEngineExpressions) ReconcileOperations(plan IncidentEn
 					if bi >= len(planOp.Branches.Branches) {
 						break
 					}
-					op.Branches.Branches[bi].ConditionGroups.ReconcileOperations(planOp.Branches.Branches[bi].ConditionGroups)
+					op.Branches.Branches[bi].ConditionGroups.ReconcileSpelling(planOp.Branches.Branches[bi].ConditionGroups)
+					op.Branches.Branches[bi].Result = op.Branches.Branches[bi].Result.
+						ReconcileSpelling(planOp.Branches.Branches[bi].Result)
 				}
 			}
 		}
@@ -410,7 +663,48 @@ func ParamBindingAttributes() map[string]schema.Attribute {
 			Optional:            true,
 			Attributes:          ParamBindingValueAttributes(),
 		},
+
+		// Shorthands for the two above. ConflictsWith keeps them exclusive wherever the binding
+		// is used, so no resource has to wire up its own check.
+		"value_literal": schema.StringAttribute{
+			CustomType:          jsontypes.NormalizedJSONOrStringType{},
+			MarkdownDescription: "A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.",
+			Optional:            true,
+			Validators:          []validator.String{stringvalidator.ConflictsWith(bindingFormsOtherThan("value_literal")...)},
+		},
+		"value_reference": schema.StringAttribute{
+			MarkdownDescription: "A reference into the scope, shorthand for `value = { reference = ... }`.",
+			Optional:            true,
+			Validators:          []validator.String{stringvalidator.ConflictsWith(bindingFormsOtherThan("value_reference")...)},
+		},
+		"expression_ref": schema.StringAttribute{
+			MarkdownDescription: "The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions[\"name\"]`.",
+			Optional:            true,
+			Validators:          []validator.String{stringvalidator.ConflictsWith(bindingFormsOtherThan("expression_ref")...)},
+		},
+		"values": schema.ListAttribute{
+			ElementType:         jsontypes.NormalizedJSONOrStringType{},
+			MarkdownDescription: "Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.",
+			Optional:            true,
+			Validators:          []validator.List{listvalidator.ConflictsWith(bindingFormsOtherThan("values")...)},
+		},
 	}
+}
+
+// bindingForms is every way of writing a binding's value. Exactly one may be set.
+var bindingForms = []string{"value", "array_value", "value_literal", "value_reference", "expression_ref", "values"}
+
+// bindingFormsOtherThan names the sibling attributes a given form conflicts with. The paths are
+// relative to the binding object, so they resolve wherever the binding is nested.
+func bindingFormsOtherThan(self string) []path.Expression {
+	out := []path.Expression{}
+	for _, form := range bindingForms {
+		if form != self {
+			out = append(out, path.MatchRelative().AtParent().AtName(form))
+		}
+	}
+
+	return out
 }
 
 func ParamBindingsAttribute() schema.ListNestedAttribute {
@@ -624,15 +918,16 @@ func (pbs IncidentEngineParamBindings) ToPayload() []client.EngineParamBindingPa
 }
 
 func (binding IncidentEngineParamBinding) ToPayload() client.EngineParamBindingPayloadV2 {
-	arrayValue := []client.EngineParamBindingValuePayloadV2{}
+	resolved := binding.resolved()
 
-	for _, v := range binding.ArrayValue {
+	arrayValue := []client.EngineParamBindingValuePayloadV2{}
+	for _, v := range resolved.ArrayValue {
 		arrayValue = append(arrayValue, v.ToPayload())
 	}
 
 	var value *client.EngineParamBindingValuePayloadV2
-	if binding.Value != nil {
-		value = lo.ToPtr(binding.Value.ToPayload())
+	if resolved.Value != nil {
+		value = lo.ToPtr(resolved.Value.ToPayload())
 	}
 
 	return client.EngineParamBindingPayloadV2{

--- a/internal/provider/models/engine_datasource.go
+++ b/internal/provider/models/engine_datasource.go
@@ -37,6 +37,24 @@ func ParamBindingDataSourceAttributes() map[string]schema.Attribute {
 			Computed:            true,
 			Attributes:          ParamBindingValueDataSourceAttributes(),
 		},
+
+		// The shorthands are spellings a config chooses, so a data source never reports one —
+		// they read as null. They are declared because the model is shared with the resources,
+		// and a model field with no matching attribute fails the object conversion.
+		"value_literal": schema.StringAttribute{
+			CustomType: jsontypes.NormalizedJSONOrStringType{},
+			Computed:   true,
+		},
+		"value_reference": schema.StringAttribute{
+			Computed: true,
+		},
+		"expression_ref": schema.StringAttribute{
+			Computed: true,
+		},
+		"values": schema.ListAttribute{
+			ElementType: jsontypes.NormalizedJSONOrStringType{},
+			Computed:    true,
+		},
 	}
 }
 

--- a/internal/provider/models/engine_test.go
+++ b/internal/provider/models/engine_test.go
@@ -145,9 +145,9 @@ func TestIncidentEngineParamBindings_TrimAppendedEmpty(t *testing.T) {
 	}
 }
 
-// TestIncidentEngineConditionGroups_ReconcileOperations covers ONC-12602: restore
+// TestIncidentEngineConditionGroups_ReconcileSpelling covers ONC-12602: restore
 // the planned value for a known alias, leave everything else alone.
-func TestIncidentEngineConditionGroups_ReconcileOperations(t *testing.T) {
+func TestIncidentEngineConditionGroups_ReconcileSpelling(t *testing.T) {
 	condition := func(subject, operation string) IncidentEngineCondition {
 		return IncidentEngineCondition{
 			Subject:   types.StringValue(subject),
@@ -205,17 +205,17 @@ func TestIncidentEngineConditionGroups_ReconcileOperations(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			tc.applied.ReconcileOperations(tc.plan)
+			tc.applied.ReconcileSpelling(tc.plan)
 			got := tc.applied[0].Conditions[0].Operation.ValueString()
 			assert.Equal(t, tc.want, got)
 		})
 	}
 }
 
-// TestIncidentEngineConditionGroups_ReconcileOperationsMismatchedLengths asserts
+// TestIncidentEngineConditionGroups_ReconcileSpellingMismatchedLengths asserts
 // reconciliation is safe when the plan and read-back have different numbers of
 // groups or conditions.
-func TestIncidentEngineConditionGroups_ReconcileOperationsMismatchedLengths(t *testing.T) {
+func TestIncidentEngineConditionGroups_ReconcileSpellingMismatchedLengths(t *testing.T) {
 	applied := IncidentEngineConditionGroups{
 		{Conditions: IncidentEngineConditions{
 			{Subject: types.StringValue("alert.attributes.01ABC"), Operation: types.StringValue("contains_one_of")},
@@ -228,19 +228,19 @@ func TestIncidentEngineConditionGroups_ReconcileOperationsMismatchedLengths(t *t
 		}},
 	}
 
-	assert.NotPanics(t, func() { applied.ReconcileOperations(plan) })
+	assert.NotPanics(t, func() { applied.ReconcileSpelling(plan) })
 	assert.Equal(t, "one_of", applied[0].Conditions[0].Operation.ValueString())
 	// The second condition has no planned counterpart, so it is left as-is.
 	assert.Equal(t, "contains_one_of", applied[0].Conditions[1].Operation.ValueString())
 
 	// A nil plan must be a no-op rather than a panic.
-	assert.NotPanics(t, func() { applied.ReconcileOperations(nil) })
+	assert.NotPanics(t, func() { applied.ReconcileSpelling(nil) })
 }
 
-// TestIncidentEngineExpressions_ReconcileOperationsCorrelatesByReference asserts
+// TestIncidentEngineExpressions_ReconcileSpellingCorrelatesByReference asserts
 // filter conditions still reconcile when the API returns expressions in a
 // different order to the plan.
-func TestIncidentEngineExpressions_ReconcileOperationsCorrelatesByReference(t *testing.T) {
+func TestIncidentEngineExpressions_ReconcileSpellingCorrelatesByReference(t *testing.T) {
 	expression := func(reference, operation string) IncidentEngineExpression {
 		return IncidentEngineExpression{
 			Reference: types.StringValue(reference),
@@ -275,16 +275,16 @@ func TestIncidentEngineExpressions_ReconcileOperationsCorrelatesByReference(t *t
 		expression("first", "one_of"),
 	}
 
-	applied.ReconcileOperations(plan)
+	applied.ReconcileSpelling(plan)
 
 	assert.Equal(t, "one_of", operationOf(applied[0]), "first expression reconciled")
 	assert.Equal(t, "one_of", operationOf(applied[1]), "second expression reconciled")
 
 	// An unplanned expression is left alone, and a nil plan must not panic.
 	unplanned := IncidentEngineExpressions{expression("third", "contains_one_of")}
-	assert.NotPanics(t, func() { unplanned.ReconcileOperations(plan) })
+	assert.NotPanics(t, func() { unplanned.ReconcileSpelling(plan) })
 	assert.Equal(t, "contains_one_of", operationOf(unplanned[0]))
-	assert.NotPanics(t, func() { unplanned.ReconcileOperations(nil) })
+	assert.NotPanics(t, func() { unplanned.ReconcileSpelling(nil) })
 }
 
 func TestIncidentEngineParamBinding_IsEmpty(t *testing.T) {

--- a/internal/provider/schema_converters.go
+++ b/internal/provider/schema_converters.go
@@ -73,8 +73,8 @@ func (r *IncidentWorkflowResource) buildModel(ctx context.Context, workflow clie
 	}
 
 	if prior != nil {
-		model.ConditionGroups.ReconcileOperations(prior.ConditionGroups)
-		model.Expressions.ReconcileOperations(prior.Expressions)
+		model.ConditionGroups.ReconcileSpelling(prior.ConditionGroups)
+		model.Expressions.ReconcileSpelling(prior.Expressions)
 		model.FormFields = reconcileFormFields(prior.FormFields, model.FormFields)
 	}
 
@@ -162,17 +162,19 @@ func buildSteps(steps []client.StepConfigV2, prior *IncidentWorkflowResourceMode
 	out := []IncidentWorkflowStep{}
 
 	// Keyed by step ID so we survive reordering. Unseen steps keep all their bindings.
-	priorBindingCounts := map[string]int{}
+	priorSteps := map[string]IncidentWorkflowStep{}
 	if prior != nil {
 		for _, step := range prior.Steps {
-			priorBindingCounts[step.ID.ValueString()] = len(step.ParamBindings)
+			priorSteps[step.ID.ValueString()] = step
 		}
 	}
 
 	for _, s := range steps {
 		paramBindings := models.IncidentEngineParamBindings{}.FromAPI(s.ParamBindings)
-		if priorLen, ok := priorBindingCounts[s.Id]; ok {
-			paramBindings = paramBindings.TrimAppendedEmpty(priorLen)
+		if priorStep, ok := priorSteps[s.Id]; ok {
+			paramBindings = paramBindings.
+				TrimAppendedEmpty(len(priorStep.ParamBindings)).
+				ReconcileSpelling(priorStep.ParamBindings)
 		}
 
 		out = append(out, IncidentWorkflowStep{


### PR DESCRIPTION
`value_literal`, `value_reference`, `expression_ref` and `values` stand for the shapes almost every config writes, so a binding is one line instead of three levels of nesting. `value` and `array_value` keep working, and setting more than one form is rejected at plan time.

```hcl
param_bindings = [{ value = { reference = "incident.url" } }]  # before
param_bindings = [{ value_reference = "incident.url" }]        # after
```

`ToPayload` folds a shorthand onto the form the API stores, so both spellings send the same request. A read only ever sees the stored form, so `ReconcileSpelling` puts back whichever the config used — without that, a config using a shorthand fails the apply as an inconsistent result.

Bindings appear on every engine resource, so the reconciliation had to reach all of them: conditions, expression filters, branch and else-branch results, workflow steps, alert route templates and channel targets, escalation targets, and alert source templates. Escalation paths and alert sources had no prior to reconcile against at all, so they gain one here. That also fixes an operation alias such as `one_of` on an alert source template expression, which was failing the same way.

Alert route severity holds its binding as a `types.Object` built from its own 2-attribute list, so that list is now the shared one.

## Testing

Unit tests cover each shorthand folding onto its long form, the reconciliation keeping a shorthand only while it still means what came back, the object round-trip, and the escalation path prior decode.

Acceptance tests against a local stack: alert route (v2), alert source, maintenance window and workflow suites pass. Three escalation path tests and two alert route v3 tests fail on local environment limits unrelated to this change (a Slack channel with no bot invited; an org not migrated to the v3 alert grouping engine).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide-reaching schema and read/write normalization across many resources; mistakes could cause plan/apply drift, though changes are additive and backward compatible with existing nested `value` blocks.
> 
> **Overview**
> Adds **`value_literal`**, **`value_reference`**, **`expression_ref`**, and **`values`** as optional shorthands anywhere a param binding’s value is set, so configs can use one line instead of nested `value` / `array_value` blocks. Existing `value` and `array_value` shapes still work; **plan-time validation rejects using more than one form** on the same binding.
> 
> On write, shorthands fold into the API’s canonical shape; on read, **reconciliation preserves whichever spelling the config used** so Terraform does not report “inconsistent result after apply” when only the representation differs. That reconciliation is wired through **engine resources** that carry bindings (conditions, expression branches/results, workflow steps, alert routes, escalation paths, alert source templates, maintenance windows, and related targets). **Escalation paths and alert sources** gain this reconciliation where it was missing before.
> 
> Also fixes **`incident_alert_source`** post-apply drift when an expression operation is written as an **alias** (e.g. `one_of`) but the API returns the canonical operation name—state now matches the config’s spelling. Generated **resource and data source docs** document the new binding attributes across affected schemas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6e40e1607fedda30f8315e7086b11012fa7d421. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->