### PR TITLE
Delete forceCoerce, which converts each type to itself

### DIFF
--- a/internal/provider/incident_workflow_data_source.go
+++ b/internal/provider/incident_workflow_data_source.go
@@ -214,7 +214,7 @@ func (d *IncidentWorkflowDataSource) Read(ctx context.Context, req datasource.Re
 	// Reuse the resource's buildModel for consistency. There's no prior state to
 	// reconcile against in a data source, so pass nil: we want whatever the API has.
 	workflowResource := &IncidentWorkflowResource{}
-	model := workflowResource.buildModel(ctx, result.JSON200.Workflow, nil)
+	model := workflowResource.buildModel(result.JSON200.Workflow, nil)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
 }

--- a/internal/provider/incident_workflow_data_source_test.go
+++ b/internal/provider/incident_workflow_data_source_test.go
@@ -98,7 +98,7 @@ func TestIncidentWorkflowDataSourceSchemaMatchesModel(t *testing.T) {
 		PrivateIncidentScope:      client.WorkflowV2PrivateIncidentScope("owning_teams"),
 	}
 
-	model := (&IncidentWorkflowResource{}).buildModel(ctx, workflow, nil)
+	model := (&IncidentWorkflowResource{}).buildModel(workflow, nil)
 
 	state := tfsdk.State{
 		Schema: resp.Schema,

--- a/internal/provider/incident_workflow_resource.go
+++ b/internal/provider/incident_workflow_resource.go
@@ -319,7 +319,7 @@ func (r *IncidentWorkflowResource) Create(ctx context.Context, req resource.Crea
 	tflog.Trace(ctx, fmt.Sprintf("created a workflow resource with id=%s", result.JSON201.Workflow.Id))
 	// Unlike update and read, create has no skip_step_upgrades, so the response may
 	// carry param_bindings the plan never set.
-	data = r.buildModel(ctx, result.JSON201.Workflow, data)
+	data = r.buildModel(result.JSON201.Workflow, data)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -399,7 +399,7 @@ func (r *IncidentWorkflowResource) Update(ctx context.Context, req resource.Upda
 		return
 	}
 
-	data = r.buildModel(ctx, result.JSON200.Workflow, data)
+	data = r.buildModel(result.JSON200.Workflow, data)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -425,7 +425,7 @@ func (r *IncidentWorkflowResource) Read(ctx context.Context, req resource.ReadRe
 		return
 	}
 
-	data = r.buildModel(ctx, result.JSON200.Workflow, data)
+	data = r.buildModel(result.JSON200.Workflow, data)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 

--- a/internal/provider/schema_converters.go
+++ b/internal/provider/schema_converters.go
@@ -1,53 +1,27 @@
 package provider
 
 import (
-	"context"
-	"encoding/json"
 	"sort"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/pkg/errors"
 	"github.com/samber/lo"
 
 	"github.com/incident-io/terraform-provider-incident/v6/internal/client"
 	"github.com/incident-io/terraform-provider-incident/v6/internal/provider/models"
 )
 
-// forceCoerce converts between two API client types which we are certain are
-// identical, but the Go type system does not know that.
-func forceCoerce[T any](ctx context.Context, input any) T {
-	// This is a horrible hack to work around the schema having a bunch of
-	// duplicated types. Until we've sorted that out, this to-and-from JSONs
-	jsoned, err := json.Marshal(input)
-	if err != nil {
-		tflog.Error(ctx, "Failed to marshal input", map[string]any{
-			"error": err.Error(),
-		})
-		panic(errors.Wrap(err, "failed to marshal input"))
-	}
-	var res T
-	if err := json.Unmarshal(jsoned, &res); err != nil {
-		tflog.Error(ctx, "Failed to unmarshal input", map[string]any{
-			"error": err.Error(),
-		})
-		panic(errors.Wrap(err, "failed to unmarshal input"))
-	}
-	return res
-}
-
 // buildModel converts from the response type to the terraform model/schema type. prior
 // is the plan (create/update) or prior state (read), and nil on import.
-func (r *IncidentWorkflowResource) buildModel(ctx context.Context, workflow client.WorkflowV2, prior *IncidentWorkflowResourceModel) *IncidentWorkflowResourceModel {
+func (r *IncidentWorkflowResource) buildModel(workflow client.WorkflowV2, prior *IncidentWorkflowResourceModel) *IncidentWorkflowResourceModel {
 	model := &IncidentWorkflowResourceModel{
 		ID:                        types.StringValue(workflow.Id),
 		Name:                      types.StringValue(workflow.Name),
 		Trigger:                   types.StringValue(workflow.Trigger.Name),
-		ConditionGroups:           models.IncidentEngineConditionGroups{}.FromAPI(forceCoerce[[]client.ConditionGroupV2](ctx, workflow.ConditionGroups)),
+		ConditionGroups:           models.IncidentEngineConditionGroups{}.FromAPI(workflow.ConditionGroups),
 		Steps:                     buildSteps(workflow.Steps, prior),
-		Expressions:               models.IncidentEngineExpressions{}.FromAPI(forceCoerce[[]client.ExpressionV2](ctx, workflow.Expressions)),
+		Expressions:               models.IncidentEngineExpressions{}.FromAPI(workflow.Expressions),
 		OnceFor:                   buildOnceFor(workflow.OnceFor),
 		RunsOnIncidentModes:       buildRunsOnIncidentModes(workflow.RunsOnIncidentModes),
 		IncludePrivateIncidents:   types.BoolValue(workflow.IncludePrivateIncidents),

--- a/internal/provider/schema_converters_test.go
+++ b/internal/provider/schema_converters_test.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"context"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -44,11 +43,11 @@ func TestWorkflowBuildModelReconcilesConditionOperation(t *testing.T) {
 
 	r := &IncidentWorkflowResource{}
 
-	withPrior := r.buildModel(context.Background(), workflow, prior)
+	withPrior := r.buildModel(workflow, prior)
 	assert.Equal(t, "one_of", withPrior.ConditionGroups[0].Conditions[0].Operation.ValueString(),
 		"with a plan the operation should be reconciled")
 
-	noPrior := r.buildModel(context.Background(), workflow, nil)
+	noPrior := r.buildModel(workflow, nil)
 	assert.Equal(t, "contains_one_of", noPrior.ConditionGroups[0].Conditions[0].Operation.ValueString(),
 		"with no plan the operation should stay verbatim")
 }


### PR DESCRIPTION
## Problem

`forceCoerce` (`internal/provider/schema_converters.go`) exists to convert *"between two API client types which we are certain are identical, but the Go type system does not know that"*, by round-tripping through JSON. Its own comment calls it "a horrible hack" and ties it to "the schema having a bunch of duplicated types".

That duplication has since been fixed upstream. **Both call sites now convert a type to itself:**

- `WorkflowV2.ConditionGroups` is already `[]client.ConditionGroupV2`
- `WorkflowV2.Expressions` is already `[]client.ExpressionV2`

I confirmed by compiling direct assignments against the generated client.

So what the code actually does today is:

1. Two full `json.Marshal` + `json.Unmarshal` cycles on **every** workflow create, read and update — for nothing.
2. Two `panic()` sites reachable from the request path. A panic in a provider crashes the plugin: the user gets a Go stack trace and "the plugin crashed!" rather than a diagnostic.
3. A silent-data-loss hazard. `json.Unmarshal` into a different struct drops fields the target lacks **without error**. If those types ever diverge again, the provider quietly loses workflow condition groups or expressions instead of failing — and workflow expressions are the most intricate part of that resource.

## Change

Delete `forceCoerce`; pass the values straight to `FromAPI`. `buildModel`'s `ctx` parameter is unused once the calls go direct and `unparam` fails the build on it, so that goes too, along with the now-unused `encoding/json`, `tflog` and `pkg/errors` imports.

Net −27 lines.

## Verification

`go build ./...`, `go test ./...` and `golangci-lint run ./...` (0 issues) all pass.

---

Part of a set of independent PRs from a codebase scan. This removes two of the panic sites that the "return diagnostics instead of panicking" PR also addresses — that one is scoped to exclude these, so the two don't overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches workflow state mapping for condition groups and expressions on every CRUD path; behavior should be identical but this is core workflow resource logic.
> 
> **Overview**
> Removes the **`forceCoerce`** helper that JSON-marshaled and unmarshaled workflow **`condition_groups`** and **`expressions`** on every create/read/update even though the API types already match what **`FromAPI`** expects.
> 
> **`IncidentWorkflowResource.buildModel`** now passes **`workflow.ConditionGroups`** and **`workflow.Expressions`** straight into the model converters and drops the unused **`context.Context`** parameter; workflow resource, data source, and tests are updated to match.
> 
> This eliminates redundant serialization work, two request-path **`panic`** sites on marshal/unmarshal failure, and the risk of silent field loss if types ever diverged again during JSON coercion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53c82ba1d329ac6036273ae42c7e8e464c6558a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->