### PR TITLE
Changelog for v6.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## v6.9.0
 
 - Add `value_literal`, `value_reference`, `expression_ref` and `values` as shorthands for a param binding's value, wherever bindings appear. `param_bindings = [{ value = { reference = "incident.url" } }]` becomes `param_bindings = [{ value_reference = "incident.url" }]`; `value` and `array_value` keep working, and setting more than one form is rejected at plan time.
 - Add `concatenate` to expression operations, which adds the values behind another reference to the current value. Configs using it previously failed to apply.


### PR DESCRIPTION
Promotes the unreleased changes to v6.9.0, ready to tag once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CHANGELOG-only edit with no runtime or schema changes in this PR.
> 
> **Overview**
> **Renames the changelog section from `Unreleased` to `v6.9.0`** so the listed provider changes are tied to this release when you tag after merge. The bullet text is unchanged; this is release bookkeeping only.
> 
> That section documents **v6.9.0** as: param-binding value shorthands (`value_literal`, `value_reference`, `expression_ref`, `values`), `concatenate` in expressions, a fix for inconsistent apply on `incident_alert_source` with operation aliases, `rank` on `incident_status`, and `incident_incident_role` lookup by `name` (with an updated workflow example).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c8e69d883461415efd076af3a53b0bf7c812a8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->