### PR TITLE
Run the unit tests in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,20 @@ jobs:
           version: latest
           skip-cache: true
 
+  # The unit tests need no API credentials, so unlike the acceptance tests below
+  # they also run on pull requests from forks.
+  unit:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@v7.0.0
+        with:
+          go-version-file: 'go.mod'
+      - run: go mod download
+      - run: make test
+
   generate:
     runs-on: ubuntu-latest
     steps:

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -48,7 +48,14 @@ Tests run against a real API, either the production/staging incident.io API or
 whatever you may be running locally (for incident.io staff). If you're staff,
 it's best to use a localhost endpoint for lower latency if possible.
 
-To run the tests:
+The unit tests need no credentials at all, and are the fastest way to check a
+change to the model or conversion code:
+
+```console
+$> make test
+```
+
+To run the acceptance tests:
 
 ```console
 # Run the whole suite

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,14 @@ default: testacc
 # Development
 ################################################################################
 
+# Run the unit tests: every package, with no API credentials needed. The
+# acceptance tests are gated behind TF_ACC and skip themselves without it, so
+# this covers the pure-Go suites (models, jsontypes, richtexttypes, apischema)
+# that `testacc` never reaches.
+.PHONY: test
+test:
+	go test ./... $(TESTARGS)
+
 # Run acceptance tests
 .PHONY: testacc
 testacc:


### PR DESCRIPTION
## Problem

CI runs `make testacc`, which is `go test ./internal/provider` — a single package. Four packages hold unit tests that consequently **never run in CI**:

| Package | Test files | What it guards |
|---|---|---|
| `internal/provider/models` | 8 (incl. a 1,581-line `expression_v3_test.go`) | engine / expression / alert-route conversion |
| `internal/provider/richtexttypes` | 3 | rich text conversion |
| `internal/provider/jsontypes` | 1 | JSON semantic equality (the ONC-7057 / ONC-7504 fix) |
| `internal/apischema` | 1 | enum docstring generation |

That's the code the trickiest bugs in this provider have lived in. A regression in any of it is invisible to CI today. They all pass, in about a second.

Second problem: the acceptance job needs `INCIDENT_API_KEY`, so it can't run on a pull request from a fork. Today a contributor gets **no** test signal — only build, lint and generate. This job needs no credentials, so it runs there too.

## Change

- New `unit` job in `.github/workflows/test.yml` running `make test`.
- New `make test` target = `go test ./...`. Acceptance tests are gated behind `TF_ACC` and skip themselves without it, so this is the credential-free suite.
- `DEVELOPING.md` documents it next to `make testacc`.

`make testacc` is left alone — it stays the acceptance entry point.

## Verification

`make test` passes locally across all seven packages.

---

Part of a set of independent PRs from a codebase scan. Each branches off `master` on its own; this one touches only CI, the Makefile and docs, so it should merge without conflicting with the others.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI workflow, Makefile, and developer docs with no runtime or provider behavior impact.
> 
> **Overview**
> **CI now runs the full Go unit test suite** via a new `unit` job that executes `make test`, so packages like `models`, `jsontypes`, `richtexttypes`, and `apischema` are exercised on every push/PR—not only the acceptance package CI used to hit indirectly.
> 
> The job needs no `INCIDENT_API_KEY`, so **fork PRs get test signal** where the acceptance matrix cannot run. `make testacc` and the acceptance workflow are unchanged.
> 
> Locally, **`make test`** (`go test ./...`) is documented in `DEVELOPING.md` as the fast, credential-free check for model/conversion changes; acceptance tests remain `make testacc`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ab2edfa1dacdc5d338ab490d4e1a7daf8d009e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->