### PR TITLE
Route HTTP status checks through one helper

### DIFF
--- a/internal/provider/alert_source_attribute_beta_resource.go
+++ b/internal/provider/alert_source_attribute_beta_resource.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"maps"
 	"net/http"
@@ -269,8 +268,7 @@ func (r *alertSourceAttributeBetaResource) ModifyPlan(ctx context.Context, req r
 	}
 
 	// 422 is the API rejecting this binding, which is the whole point.
-	var httpErr client.HTTPError
-	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusUnprocessableEntity {
+	if httpErr, ok := apiErrorWithStatus(err, http.StatusUnprocessableEntity); ok {
 		resp.Diagnostics.AddError("Invalid alert source attribute", httpErr.Error())
 		return
 	}
@@ -614,12 +612,6 @@ func bindingToModel(binding *models.Binding, model *alertSourceAttributeBetaMode
 	model.Values = binding.Values
 	model.Value = binding.Value
 	model.ArrayValue = binding.ArrayValue
-}
-
-// isConflict reports whether err is an API 409.
-func isConflict(err error) bool {
-	var httpErr client.HTTPError
-	return errors.As(err, &httpErr) && httpErr.StatusCode == 409
 }
 
 // attributeIsBound reports whether the attribute is bound on the source.

--- a/internal/provider/alert_source_beta_resource.go
+++ b/internal/provider/alert_source_beta_resource.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -489,8 +488,7 @@ func (r *alertSourceBetaResource) ModifyPlan(ctx context.Context, req resource.M
 	}
 
 	// 422 is the API rejecting this source, which is the whole point.
-	var httpErr client.HTTPError
-	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusUnprocessableEntity {
+	if httpErr, ok := apiErrorWithStatus(err, http.StatusUnprocessableEntity); ok {
 		resp.Diagnostics.AddError("Invalid alert source", httpErr.Error())
 		return
 	}

--- a/internal/provider/escalation_path_beta_resource.go
+++ b/internal/provider/escalation_path_beta_resource.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 
@@ -351,8 +350,7 @@ func (r *escalationPathBetaResource) ModifyPlan(ctx context.Context, req resourc
 	}
 
 	// 422 is the API rejecting this path, which is the whole point.
-	var httpErr client.HTTPError
-	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusUnprocessableEntity {
+	if httpErr, ok := apiErrorWithStatus(err, http.StatusUnprocessableEntity); ok {
 		resp.Diagnostics.AddError("Invalid escalation path", httpErr.Error())
 		return
 	}

--- a/internal/provider/helpers.go
+++ b/internal/provider/helpers.go
@@ -1,10 +1,14 @@
 package provider
 
 import (
+	"errors"
+	"net/http"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/incident-io/terraform-provider-incident/v6/internal/apischema"
+	"github.com/incident-io/terraform-provider-incident/v6/internal/client"
 )
 
 // EnumValuesDescription documents an attribute whose values are a fixed enum in the API
@@ -45,4 +49,29 @@ func knownInt64(value attr.Value) (int64, bool) {
 	}
 
 	return number.ValueInt64(), true
+}
+
+// apiErrorWithStatus returns the API error behind err when it carries the given status code.
+// Every status the provider reacts to goes through here, so there's one place that knows how
+// the client reports one.
+func apiErrorWithStatus(err error, statusCode int) (client.HTTPError, bool) {
+	httpErr := client.HTTPError{}
+	if errors.As(err, &httpErr) && httpErr.StatusCode == statusCode {
+		return httpErr, true
+	}
+
+	return client.HTTPError{}, false
+}
+
+// isNotFound reports whether err is a 404 from the API, which for a Read means the resource
+// has been deleted outside Terraform and should be removed from state.
+func isNotFound(err error) bool {
+	_, ok := apiErrorWithStatus(err, http.StatusNotFound)
+	return ok
+}
+
+// isConflict reports whether err is a 409 from the API.
+func isConflict(err error) bool {
+	_, ok := apiErrorWithStatus(err, http.StatusConflict)
+	return ok
 }

--- a/internal/provider/helpers_http_test.go
+++ b/internal/provider/helpers_http_test.go
@@ -1,0 +1,50 @@
+package provider
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/incident-io/terraform-provider-incident/v6/internal/client"
+)
+
+func TestAPIErrorWithStatus(t *testing.T) {
+	notFound := client.HTTPError{StatusCode: http.StatusNotFound, Body: []byte(`{"message":"gone"}`)}
+
+	for _, tc := range []struct {
+		name       string
+		err        error
+		statusCode int
+		want       bool
+	}{
+		{"matching status", notFound, http.StatusNotFound, true},
+		{"different status", notFound, http.StatusConflict, false},
+		{"nil error", nil, http.StatusNotFound, false},
+		{"not an API error", fmt.Errorf("dial tcp: connection refused"), http.StatusNotFound, false},
+		// The client wraps errors on the way out, so unwrapping has to work.
+		{"wrapped with pkg/errors", errors.Wrap(notFound, "reading"), http.StatusNotFound, true},
+		{"wrapped with fmt", fmt.Errorf("reading: %w", notFound), http.StatusNotFound, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := apiErrorWithStatus(tc.err, tc.statusCode)
+
+			assert.Equal(t, tc.want, ok)
+			if tc.want {
+				// The caller needs the body to build a diagnostic from.
+				assert.Contains(t, got.Error(), "gone")
+			}
+		})
+	}
+}
+
+func TestIsNotFoundAndIsConflict(t *testing.T) {
+	assert.True(t, isNotFound(client.HTTPError{StatusCode: http.StatusNotFound}))
+	assert.False(t, isNotFound(client.HTTPError{StatusCode: http.StatusConflict}))
+	assert.False(t, isNotFound(nil))
+
+	assert.True(t, isConflict(client.HTTPError{StatusCode: http.StatusConflict}))
+	assert.False(t, isConflict(client.HTTPError{StatusCode: http.StatusNotFound}))
+}

--- a/internal/provider/incident_alert_attribute_resource.go
+++ b/internal/provider/incident_alert_attribute_resource.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -141,9 +140,7 @@ func (r *IncidentAlertAttributeResource) Read(ctx context.Context, req resource.
 
 	result, err := r.client.AlertAttributesV2ShowWithResponse(ctx, data.ID.ValueString())
 	if err != nil {
-		// Check if error message contains any indication of a 404 not found
-		httpErr := client.HTTPError{}
-		if errors.As(err, &httpErr) && httpErr.StatusCode == 404 {
+		if isNotFound(err) {
 			tflog.Warn(ctx, fmt.Sprintf("Alert attribute with ID %s not found: removing from state.", data.ID.ValueString()))
 			resp.State.RemoveResource(ctx)
 			return
@@ -221,9 +218,7 @@ func (r *IncidentAlertAttributeResource) ImportState(ctx context.Context, req re
 	// Get the resource data from API
 	result, err := r.client.AlertAttributesV2ShowWithResponse(ctx, req.ID)
 	if err != nil {
-		// Check if error message contains any indication of a 404 not found
-		httpErr := client.HTTPError{}
-		if errors.As(err, &httpErr) && httpErr.StatusCode == 404 {
+		if isNotFound(err) {
 			tflog.Warn(ctx, fmt.Sprintf("Alert attribute with ID %s not found: removing from state.", req.ID))
 			resp.State.RemoveResource(ctx)
 			return

--- a/internal/provider/incident_alert_route_resource.go
+++ b/internal/provider/incident_alert_route_resource.go
@@ -711,12 +711,6 @@ func (r *IncidentAlertRouteResource) ImportState(ctx context.Context, req resour
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-// isNotFound reports whether err is a 404 from the API.
-func isNotFound(err error) bool {
-	httpErr := client.HTTPError{}
-	return errors.As(err, &httpErr) && httpErr.StatusCode == 404
-}
-
 // alertRouteAPINotYetAvailableCode is the error code the v3 alert routes API
 // returns (with a 403) for organisations that have not migrated to the new
 // alert grouping engine.

--- a/internal/provider/incident_alert_source_resource.go
+++ b/internal/provider/incident_alert_source_resource.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -319,8 +318,7 @@ func (r *IncidentAlertSourceResource) ModifyPlan(ctx context.Context, req resour
 	}
 
 	// 422 is the API telling us this template is wrong, which is the whole point.
-	var httpErr client.HTTPError
-	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusUnprocessableEntity {
+	if httpErr, ok := apiErrorWithStatus(err, http.StatusUnprocessableEntity); ok {
 		resp.Diagnostics.AddAttributeError(path.Root("template"),
 			"Invalid alert source template", httpErr.Error())
 		return
@@ -736,9 +734,7 @@ func (r *IncidentAlertSourceResource) Read(ctx context.Context, req resource.Rea
 
 	result, err := r.client.AlertSourcesV2ShowWithResponse(ctx, data.ID.ValueString())
 	if err != nil {
-		// Check if error message contains any indication of a 404 not found
-		httpErr := client.HTTPError{}
-		if errors.As(err, &httpErr) && httpErr.StatusCode == 404 {
+		if isNotFound(err) {
 			tflog.Warn(ctx, fmt.Sprintf("Alert source with ID %s not found: removing from state.", data.ID.ValueString()))
 			resp.State.RemoveResource(ctx)
 			return

--- a/internal/provider/incident_catalog_entry_resource.go
+++ b/internal/provider/incident_catalog_entry_resource.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sort"
 
@@ -268,9 +267,7 @@ func (r *IncidentCatalogEntryResource) Read(ctx context.Context, req resource.Re
 
 	result, err := r.client.CatalogV3ShowEntryWithResponse(ctx, data.ID.ValueString(), nil)
 	if err != nil {
-		// Check if error message contains any indication of a 404 not found
-		httpErr := client.HTTPError{}
-		if errors.As(err, &httpErr) && httpErr.StatusCode == 404 {
+		if isNotFound(err) {
 			tflog.Warn(ctx, fmt.Sprintf("Catalog entry with ID %s not found: removing from state.", data.ID.ValueString()))
 			resp.State.RemoveResource(ctx)
 			return

--- a/internal/provider/incident_catalog_type_attribute_resource.go
+++ b/internal/provider/incident_catalog_type_attribute_resource.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -303,9 +302,7 @@ func (r *IncidentCatalogTypeAttributeResource) Read(ctx context.Context, req res
 
 	result, err := r.client.CatalogV3ShowTypeWithResponse(ctx, data.CatalogTypeID.ValueString())
 	if err != nil {
-		// Check if error message contains any indication of a 404 not found
-		httpErr := client.HTTPError{}
-		if errors.As(err, &httpErr) && httpErr.StatusCode == 404 {
+		if isNotFound(err) {
 			tflog.Warn(ctx, fmt.Sprintf("Catalog type with ID %s not found: removing from state.", data.CatalogTypeID.ValueString()))
 			resp.State.RemoveResource(ctx)
 			return
@@ -519,8 +516,7 @@ func (r *IncidentCatalogTypeAttributeResource) ImportState(ctx context.Context, 
 	// types.List[DynamicPseudoType] instead of types.List[String]).
 	result, err := r.client.CatalogV3ShowTypeWithResponse(ctx, catalogTypeID)
 	if err != nil {
-		httpErr := client.HTTPError{}
-		if errors.As(err, &httpErr) && httpErr.StatusCode == 404 {
+		if isNotFound(err) {
 			resp.Diagnostics.AddError(
 				"Catalog Type Not Found",
 				fmt.Sprintf("No catalog type exists with ID %q. Import IDs must be in the format catalog_type_id:attribute_id.", catalogTypeID),

--- a/internal/provider/incident_catalog_type_resource.go
+++ b/internal/provider/incident_catalog_type_resource.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -200,9 +199,7 @@ func (r *IncidentCatalogTypeResource) Read(ctx context.Context, req resource.Rea
 
 	result, err := r.client.CatalogV3ShowTypeWithResponse(ctx, data.ID.ValueString())
 	if err != nil {
-		// Check if error message contains any indication of a 404 not found
-		httpErr := client.HTTPError{}
-		if errors.As(err, &httpErr) && httpErr.StatusCode == 404 {
+		if isNotFound(err) {
 			tflog.Warn(ctx, fmt.Sprintf("Catalog type with ID %s not found: removing from state.", data.ID.ValueString()))
 			resp.State.RemoveResource(ctx)
 			return

--- a/internal/provider/incident_custom_field_option_resource.go
+++ b/internal/provider/incident_custom_field_option_resource.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -126,9 +125,7 @@ func (r *IncidentCustomFieldOptionResource) Read(ctx context.Context, req resour
 
 	result, err := r.client.CustomFieldOptionsV1ShowWithResponse(ctx, data.ID.ValueString())
 	if err != nil {
-		// Check if error message contains any indication of a 404 not found
-		httpErr := client.HTTPError{}
-		if errors.As(err, &httpErr) && httpErr.StatusCode == 404 {
+		if isNotFound(err) {
 			tflog.Warn(ctx, fmt.Sprintf("Custom field option with ID %s not found: removing from state.", data.ID.ValueString()))
 			resp.State.RemoveResource(ctx)
 			return

--- a/internal/provider/incident_custom_field_resource.go
+++ b/internal/provider/incident_custom_field_resource.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -170,9 +169,7 @@ func (r *IncidentCustomFieldResource) Read(ctx context.Context, req resource.Rea
 
 	result, err := r.client.CustomFieldsV2ShowWithResponse(ctx, data.ID.ValueString())
 	if err != nil {
-		// Check if error message contains any indication of a 404 not found
-		httpErr := client.HTTPError{}
-		if errors.As(err, &httpErr) && httpErr.StatusCode == 404 {
+		if isNotFound(err) {
 			tflog.Warn(ctx, fmt.Sprintf("Custom field with ID %s not found: removing from state.", data.ID.ValueString()))
 			resp.State.RemoveResource(ctx)
 			return

--- a/internal/provider/incident_escalation_path_resource.go
+++ b/internal/provider/incident_escalation_path_resource.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -439,8 +438,7 @@ func (r *IncidentEscalationPathResource) ModifyPlan(ctx context.Context, req res
 	}
 
 	// 422 is the API rejecting this config, which is the whole point.
-	var httpErr client.HTTPError
-	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusUnprocessableEntity {
+	if httpErr, ok := apiErrorWithStatus(err, http.StatusUnprocessableEntity); ok {
 		resp.Diagnostics.AddError("Invalid escalation path", httpErr.Error())
 		return
 	}
@@ -746,9 +744,7 @@ func (r *IncidentEscalationPathResource) Read(ctx context.Context, req resource.
 
 	result, err := r.client.EscalationsV2ShowPathWithResponse(ctx, data.ID.ValueString())
 	if err != nil {
-		// Check if error message contains any indication of a 404 not found
-		httpErr := client.HTTPError{}
-		if errors.As(err, &httpErr) && httpErr.StatusCode == 404 {
+		if isNotFound(err) {
 			tflog.Warn(ctx, fmt.Sprintf("Escalation path with ID %s not found: removing from state.", data.ID.ValueString()))
 			resp.State.RemoveResource(ctx)
 			return

--- a/internal/provider/incident_maintenance_window_resource.go
+++ b/internal/provider/incident_maintenance_window_resource.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -250,8 +249,7 @@ func (r *IncidentMaintenanceWindowResource) Read(ctx context.Context, req resour
 
 	result, err := r.client.MaintenanceWindowsV1ShowWithResponse(ctx, data.ID.ValueString())
 	if err != nil {
-		httpErr := client.HTTPError{}
-		if errors.As(err, &httpErr) && httpErr.StatusCode == 404 {
+		if isNotFound(err) {
 			tflog.Warn(ctx, fmt.Sprintf("Maintenance window with ID %s not found: removing from state.", data.ID.ValueString()))
 			resp.State.RemoveResource(ctx)
 			return

--- a/internal/provider/incident_role_resource.go
+++ b/internal/provider/incident_role_resource.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -123,9 +122,7 @@ func (r *IncidentRoleResource) Read(ctx context.Context, req resource.ReadReques
 
 	result, err := r.client.IncidentRolesV2ShowWithResponse(ctx, data.ID.ValueString())
 	if err != nil {
-		// Check if error message contains any indication of a 404 not found
-		httpErr := client.HTTPError{}
-		if errors.As(err, &httpErr) && httpErr.StatusCode == 404 {
+		if isNotFound(err) {
 			tflog.Warn(ctx, fmt.Sprintf("Incident role with ID %s not found: removing from state.", data.ID.ValueString()))
 			resp.State.RemoveResource(ctx)
 			return

--- a/internal/provider/incident_schedule_resource.go
+++ b/internal/provider/incident_schedule_resource.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -302,9 +301,7 @@ func (r *IncidentScheduleResource) Read(ctx context.Context, req resource.ReadRe
 
 	result, err := r.client.SchedulesV2ShowWithResponse(ctx, data.ID.ValueString())
 	if err != nil {
-		// Check if error message contains any indication of a 404 not found
-		httpErr := client.HTTPError{}
-		if errors.As(err, &httpErr) && httpErr.StatusCode == 404 {
+		if isNotFound(err) {
 			tflog.Warn(ctx, fmt.Sprintf("Schedule with ID %s not found: removing from state.", data.ID.ValueString()))
 			resp.State.RemoveResource(ctx)
 			return

--- a/internal/provider/incident_schedule_sync_rule_resource.go
+++ b/internal/provider/incident_schedule_sync_rule_resource.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -148,8 +147,7 @@ func (r *IncidentScheduleSyncRuleResource) Read(ctx context.Context, req resourc
 
 	result, err := r.client.SchedulesV2ShowScheduleSyncRuleWithResponse(ctx, data.ScheduleID.ValueString(), data.ID.ValueString())
 	if err != nil {
-		httpErr := client.HTTPError{}
-		if errors.As(err, &httpErr) && httpErr.StatusCode == 404 {
+		if isNotFound(err) {
 			tflog.Warn(ctx, fmt.Sprintf("Schedule sync rule with ID %s not found: removing from state.", data.ID.ValueString()))
 			resp.State.RemoveResource(ctx)
 			return
@@ -255,8 +253,7 @@ func (r *IncidentScheduleSyncRuleResource) ImportState(ctx context.Context, req 
 	// message instead of an empty import.
 	result, err := r.client.SchedulesV2ShowScheduleSyncRuleWithResponse(ctx, scheduleID, ruleID)
 	if err != nil {
-		httpErr := client.HTTPError{}
-		if errors.As(err, &httpErr) && httpErr.StatusCode == 404 {
+		if isNotFound(err) {
 			resp.Diagnostics.AddError(
 				"Schedule Sync Rule Not Found",
 				fmt.Sprintf("No sync rule with ID %q exists on schedule %q. Import IDs must be in the format schedule_id:rule_id.", ruleID, scheduleID),

--- a/internal/provider/incident_schedule_sync_target_resource.go
+++ b/internal/provider/incident_schedule_sync_target_resource.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -195,8 +194,7 @@ func (r *IncidentScheduleSyncTargetResource) Read(ctx context.Context, req resou
 
 	result, err := r.client.ScheduleSyncTargetsV2ShowWithResponse(ctx, data.ID.ValueString())
 	if err != nil {
-		httpErr := client.HTTPError{}
-		if errors.As(err, &httpErr) && httpErr.StatusCode == 404 {
+		if isNotFound(err) {
 			tflog.Warn(ctx, fmt.Sprintf("Schedule sync target with ID %s not found: removing from state.", data.ID.ValueString()))
 			resp.State.RemoveResource(ctx)
 			return
@@ -280,8 +278,7 @@ func (r *IncidentScheduleSyncTargetResource) ImportState(ctx context.Context, re
 	// message instead of an empty import.
 	result, err := r.client.ScheduleSyncTargetsV2ShowWithResponse(ctx, targetID)
 	if err != nil {
-		httpErr := client.HTTPError{}
-		if errors.As(err, &httpErr) && httpErr.StatusCode == 404 {
+		if isNotFound(err) {
 			resp.Diagnostics.AddError(
 				"Schedule Sync Target Not Found",
 				fmt.Sprintf("No sync target exists with ID %q.", targetID),

--- a/internal/provider/incident_severity_resource.go
+++ b/internal/provider/incident_severity_resource.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -122,9 +121,7 @@ func (r *IncidentSeverityResource) Read(ctx context.Context, req resource.ReadRe
 
 	result, err := r.client.SeveritiesV1ShowWithResponse(ctx, data.ID.ValueString())
 	if err != nil {
-		// Check if error message contains any indication of a 404 not found
-		httpErr := client.HTTPError{}
-		if errors.As(err, &httpErr) && httpErr.StatusCode == 404 {
+		if isNotFound(err) {
 			tflog.Warn(ctx, fmt.Sprintf("Incident severity with ID %s not found: removing from state.", data.ID.ValueString()))
 			resp.State.RemoveResource(ctx)
 			return

--- a/internal/provider/incident_status_resource.go
+++ b/internal/provider/incident_status_resource.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -120,9 +119,7 @@ func (r *IncidentStatusResource) Read(ctx context.Context, req resource.ReadRequ
 
 	result, err := r.client.IncidentStatusesV1ShowWithResponse(ctx, data.ID.ValueString())
 	if err != nil {
-		// Check if error message contains any indication of a 404 not found
-		httpErr := client.HTTPError{}
-		if errors.As(err, &httpErr) && httpErr.StatusCode == 404 {
+		if isNotFound(err) {
 			tflog.Warn(ctx, fmt.Sprintf("Incident status with ID %s not found: removing from state.", data.ID.ValueString()))
 			resp.State.RemoveResource(ctx)
 			return

--- a/internal/provider/incident_workflow_resource.go
+++ b/internal/provider/incident_workflow_resource.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -414,9 +413,7 @@ func (r *IncidentWorkflowResource) Read(ctx context.Context, req resource.ReadRe
 		SkipStepUpgrades: lo.ToPtr(true),
 	})
 	if err != nil {
-		// Check if error message contains any indication of a 404 not found
-		httpErr := client.HTTPError{}
-		if errors.As(err, &httpErr) && httpErr.StatusCode == 404 {
+		if isNotFound(err) {
 			tflog.Warn(ctx, fmt.Sprintf("Workflow with ID %s not found: removing from state.", data.ID.ValueString()))
 			resp.State.RemoveResource(ctx)
 			return


### PR DESCRIPTION
## Problem

Twenty-one `Read` and `ImportState` methods each carry their own copy of this:

```go
// Check if error message contains any indication of a 404 not found
httpErr := client.HTTPError{}
if errors.As(err, &httpErr) && httpErr.StatusCode == 404 {
	tflog.Warn(ctx, ...)
	resp.State.RemoveResource(ctx)
	return
}
```

`isNotFound` **already exists** for exactly this, at `incident_alert_route_resource.go:715` — it's just never used outside that one file.

That comment appears on fourteen of the copies and is stale: it describes matching on the error *message*, which the code stopped doing when it moved to `errors.As`. Anyone reading it would think status detection here is string-based.

Separately, five sites hand-rolled the same shape for 422 and one for 409, with a bare `404`/`409` literal rather than the `net/http` constant.

## Change

One primitive in `helpers.go`:

```go
func apiErrorWithStatus(err error, statusCode int) (client.HTTPError, bool)
```

with `isNotFound` and `isConflict` named on top. It returns the error rather than just a bool because the 422 sites put `httpErr.Error()` into their diagnostic — a bare predicate would have moved the duplication rather than removed it. `isConflict` moves out of `alert_source_attribute_beta_resource.go` for the same reason.

There is now exactly one place in the provider that knows how the client reports an HTTP status.

**No behaviour change.** −95/+54 lines across 21 files.

## Tests

New `helpers_http_test.go`, including that unwrapping works through both `pkg/errors` and `fmt %w`. That case matters: the client wraps errors on the way out, and an `isNotFound` that silently returned false for a wrapped 404 would leave a resource deleted outside Terraform stuck in state forever.

## Verification

`go build`, `go vet`, `golangci-lint run ./...` (0 issues), `go test ./...` all pass. Confirmed no raw status comparison survives outside the helper.

---

Part of a set of independent PRs from a codebase scan. This touches the same `Read` methods as the "guard nil API responses" PR, so expect conflicts between those two — they're each self-contained, and I'd suggest merging this one first since it shrinks the surface the other has to edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)