### PR TITLE
Enable govet in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ linters:
     - errcheck
     - forcetypeassert
     - godot
+    - govet
     - ineffassign
     - makezero
     - misspell


### PR DESCRIPTION
## Problem

`.golangci.yml` sets `default: none` and enables fifteen linters — but `govet` isn't one of them. So the standard vet passes never run in CI: no `printf` checking (a format verb mismatched to its argument), no `copylocks`, no `lostcancel`.

## Change

Add `govet` to the enabled list. One line.

## Verification

The tree is already clean under it, so this costs nothing today — `golangci-lint run ./...` reports 0 issues with a cleared cache.

Confirmed it's genuinely doing work rather than silently no-oping, by planting a violation:

```go
return fmt.Sprintf("%d", "not a number")
```

```
printf: fmt.Sprintf format %d has arg "not a number" of wrong type string (govet)
```

## Possible follow-up

`errorlint` would also earn its place here — this codebase leans on `errors.As` for control flow in ~21 places to detect 404s. Left out to keep this reviewable in one line; happy to add it here if you'd prefer.

---

Part of a set of independent PRs from a codebase scan. This one touches only `.golangci.yml` and won't conflict with any of the others.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to lint rules; no runtime or application logic is modified, and the tree already reports zero issues under govet.
> 
> **Overview**
> **Enables the `govet` linter** in `.golangci.yml` so CI’s `golangci-lint` step (in `test.yml`) also runs standard `go vet` checks—e.g. `printf` format/argument mismatches, `copylocks`, and `lostcancel`—alongside the existing enabled linters.
> 
> The repo already passes with this setting; the change only tightens what future PRs must satisfy, with no code edits in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85a7ae918e7a8341fa7e689389c3449e56e68dac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->