### PR TITLE
Share the Configure boilerplate across resources and data sources

### DIFF
--- a/internal/provider/alert_source_attribute_beta_modify_plan_test.go
+++ b/internal/provider/alert_source_attribute_beta_modify_plan_test.go
@@ -95,7 +95,7 @@ func modifyAlertSourceAttributePlanFrom(
 ) resource.ModifyPlanResponse {
 	t.Helper()
 
-	r := &alertSourceAttributeBetaResource{client: api.start(t)}
+	r := &alertSourceAttributeBetaResource{resourceConfigurer: withClient(api.start(t))}
 
 	var resp resource.ModifyPlanResponse
 	r.ModifyPlan(context.Background(), resource.ModifyPlanRequest{Plan: plan, State: state}, &resp)

--- a/internal/provider/alert_source_attribute_beta_resource.go
+++ b/internal/provider/alert_source_attribute_beta_resource.go
@@ -38,7 +38,7 @@ func NewAlertSourceAttributeBetaResource() resource.Resource {
 }
 
 type alertSourceAttributeBetaResource struct {
-	client *client.ClientWithResponses
+	resourceConfigurer
 }
 
 // alertSourceAttributeBetaModel is one attribute of one alert source. The value spellings sit
@@ -126,21 +126,6 @@ compatible, so pin the provider version if that matters to you.
 			"named_expression": models.NamedExpressionBlock(),
 		},
 	}
-}
-
-func (r *alertSourceAttributeBetaResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-	data, ok := req.ProviderData.(*IncidentProviderData)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected provider data",
-			fmt.Sprintf("expected *IncidentProviderData, got %T. This is a provider bug.", req.ProviderData),
-		)
-		return
-	}
-	r.client = data.Client
 }
 
 var alertSourceAttributeMergeStrategies = enumValues("AlertSourceAttributeV3", "merge_strategy")

--- a/internal/provider/alert_source_beta_modify_plan_test.go
+++ b/internal/provider/alert_source_beta_modify_plan_test.go
@@ -95,7 +95,7 @@ func modifyAlertSourceBetaPlanFrom(
 ) resource.ModifyPlanResponse {
 	t.Helper()
 
-	r := &alertSourceBetaResource{client: api.start(t)}
+	r := &alertSourceBetaResource{resourceConfigurer: withClient(api.start(t))}
 
 	var resp resource.ModifyPlanResponse
 	r.ModifyPlan(context.Background(), resource.ModifyPlanRequest{Plan: plan, State: state}, &resp)

--- a/internal/provider/alert_source_beta_resource.go
+++ b/internal/provider/alert_source_beta_resource.go
@@ -36,9 +36,7 @@ func NewAlertSourceBetaResource() resource.Resource {
 }
 
 type alertSourceBetaResource struct {
-	client                *client.ClientWithResponses
-	terraformVersion      string
-	markImportedAsManaged bool
+	resourceConfigurer
 }
 
 // alertSourceExpressions stores names as written: only this source's attributes, which share a
@@ -220,23 +218,6 @@ compatible, so pin the provider version if that matters to you.
 			"named_expression": models.NamedExpressionBlock(),
 		},
 	}
-}
-
-func (r *alertSourceBetaResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-	data, ok := req.ProviderData.(*IncidentProviderData)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected provider data",
-			fmt.Sprintf("expected *IncidentProviderData, got %T. This is a provider bug.", req.ProviderData),
-		)
-		return
-	}
-	r.client = data.Client
-	r.terraformVersion = data.TerraformVersion
-	r.markImportedAsManaged = data.MarkImportedAsManaged
 }
 
 // ValidateConfig runs the checks the schema can't express, so they land at plan time against a

--- a/internal/provider/configure.go
+++ b/internal/provider/configure.go
@@ -1,0 +1,73 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+
+	"github.com/incident-io/terraform-provider-incident/v6/internal/client"
+)
+
+// providerConfig is everything a resource or data source takes from the provider. Embed
+// resourceConfigurer or dataSourceConfigurer rather than this, and read the fields directly:
+// they promote, so r.client keeps working.
+type providerConfig struct {
+	client                *client.ClientWithResponses
+	terraformVersion      string
+	markImportedAsManaged bool
+}
+
+// configure reads the provider data, which is nil until the provider itself is configured —
+// the framework calls Configure on every resource and data source in the graph regardless.
+func (c *providerConfig) configure(providerData any, diags *diag.Diagnostics) {
+	if providerData == nil {
+		return
+	}
+
+	data, ok := providerData.(*IncidentProviderData)
+	if !ok {
+		diags.AddError(
+			"Unexpected Provider Data",
+			fmt.Sprintf("Expected *IncidentProviderData, got: %T. Please report this issue to the provider developers.", providerData),
+		)
+
+		return
+	}
+
+	c.client = data.Client
+	c.terraformVersion = data.TerraformVersion
+	c.markImportedAsManaged = data.MarkImportedAsManaged
+}
+
+// resourceConfigurer implements Configure for a resource. Embed it in the resource struct.
+type resourceConfigurer struct {
+	providerConfig
+}
+
+func (c *resourceConfigurer) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	c.configure(req.ProviderData, &resp.Diagnostics)
+}
+
+// dataSourceConfigurer implements Configure for a data source. Embed it in the data source
+// struct. It's separate from resourceConfigurer only because the framework gives the two a
+// different request and response type, so one method can't serve both.
+type dataSourceConfigurer struct {
+	providerConfig
+}
+
+func (c *dataSourceConfigurer) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	c.configure(req.ProviderData, &resp.Diagnostics)
+}
+
+// withClient and withClientDataSource build a configurer around a client, for tests that
+// construct a resource or data source directly rather than through the provider.
+func withClient(c *client.ClientWithResponses) resourceConfigurer {
+	return resourceConfigurer{providerConfig{client: c}}
+}
+
+func withClientDataSource(c *client.ClientWithResponses) dataSourceConfigurer {
+	return dataSourceConfigurer{providerConfig{client: c}}
+}

--- a/internal/provider/configure_test.go
+++ b/internal/provider/configure_test.go
@@ -1,0 +1,121 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/incident-io/terraform-provider-incident/v6/internal/client"
+)
+
+// Configure is promoted from an embedded configurer rather than declared on each type, so
+// assert every registered resource and data source still satisfies the framework interface
+// and actually takes the client. A missing Configure fails at apply with a nil client, not at
+// compile time.
+func TestEveryResourceIsConfigurable(t *testing.T) {
+	p := &IncidentProvider{}
+	api := &client.ClientWithResponses{}
+	providerData := &IncidentProviderData{
+		Client:                api,
+		TerraformVersion:      "1.14.0",
+		MarkImportedAsManaged: true,
+	}
+
+	for _, newResource := range p.Resources(context.Background()) {
+		r := newResource()
+		name := fmt.Sprintf("%T", r)
+
+		t.Run(name, func(t *testing.T) {
+			configurable, ok := r.(resource.ResourceWithConfigure)
+			require.True(t, ok, "%s does not implement resource.ResourceWithConfigure", name)
+
+			resp := &resource.ConfigureResponse{}
+			configurable.Configure(context.Background(),
+				resource.ConfigureRequest{ProviderData: providerData}, resp)
+
+			require.False(t, resp.Diagnostics.HasError(), "%v", resp.Diagnostics)
+			assert.Same(t, api, clientOf(t, r), "%s did not take the client", name)
+		})
+	}
+
+	for _, newDataSource := range p.DataSources(context.Background()) {
+		d := newDataSource()
+		name := fmt.Sprintf("%T", d)
+
+		t.Run(name, func(t *testing.T) {
+			configurable, ok := d.(datasource.DataSourceWithConfigure)
+			require.True(t, ok, "%s does not implement datasource.DataSourceWithConfigure", name)
+
+			resp := &datasource.ConfigureResponse{}
+			configurable.Configure(context.Background(),
+				datasource.ConfigureRequest{ProviderData: providerData}, resp)
+
+			require.False(t, resp.Diagnostics.HasError(), "%v", resp.Diagnostics)
+			assert.Same(t, api, clientOf(t, d), "%s did not take the client", name)
+		})
+	}
+}
+
+// The framework calls Configure on everything in the graph before the provider itself is
+// configured, handing it a nil ProviderData. That has to be a no-op, not an error.
+func TestConfigureToleratesNilProviderData(t *testing.T) {
+	var c providerConfig
+	var diags diag.Diagnostics
+
+	c.configure(nil, &diags)
+
+	assert.False(t, diags.HasError())
+	assert.Nil(t, c.client)
+}
+
+func TestConfigureRejectsUnexpectedProviderData(t *testing.T) {
+	var c providerConfig
+	var diags diag.Diagnostics
+
+	c.configure("not the provider data", &diags)
+
+	require.True(t, diags.HasError())
+	assert.Contains(t, diags.Errors()[0].Detail(), "Expected *IncidentProviderData")
+}
+
+// configuredClient is declared here rather than in configure.go because only the tests need
+// it. Embedding promotes it, so it reaches the client of any resource or data source.
+func (c providerConfig) configuredClient() *client.ClientWithResponses {
+	return c.client
+}
+
+// clientOf reaches the promoted client field, whichever configurer the type embeds.
+func clientOf(t *testing.T, v any) *client.ClientWithResponses {
+	t.Helper()
+
+	c, ok := v.(interface {
+		configuredClient() *client.ClientWithResponses
+	})
+	require.True(t, ok, "%T embeds no configurer", v)
+
+	return c.configuredClient()
+}
+
+// configure sets everything the provider hands over, not just the client.
+func TestConfigureTakesAllProviderData(t *testing.T) {
+	var c providerConfig
+	var diags diag.Diagnostics
+	api := &client.ClientWithResponses{}
+
+	c.configure(&IncidentProviderData{
+		Client:                api,
+		TerraformVersion:      "1.15.2",
+		MarkImportedAsManaged: false,
+	}, &diags)
+
+	require.False(t, diags.HasError())
+	assert.Same(t, api, c.client)
+	assert.Equal(t, "1.15.2", c.terraformVersion)
+	assert.False(t, c.markImportedAsManaged)
+}

--- a/internal/provider/escalation_path_beta_resource.go
+++ b/internal/provider/escalation_path_beta_resource.go
@@ -34,9 +34,7 @@ func NewEscalationPathBetaResource() resource.Resource {
 }
 
 type escalationPathBetaResource struct {
-	client                *client.ClientWithResponses
-	terraformVersion      string
-	markImportedAsManaged bool
+	resourceConfigurer
 }
 
 type escalationPathBetaModel struct {
@@ -252,25 +250,6 @@ func escalationPathBetaNodeSchema() schema.NestedAttributeObject {
 			},
 		},
 	}
-}
-
-func (r *escalationPathBetaResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-
-	data, ok := req.ProviderData.(*IncidentProviderData)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *IncidentProviderData, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-		return
-	}
-
-	r.client = data.Client
-	r.terraformVersion = data.TerraformVersion
-	r.markImportedAsManaged = data.MarkImportedAsManaged
 }
 
 func (r *escalationPathBetaResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {

--- a/internal/provider/incident_alert_attribute_data_source.go
+++ b/internal/provider/incident_alert_attribute_data_source.go
@@ -23,7 +23,7 @@ func NewIncidentAlertAttributeDataSource() datasource.DataSource {
 }
 
 type IncidentAlertAttributeDataSource struct {
-	client *client.ClientWithResponses
+	dataSourceConfigurer
 }
 
 func (i *IncidentAlertAttributeDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
@@ -56,24 +56,6 @@ func (i *IncidentAlertAttributeDataSource) Schema(ctx context.Context, req datas
 			},
 		},
 	}
-}
-
-func (i *IncidentAlertAttributeDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-
-	client, ok := req.ProviderData.(*IncidentProviderData)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Data Source Alert Attribute Type",
-			fmt.Sprintf("Expected *client.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-
-		return
-	}
-
-	i.client = client.Client
 }
 
 func (i *IncidentAlertAttributeDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {

--- a/internal/provider/incident_alert_attribute_resource.go
+++ b/internal/provider/incident_alert_attribute_resource.go
@@ -24,8 +24,7 @@ var (
 )
 
 type IncidentAlertAttributeResource struct {
-	client           *client.ClientWithResponses
-	terraformVersion string
+	resourceConfigurer
 }
 
 type IncidentAlertAttributeResourceModel struct {
@@ -79,25 +78,6 @@ func (r *IncidentAlertAttributeResource) Schema(ctx context.Context, req resourc
 			},
 		},
 	}
-}
-
-func (r *IncidentAlertAttributeResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-
-	client, ok := req.ProviderData.(*IncidentProviderData)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *client.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-
-		return
-	}
-
-	r.client = client.Client
-	r.terraformVersion = client.TerraformVersion
 }
 
 func (r *IncidentAlertAttributeResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/provider/incident_alert_route_resource.go
+++ b/internal/provider/incident_alert_route_resource.go
@@ -50,9 +50,7 @@ const (
 )
 
 type IncidentAlertRouteResource struct {
-	client                *client.ClientWithResponses
-	terraformVersion      string
-	markImportedAsManaged bool
+	resourceConfigurer
 }
 
 func NewIncidentAlertRouteResource() resource.Resource {
@@ -465,25 +463,6 @@ func incidentTemplateAttributes(includeWorkspace bool) map[string]schema.Attribu
 	}
 
 	return attrs
-}
-
-func (r *IncidentAlertRouteResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-
-	client, ok := req.ProviderData.(*IncidentProviderData)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *client.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-		return
-	}
-
-	r.client = client.Client
-	r.terraformVersion = client.TerraformVersion
-	r.markImportedAsManaged = client.MarkImportedAsManaged
 }
 
 func (r *IncidentAlertRouteResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/provider/incident_alert_source_modify_plan_test.go
+++ b/internal/provider/incident_alert_source_modify_plan_test.go
@@ -225,7 +225,7 @@ func modifyAlertSourcePlanWithState(t *testing.T, api *fakeValidateAPI, plan *tf
 		planRaw = *plan
 	}
 
-	r := &IncidentAlertSourceResource{client: api.start(t)}
+	r := &IncidentAlertSourceResource{resourceConfigurer: withClient(api.start(t))}
 
 	var resp resource.ModifyPlanResponse
 	r.ModifyPlan(t.Context(), resource.ModifyPlanRequest{

--- a/internal/provider/incident_alert_source_resource.go
+++ b/internal/provider/incident_alert_source_resource.go
@@ -32,9 +32,7 @@ var (
 )
 
 type IncidentAlertSourceResource struct {
-	client                *client.ClientWithResponses
-	terraformVersion      string
-	markImportedAsManaged bool
+	resourceConfigurer
 }
 
 // ValidateConfig checks that jira_options is only set when the source type is
@@ -628,25 +626,6 @@ func (r *IncidentAlertSourceResource) Schema(ctx context.Context, req resource.S
 			},
 		},
 	}
-}
-
-func (r *IncidentAlertSourceResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-
-	client, ok := req.ProviderData.(*IncidentProviderData)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *client.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-		return
-	}
-
-	r.client = client.Client
-	r.terraformVersion = client.TerraformVersion
-	r.markImportedAsManaged = client.MarkImportedAsManaged
 }
 
 func (r *IncidentAlertSourceResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/provider/incident_alert_sources_data_source.go
+++ b/internal/provider/incident_alert_sources_data_source.go
@@ -25,7 +25,7 @@ func NewIncidentAlertSourcesDataSource() datasource.DataSource {
 }
 
 type IncidentAlertSourcesDataSource struct {
-	client *client.ClientWithResponses
+	dataSourceConfigurer
 }
 
 type IncidentAlertSourcesDataSourceModel struct {
@@ -42,23 +42,6 @@ type IncidentAlertSourcesDataSourceItemModel struct {
 	Template       *models.AlertTemplateModel          `tfsdk:"template"`
 	JiraOptions    *models.AlertSourceJiraOptionsModel `tfsdk:"jira_options"`
 	EmailAddress   types.String                        `tfsdk:"email_address"`
-}
-
-func (d *IncidentAlertSourcesDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-
-	client, ok := req.ProviderData.(*IncidentProviderData)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected *IncidentProviderData, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-		return
-	}
-
-	d.client = client.Client
 }
 
 func (d *IncidentAlertSourcesDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {

--- a/internal/provider/incident_catalog_entries_data_source.go
+++ b/internal/provider/incident_catalog_entries_data_source.go
@@ -23,7 +23,7 @@ func NewIncidentCatalogEntriesDataSource() datasource.DataSource {
 }
 
 type IncidentCatalogEntriesDataSource struct {
-	client *client.ClientWithResponses
+	dataSourceConfigurer
 }
 
 type IncidentCatalogEntriesDataSourceModel struct {
@@ -39,23 +39,6 @@ type IncidentCatalogEntriesDataSourceEntryModel struct {
 	Aliases         types.List                   `tfsdk:"aliases"`
 	Rank            types.Int64                  `tfsdk:"rank"`
 	AttributeValues []CatalogEntryAttributeValue `tfsdk:"attribute_values"`
-}
-
-func (d *IncidentCatalogEntriesDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-
-	client, ok := req.ProviderData.(*IncidentProviderData)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected *IncidentProviderData, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-		return
-	}
-
-	d.client = client.Client
 }
 
 func (d *IncidentCatalogEntriesDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {

--- a/internal/provider/incident_catalog_entries_resource.go
+++ b/internal/provider/incident_catalog_entries_resource.go
@@ -31,7 +31,7 @@ var (
 )
 
 type IncidentCatalogEntriesResource struct {
-	client *client.ClientWithResponses
+	resourceConfigurer
 }
 
 type IncidentCatalogEntriesResourceModel struct {
@@ -164,24 +164,6 @@ This can be used to allow other attributes of a catalog entry to be managed else
 			},
 		},
 	}
-}
-
-func (r *IncidentCatalogEntriesResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-
-	client, ok := req.ProviderData.(*IncidentProviderData)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *client.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-
-		return
-	}
-
-	r.client = client.Client
 }
 
 func (r *IncidentCatalogEntriesResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/provider/incident_catalog_entry_data_source.go
+++ b/internal/provider/incident_catalog_entry_data_source.go
@@ -24,7 +24,7 @@ func NewIncidentCatalogEntryDataSource() datasource.DataSource {
 }
 
 type IncidentCatalogEntryDataSource struct {
-	client *client.ClientWithResponses
+	dataSourceConfigurer
 }
 
 type IncidentCatalogEntryDataSourceModel struct {
@@ -96,24 +96,6 @@ The API will automatically match the identifier against names, external IDs, and
 			},
 		},
 	}
-}
-
-func (i *IncidentCatalogEntryDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-
-	client, ok := req.ProviderData.(*IncidentProviderData)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Data Source Catalog Entry",
-			fmt.Sprintf("Expected *client.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-
-		return
-	}
-
-	i.client = client.Client
 }
 
 func (i *IncidentCatalogEntryDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {

--- a/internal/provider/incident_catalog_entry_resource.go
+++ b/internal/provider/incident_catalog_entry_resource.go
@@ -29,7 +29,7 @@ var (
 )
 
 type IncidentCatalogEntryResource struct {
-	client *client.ClientWithResponses
+	resourceConfigurer
 }
 
 type IncidentCatalogEntryResourceModel struct {
@@ -197,24 +197,6 @@ When ` + "`managed_attributes`" + ` is set, destroying the Terraform resource wi
 			},
 		},
 	}
-}
-
-func (r *IncidentCatalogEntryResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-
-	client, ok := req.ProviderData.(*IncidentProviderData)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *client.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-
-		return
-	}
-
-	r.client = client.Client
 }
 
 func (r *IncidentCatalogEntryResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/provider/incident_catalog_type_attribute_data_source.go
+++ b/internal/provider/incident_catalog_type_attribute_data_source.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/incident-io/terraform-provider-incident/v6/internal/apischema"
-	"github.com/incident-io/terraform-provider-incident/v6/internal/client"
 )
 
 var (
@@ -24,7 +23,7 @@ func NewIncidentCatalogTypeAttributeDataSource() datasource.DataSource {
 }
 
 type IncidentCatalogTypeAttributeDataSource struct {
-	client *client.ClientWithResponses
+	dataSourceConfigurer
 }
 
 type IncidentCatalogTypeAttributeDataSourceModel struct {
@@ -77,24 +76,6 @@ func (i *IncidentCatalogTypeAttributeDataSource) Schema(ctx context.Context, req
 			},
 		},
 	}
-}
-
-func (i *IncidentCatalogTypeAttributeDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-
-	client, ok := req.ProviderData.(*IncidentProviderData)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Data Source Catalog Type Attribute",
-			fmt.Sprintf("Expected *client.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-
-		return
-	}
-
-	i.client = client.Client
 }
 
 func (i *IncidentCatalogTypeAttributeDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {

--- a/internal/provider/incident_catalog_type_attribute_resource.go
+++ b/internal/provider/incident_catalog_type_attribute_resource.go
@@ -48,7 +48,7 @@ func isSchemaOnlyMode(mode client.CatalogTypeAttributeV3Mode) bool {
 }
 
 type IncidentCatalogTypeAttributeResource struct {
-	client *client.ClientWithResponses
+	resourceConfigurer
 }
 
 type IncidentCatalogTypeAttributesResourceModel struct {
@@ -221,24 +221,6 @@ func (r *IncidentCatalogTypeAttributeResource) ValidateConfig(ctx context.Contex
 	if isSchemaOnly && isPath {
 		resp.Diagnostics.AddError("schema_only", "You cannot set schema_only on a path attribute.")
 	}
-}
-
-func (r *IncidentCatalogTypeAttributeResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-
-	client, ok := req.ProviderData.(*IncidentProviderData)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *client.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-
-		return
-	}
-
-	r.client = client.Client
 }
 
 func (r *IncidentCatalogTypeAttributeResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/provider/incident_catalog_type_data_source.go
+++ b/internal/provider/incident_catalog_type_data_source.go
@@ -23,7 +23,7 @@ func NewIncidentCatalogTypeDataSource() datasource.DataSource {
 }
 
 type IncidentCatalogTypeDataSource struct {
-	client *client.ClientWithResponses
+	dataSourceConfigurer
 }
 
 func (i *IncidentCatalogTypeDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
@@ -68,24 +68,6 @@ func (i *IncidentCatalogTypeDataSource) Schema(ctx context.Context, req datasour
 			},
 		},
 	}
-}
-
-func (i *IncidentCatalogTypeDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-
-	client, ok := req.ProviderData.(*IncidentProviderData)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Data Source Catalog Type",
-			fmt.Sprintf("Expected *client.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-
-		return
-	}
-
-	i.client = client.Client
 }
 
 func (i *IncidentCatalogTypeDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {

--- a/internal/provider/incident_catalog_type_resource.go
+++ b/internal/provider/incident_catalog_type_resource.go
@@ -27,8 +27,7 @@ var (
 )
 
 type IncidentCatalogTypeResource struct {
-	client           *client.ClientWithResponses
-	terraformVersion string
+	resourceConfigurer
 }
 
 type IncidentCatalogTypeResourceModel struct {
@@ -113,25 +112,6 @@ func (r *IncidentCatalogTypeResource) Schema(ctx context.Context, req resource.S
 			},
 		},
 	}
-}
-
-func (r *IncidentCatalogTypeResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-
-	client, ok := req.ProviderData.(*IncidentProviderData)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *client.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-
-		return
-	}
-
-	r.client = client.Client
-	r.terraformVersion = client.TerraformVersion
 }
 
 func (r *IncidentCatalogTypeResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/provider/incident_custom_field_data_source.go
+++ b/internal/provider/incident_custom_field_data_source.go
@@ -22,7 +22,7 @@ func NewIncidentCustomFieldDataSource() datasource.DataSource {
 }
 
 type IncidentCustomFieldDataSource struct {
-	client *client.ClientWithResponses
+	dataSourceConfigurer
 }
 
 func (i *IncidentCustomFieldDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
@@ -73,24 +73,6 @@ func (i *IncidentCustomFieldDataSource) Schema(ctx context.Context, req datasour
 			},
 		},
 	}
-}
-
-func (i *IncidentCustomFieldDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-
-	client, ok := req.ProviderData.(*IncidentProviderData)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Data Source Custom Field",
-			fmt.Sprintf("Expected *client.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-
-		return
-	}
-
-	i.client = client.Client
 }
 
 func (i *IncidentCustomFieldDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {

--- a/internal/provider/incident_custom_field_option_data_source.go
+++ b/internal/provider/incident_custom_field_option_data_source.go
@@ -22,7 +22,7 @@ func NewIncidentCustomFieldOptionDataSource() datasource.DataSource {
 }
 
 type IncidentCustomFieldOptionDataSource struct {
-	client *client.ClientWithResponses
+	dataSourceConfigurer
 }
 
 func (i *IncidentCustomFieldOptionDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
@@ -47,24 +47,6 @@ func (i *IncidentCustomFieldOptionDataSource) Schema(ctx context.Context, req da
 			},
 		},
 	}
-}
-
-func (i *IncidentCustomFieldOptionDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-
-	client, ok := req.ProviderData.(*IncidentProviderData)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Data Source Custom Field Option",
-			fmt.Sprintf("Expected *client.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-
-		return
-	}
-
-	i.client = client.Client
 }
 
 func (i *IncidentCustomFieldOptionDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {

--- a/internal/provider/incident_custom_field_option_resource.go
+++ b/internal/provider/incident_custom_field_option_resource.go
@@ -24,7 +24,7 @@ var (
 )
 
 type IncidentCustomFieldOptionResource struct {
-	client *client.ClientWithResponses
+	resourceConfigurer
 }
 
 type IncidentCustomFieldOptionResourceModel struct {
@@ -71,24 +71,6 @@ func (r *IncidentCustomFieldOptionResource) Schema(ctx context.Context, req reso
 			},
 		},
 	}
-}
-
-func (r *IncidentCustomFieldOptionResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-
-	client, ok := req.ProviderData.(*IncidentProviderData)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *client.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-
-		return
-	}
-
-	r.client = client.Client
 }
 
 func (r *IncidentCustomFieldOptionResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/provider/incident_custom_field_resource.go
+++ b/internal/provider/incident_custom_field_resource.go
@@ -23,7 +23,7 @@ var (
 )
 
 type IncidentCustomFieldResource struct {
-	client *client.ClientWithResponses
+	resourceConfigurer
 }
 
 type IncidentCustomFieldResourceModel struct {
@@ -107,24 +107,6 @@ func (r *IncidentCustomFieldResource) Schema(ctx context.Context, req resource.S
 			},
 		},
 	}
-}
-
-func (r *IncidentCustomFieldResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-
-	client, ok := req.ProviderData.(*IncidentProviderData)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *client.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-
-		return
-	}
-
-	r.client = client.Client
 }
 
 func (r *IncidentCustomFieldResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/provider/incident_escalation_path_data_source.go
+++ b/internal/provider/incident_escalation_path_data_source.go
@@ -24,7 +24,8 @@ func NewIncidentEscalationPathDataSource() datasource.DataSource {
 }
 
 type IncidentEscalationPathDataSource struct {
-	client                        *client.ClientWithResponses
+	dataSourceConfigurer
+
 	escalationPathTypeID          string
 	escalationPathTypeIDOnce      sync.Once
 	escalationPathTypeIDLookupErr error
@@ -32,23 +33,6 @@ type IncidentEscalationPathDataSource struct {
 
 func (d *IncidentEscalationPathDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_escalation_path"
-}
-
-func (d *IncidentEscalationPathDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-
-	client, ok := req.ProviderData.(*IncidentProviderData)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected *IncidentProviderData, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-		return
-	}
-
-	d.client = client.Client
 }
 
 func (d *IncidentEscalationPathDataSource) getEscalationPathTypeID(ctx context.Context) (string, error) {

--- a/internal/provider/incident_escalation_path_modify_plan_test.go
+++ b/internal/provider/incident_escalation_path_modify_plan_test.go
@@ -180,7 +180,7 @@ func modifyEscalationPathPlanWithState(t *testing.T, api *fakeEscalationPathVali
 		planRaw = *plan
 	}
 
-	r := &IncidentEscalationPathResource{client: api.start(t)}
+	r := &IncidentEscalationPathResource{resourceConfigurer: withClient(api.start(t))}
 
 	var resp resource.ModifyPlanResponse
 	r.ModifyPlan(t.Context(), resource.ModifyPlanRequest{

--- a/internal/provider/incident_escalation_path_resource.go
+++ b/internal/provider/incident_escalation_path_resource.go
@@ -36,9 +36,7 @@ var (
 )
 
 type IncidentEscalationPathResource struct {
-	client                *client.ClientWithResponses
-	terraformVersion      string
-	markImportedAsManaged bool
+	resourceConfigurer
 }
 
 type IncidentEscalationPathResourceModel struct {
@@ -308,26 +306,6 @@ func (r *IncidentEscalationPathResource) getPathSchema(depth int) schema.NestedA
 	}
 
 	return result
-}
-
-func (r *IncidentEscalationPathResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-
-	client, ok := req.ProviderData.(*IncidentProviderData)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *client.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-
-		return
-	}
-
-	r.client = client.Client
-	r.terraformVersion = client.TerraformVersion
-	r.markImportedAsManaged = client.MarkImportedAsManaged
 }
 
 func (r *IncidentEscalationPathResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {

--- a/internal/provider/incident_incident_types_data_source.go
+++ b/internal/provider/incident_incident_types_data_source.go
@@ -22,7 +22,7 @@ func NewIncidentIncidentTypesDataSource() datasource.DataSource {
 }
 
 type IncidentIncidentTypesDataSource struct {
-	client *client.ClientWithResponses
+	dataSourceConfigurer
 }
 
 type IncidentIncidentTypesDataSourceModel struct {
@@ -36,23 +36,6 @@ type IncidentIncidentTypesDataSourceItemModel struct {
 	CreateInTriage       types.String `tfsdk:"create_in_triage"`
 	IsDefault            types.Bool   `tfsdk:"is_default"`
 	PrivateIncidentsOnly types.Bool   `tfsdk:"private_incidents_only"`
-}
-
-func (d *IncidentIncidentTypesDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-
-	client, ok := req.ProviderData.(*IncidentProviderData)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected *IncidentProviderData, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-		return
-	}
-
-	d.client = client.Client
 }
 
 func (d *IncidentIncidentTypesDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {

--- a/internal/provider/incident_maintenance_window_resource.go
+++ b/internal/provider/incident_maintenance_window_resource.go
@@ -28,7 +28,7 @@ var (
 )
 
 type IncidentMaintenanceWindowResource struct {
-	client *client.ClientWithResponses
+	resourceConfigurer
 }
 
 type MaintenanceWindowResourceModel struct {
@@ -182,24 +182,6 @@ func (r *IncidentMaintenanceWindowResource) Schema(ctx context.Context, req reso
 			},
 		},
 	}
-}
-
-func (r *IncidentMaintenanceWindowResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-
-	client, ok := req.ProviderData.(*IncidentProviderData)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *client.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-
-		return
-	}
-
-	r.client = client.Client
 }
 
 func (r *IncidentMaintenanceWindowResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/provider/incident_role_data_source.go
+++ b/internal/provider/incident_role_data_source.go
@@ -28,7 +28,7 @@ func (i *IncidentRoleDataSource) Metadata(_ context.Context, req datasource.Meta
 }
 
 type IncidentRoleDataSource struct {
-	client *client.ClientWithResponses
+	dataSourceConfigurer
 }
 
 type IncidentRoleDataSourceModel struct {
@@ -37,24 +37,6 @@ type IncidentRoleDataSourceModel struct {
 	Description  types.String `tfsdk:"description" json:"description"`
 	Instructions types.String `tfsdk:"instructions" json:"instructions"`
 	Shortform    types.String `tfsdk:"shortform" json:"shortform"`
-}
-
-func (i *IncidentRoleDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-
-	client, ok := req.ProviderData.(*IncidentProviderData)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Data Source Role Configuration",
-			fmt.Sprintf("Expected *client.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-
-		return
-	}
-
-	i.client = client.Client
 }
 
 func (i *IncidentRoleDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {

--- a/internal/provider/incident_role_resource.go
+++ b/internal/provider/incident_role_resource.go
@@ -23,7 +23,7 @@ var (
 )
 
 type IncidentRoleResource struct {
-	client *client.ClientWithResponses
+	resourceConfigurer
 }
 
 type IncidentRoleResourceModel struct {
@@ -71,24 +71,6 @@ func (r *IncidentRoleResource) Schema(ctx context.Context, req resource.SchemaRe
 			},
 		},
 	}
-}
-
-func (r *IncidentRoleResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-
-	client, ok := req.ProviderData.(*IncidentProviderData)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *client.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-
-		return
-	}
-
-	r.client = client.Client
 }
 
 func (r *IncidentRoleResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/provider/incident_schedule_beta_data_source.go
+++ b/internal/provider/incident_schedule_beta_data_source.go
@@ -29,7 +29,7 @@ func NewIncidentScheduleBetaDataSource() datasource.DataSource {
 }
 
 type IncidentScheduleBetaDataSource struct {
-	client *client.ClientWithResponses
+	dataSourceConfigurer
 }
 
 type IncidentScheduleBetaDataSourceModel struct {
@@ -68,21 +68,6 @@ func (d *IncidentScheduleBetaDataSource) Schema(_ context.Context, _ datasource.
 			},
 		},
 	}
-}
-
-func (d *IncidentScheduleBetaDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-	data, ok := req.ProviderData.(*IncidentProviderData)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected provider data",
-			fmt.Sprintf("expected *IncidentProviderData, got %T. This is a provider bug.", req.ProviderData),
-		)
-		return
-	}
-	d.client = data.Client
 }
 
 // ValidateConfig rejects an ambiguous lookup at plan time. Both attributes are

--- a/internal/provider/incident_schedule_beta_resource.go
+++ b/internal/provider/incident_schedule_beta_resource.go
@@ -35,9 +35,7 @@ func NewIncidentScheduleBetaResource() resource.Resource {
 }
 
 type IncidentScheduleBetaResource struct {
-	client                *client.ClientWithResponses
-	terraformVersion      string
-	markImportedAsManaged bool
+	resourceConfigurer
 }
 
 // IncidentScheduleBetaModel is the Terraform state/plan shape for the resource.
@@ -154,23 +152,6 @@ shifts along with it.`,
 			},
 		},
 	}
-}
-
-func (r *IncidentScheduleBetaResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-	data, ok := req.ProviderData.(*IncidentProviderData)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected provider data",
-			fmt.Sprintf("expected *IncidentProviderData, got %T. This is a provider bug.", req.ProviderData),
-		)
-		return
-	}
-	r.client = data.Client
-	r.terraformVersion = data.TerraformVersion
-	r.markImportedAsManaged = data.MarkImportedAsManaged
 }
 
 // ValidateConfig checks what it can without calling the API, so `terraform

--- a/internal/provider/incident_schedule_data_source.go
+++ b/internal/provider/incident_schedule_data_source.go
@@ -23,7 +23,8 @@ func NewIncidentScheduleDataSource() datasource.DataSource {
 }
 
 type IncidentScheduleDataSource struct {
-	client                    *client.ClientWithResponses
+	dataSourceConfigurer
+
 	scheduleTypeID            string
 	scheduleTypeIDOnce        sync.Once
 	scheduleTypeIDLookupError error
@@ -34,23 +35,6 @@ type IncidentScheduleDataSourceModel struct {
 	Name     types.String `tfsdk:"name"`
 	Timezone types.String `tfsdk:"timezone"`
 	TeamIDs  types.Set    `tfsdk:"team_ids"`
-}
-
-func (d *IncidentScheduleDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-
-	client, ok := req.ProviderData.(*IncidentProviderData)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected *IncidentProviderData, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-		return
-	}
-
-	d.client = client.Client
 }
 
 func (d *IncidentScheduleDataSource) getScheduleTypeID(ctx context.Context) (string, error) {

--- a/internal/provider/incident_schedule_resource.go
+++ b/internal/provider/incident_schedule_resource.go
@@ -30,9 +30,7 @@ var (
 )
 
 type IncidentScheduleResource struct {
-	client                *client.ClientWithResponses
-	terraformVersion      string
-	markImportedAsManaged bool
+	resourceConfigurer
 }
 
 func NewIncidentScheduleResource() resource.Resource {
@@ -167,26 +165,6 @@ func (r *IncidentScheduleResource) Schema(ctx context.Context, req resource.Sche
 			},
 		},
 	}
-}
-
-func (r *IncidentScheduleResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-
-	client, ok := req.ProviderData.(*IncidentProviderData)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *client.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-
-		return
-	}
-
-	r.client = client.Client
-	r.terraformVersion = client.TerraformVersion
-	r.markImportedAsManaged = client.MarkImportedAsManaged
 }
 
 // ValidateConfig rejects two rotations sharing an id, which cannot round-trip.

--- a/internal/provider/incident_schedule_rotation_beta_data_source.go
+++ b/internal/provider/incident_schedule_rotation_beta_data_source.go
@@ -31,7 +31,7 @@ func NewIncidentScheduleRotationBetaDataSource() datasource.DataSource {
 }
 
 type IncidentScheduleRotationBetaDataSource struct {
-	client *client.ClientWithResponses
+	dataSourceConfigurer
 }
 
 type IncidentScheduleRotationBetaDataSourceModel struct {
@@ -137,21 +137,6 @@ func (d *IncidentScheduleRotationBetaDataSource) Schema(_ context.Context, _ dat
 			},
 		},
 	}
-}
-
-func (d *IncidentScheduleRotationBetaDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-	data, ok := req.ProviderData.(*IncidentProviderData)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected provider data",
-			fmt.Sprintf("expected *IncidentProviderData, got %T. This is a provider bug.", req.ProviderData),
-		)
-		return
-	}
-	d.client = data.Client
 }
 
 // ValidateConfig rejects an ambiguous lookup at plan time. Both attributes are

--- a/internal/provider/incident_schedule_rotation_beta_modify_plan_test.go
+++ b/internal/provider/incident_schedule_rotation_beta_modify_plan_test.go
@@ -160,7 +160,7 @@ func modifyRotationPlan(t *testing.T, api *fakeAPI, state tftypes.Value, plan *t
 		planRaw = *plan
 	}
 
-	r := &IncidentScheduleRotationBetaResource{client: api.start(t)}
+	r := &IncidentScheduleRotationBetaResource{resourceConfigurer: withClient(api.start(t))}
 	var resp resource.ModifyPlanResponse
 	r.ModifyPlan(context.Background(), resource.ModifyPlanRequest{
 		State: tfsdk.State{Schema: schemaResp.Schema, Raw: state},
@@ -520,7 +520,7 @@ func TestScheduleRotationModifyPlanSupersededChangeReplaced(t *testing.T) {
 	state := effectiveFrom(t, rotationValue(t, "01SCHED", 1), 90*24*time.Hour)
 	plan := effectiveFrom(t, rotationValue(t, "01OTHERSCHED", 1), 90*24*time.Hour)
 
-	r := &IncidentScheduleRotationBetaResource{client: api.start(t)}
+	r := &IncidentScheduleRotationBetaResource{resourceConfigurer: withClient(api.start(t))}
 	resp := resource.ModifyPlanResponse{RequiresReplace: path.Paths{path.Root("schedule_id")}}
 	r.ModifyPlan(context.Background(), resource.ModifyPlanRequest{
 		State: tfsdk.State{Schema: schemaResp.Schema, Raw: state},

--- a/internal/provider/incident_schedule_rotation_beta_resource.go
+++ b/internal/provider/incident_schedule_rotation_beta_resource.go
@@ -41,8 +41,7 @@ func NewIncidentScheduleRotationBetaResource() resource.Resource {
 }
 
 type IncidentScheduleRotationBetaResource struct {
-	client           *client.ClientWithResponses
-	terraformVersion string
+	resourceConfigurer
 }
 
 // IncidentScheduleRotationBetaModel is the Terraform state/plan shape for the resource.
@@ -252,22 +251,6 @@ See ` + "`incident_schedule_beta`" + ` for how the two differ and how to migrate
 			},
 		},
 	}
-}
-
-func (r *IncidentScheduleRotationBetaResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-	data, ok := req.ProviderData.(*IncidentProviderData)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected provider data",
-			fmt.Sprintf("expected *IncidentProviderData, got %T. This is a provider bug.", req.ProviderData),
-		)
-		return
-	}
-	r.client = data.Client
-	r.terraformVersion = data.TerraformVersion
 }
 
 // handoverIntervalLimits is the largest repeat allowed for each interval type: a weekly

--- a/internal/provider/incident_schedule_sync_rule_resource.go
+++ b/internal/provider/incident_schedule_sync_rule_resource.go
@@ -25,9 +25,7 @@ var (
 )
 
 type IncidentScheduleSyncRuleResource struct {
-	client                *client.ClientWithResponses
-	terraformVersion      string
-	markImportedAsManaged bool
+	resourceConfigurer
 }
 
 func NewIncidentScheduleSyncRuleResource() resource.Resource {
@@ -83,25 +81,6 @@ func (r *IncidentScheduleSyncRuleResource) Schema(ctx context.Context, req resou
 			},
 		},
 	}
-}
-
-func (r *IncidentScheduleSyncRuleResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-
-	client, ok := req.ProviderData.(*IncidentProviderData)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *client.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-		return
-	}
-
-	r.client = client.Client
-	r.terraformVersion = client.TerraformVersion
-	r.markImportedAsManaged = client.MarkImportedAsManaged
 }
 
 func (r *IncidentScheduleSyncRuleResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/provider/incident_schedule_sync_target_resource.go
+++ b/internal/provider/incident_schedule_sync_target_resource.go
@@ -26,9 +26,7 @@ var (
 )
 
 type IncidentScheduleSyncTargetResource struct {
-	client                *client.ClientWithResponses
-	terraformVersion      string
-	markImportedAsManaged bool
+	resourceConfigurer
 }
 
 func NewIncidentScheduleSyncTargetResource() resource.Resource {
@@ -135,25 +133,6 @@ func (r *IncidentScheduleSyncTargetResource) ValidateConfig(ctx context.Context,
 				"new_slack_user_group to create a new one."))
 		return
 	}
-}
-
-func (r *IncidentScheduleSyncTargetResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-
-	client, ok := req.ProviderData.(*IncidentProviderData)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *client.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-		return
-	}
-
-	r.client = client.Client
-	r.terraformVersion = client.TerraformVersion
-	r.markImportedAsManaged = client.MarkImportedAsManaged
 }
 
 func (r *IncidentScheduleSyncTargetResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/provider/incident_severity_resource.go
+++ b/internal/provider/incident_severity_resource.go
@@ -24,7 +24,7 @@ var (
 )
 
 type IncidentSeverityResource struct {
-	client *client.ClientWithResponses
+	resourceConfigurer
 }
 
 type IncidentSeverityResourceModel struct {
@@ -68,24 +68,6 @@ func (r *IncidentSeverityResource) Schema(ctx context.Context, req resource.Sche
 			},
 		},
 	}
-}
-
-func (r *IncidentSeverityResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-
-	client, ok := req.ProviderData.(*IncidentProviderData)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *client.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-
-		return
-	}
-
-	r.client = client.Client
 }
 
 func (r *IncidentSeverityResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/provider/incident_status_data_source.go
+++ b/internal/provider/incident_status_data_source.go
@@ -24,7 +24,7 @@ func NewIncidentStatusDataSource() datasource.DataSource {
 }
 
 type IncidentStatusDataSource struct {
-	client *client.ClientWithResponses
+	dataSourceConfigurer
 }
 
 type IncidentStatusDataSourceModel struct {
@@ -37,24 +37,6 @@ type IncidentStatusDataSourceModel struct {
 
 func (d *IncidentStatusDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_status"
-}
-
-func (d *IncidentStatusDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-
-	client, ok := req.ProviderData.(*IncidentProviderData)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected *IncidentProviderData, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-
-		return
-	}
-
-	d.client = client.Client
 }
 
 func (d *IncidentStatusDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {

--- a/internal/provider/incident_status_resource.go
+++ b/internal/provider/incident_status_resource.go
@@ -23,7 +23,7 @@ var (
 )
 
 type IncidentStatusResource struct {
-	client *client.ClientWithResponses
+	resourceConfigurer
 }
 
 type IncidentStatusResourceModel struct {
@@ -69,24 +69,6 @@ func (r *IncidentStatusResource) Schema(ctx context.Context, req resource.Schema
 			},
 		},
 	}
-}
-
-func (r *IncidentStatusResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-
-	client, ok := req.ProviderData.(*IncidentProviderData)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *client.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-
-		return
-	}
-
-	r.client = client.Client
 }
 
 func (r *IncidentStatusResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/provider/incident_user_data_source.go
+++ b/internal/provider/incident_user_data_source.go
@@ -24,7 +24,7 @@ func NewIncidentUserDataSource() datasource.DataSource {
 }
 
 type IncidentUserDataSource struct {
-	client *client.ClientWithResponses
+	dataSourceConfigurer
 }
 
 type IncidentUserDataSourceModel struct {
@@ -37,24 +37,6 @@ type IncidentUserDataSourceModel struct {
 
 type IncidentUserRequest struct {
 	ID types.String `tfsdk:"id"`
-}
-
-func (i *IncidentUserDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-
-	client, ok := req.ProviderData.(*IncidentProviderData)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Data Source User",
-			fmt.Sprintf("Expected *client.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-
-		return
-	}
-
-	i.client = client.Client
 }
 
 func (i *IncidentUserDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {

--- a/internal/provider/incident_workflow_data_source.go
+++ b/internal/provider/incident_workflow_data_source.go
@@ -24,28 +24,11 @@ func NewIncidentWorkflowDataSource() datasource.DataSource {
 }
 
 type IncidentWorkflowDataSource struct {
-	client *client.ClientWithResponses
+	dataSourceConfigurer
 }
 
 func (d *IncidentWorkflowDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_workflow"
-}
-
-func (d *IncidentWorkflowDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-
-	client, ok := req.ProviderData.(*IncidentProviderData)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected *IncidentProviderData, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-		return
-	}
-
-	d.client = client.Client
 }
 
 // Schema mirrors the workflow resource, with everything but the ID computed.

--- a/internal/provider/incident_workflow_resource.go
+++ b/internal/provider/incident_workflow_resource.go
@@ -30,9 +30,7 @@ var (
 var privateIncidentScopes = []string{"all", "owning_teams", "none"}
 
 type IncidentWorkflowResource struct {
-	client                *client.ClientWithResponses
-	terraformVersion      string
-	markImportedAsManaged bool
+	resourceConfigurer
 }
 
 func NewIncidentWorkflowResource() resource.Resource {
@@ -446,26 +444,6 @@ func (r *IncidentWorkflowResource) Delete(ctx context.Context, req resource.Dele
 func (r *IncidentWorkflowResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	claimResourceOnImport(ctx, r.client, req.ID, &resp.Diagnostics, client.ManagedResourcesCreateManagedResourcePayloadV2ResourceTypeWorkflow, r.terraformVersion, r.markImportedAsManaged)
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
-}
-
-func (r *IncidentWorkflowResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-
-	client, ok := req.ProviderData.(*IncidentProviderData)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *client.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-
-		return
-	}
-
-	r.client = client.Client
-	r.terraformVersion = client.TerraformVersion
-	r.markImportedAsManaged = client.MarkImportedAsManaged
 }
 
 func toOwningTeamIDs(set types.Set) *[]string {

--- a/internal/provider/rich_text_data_source.go
+++ b/internal/provider/rich_text_data_source.go
@@ -25,7 +25,7 @@ func NewRichTextDataSource() datasource.DataSource {
 }
 
 type richTextDataSource struct {
-	client *client.ClientWithResponses
+	dataSourceConfigurer
 }
 
 type richTextDataSourceModel struct {
@@ -66,21 +66,6 @@ func (d *richTextDataSource) Schema(_ context.Context, _ datasource.SchemaReques
 			},
 		},
 	}
-}
-
-func (d *richTextDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-	data, ok := req.ProviderData.(*IncidentProviderData)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected provider data",
-			fmt.Sprintf("expected *IncidentProviderData, got %T. This is a provider bug.", req.ProviderData),
-		)
-		return
-	}
-	d.client = data.Client
 }
 
 func (d *richTextDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {

--- a/internal/provider/rich_text_data_source_test.go
+++ b/internal/provider/rich_text_data_source_test.go
@@ -145,7 +145,7 @@ func readRichText(t *testing.T, api *client.ClientWithResponses, markdown, featu
 	t.Helper()
 
 	ctx := context.Background()
-	d := &richTextDataSource{client: api}
+	d := &richTextDataSource{dataSourceConfigurer: withClientDataSource(api)}
 
 	var schemaResp datasource.SchemaResponse
 	d.Schema(ctx, datasource.SchemaRequest{}, &schemaResp)


### PR DESCRIPTION
## Problem

Every resource and data source hand-rolls the same `Configure` method — **41 copies, 567 lines**, all doing the identical nil check, type assertion and field assignments.

They've already drifted into two variants, and *both are wrong*:

```go
// 19 of them:
"Unexpected Resource Configure Type",
fmt.Sprintf("Expected *client.Client, got: %T. Please report this issue...", req.ProviderData),

// 7 newer ones:
"Unexpected provider data",
fmt.Sprintf("expected *IncidentProviderData, got %T. This is a provider bug.", req.ProviderData),
```

The first names `*client.Client`, which is not what the provider passes — it's `*IncidentProviderData`, and has been for as long as that message has existed. So the majority of these tell the user to report a provider bug while naming the wrong type.

## Change

Resources embed `resourceConfigurer`, data sources embed `dataSourceConfigurer`, both wrapping a shared `providerConfig`. The fields promote, so **every existing `r.client` / `r.terraformVersion` reference is untouched**.

The two configurer types are separate only because the framework gives resources and data sources different request/response types, so a single method can't serve both.

Before changing anything I verified mechanically that all 41 methods were exactly the standard shape — no special cases:

```
  18  datasource  assigns=('client',)
  10  resource    assigns=('client',)
  10  resource    assigns=('client', 'markImportedAsManaged', 'terraformVersion')
   3  resource    assigns=('client', 'terraformVersion')
```

**Net 801 lines deleted.**

## Tests

Composite literals can't set a promoted field, so the six tests that construct a resource directly now go through `withClient(api)` — which is also clearer about what it's building.

Added `TestEveryResourceIsConfigurable`, which walks all 23 registered resources and 18 data sources, asserts each satisfies the framework's `Configure` interface, and asserts it actually took the client. This matters because `Configure` now arrives by *promotion*, which the compiler doesn't check against the interface: a type that lost its embed would fail at apply against a nil client rather than at build time. Confirmed the test does fail when an embed is removed:

```
--- FAIL: TestEveryResourceIsConfigurable/*provider.IncidentRoleResource
    *provider.IncidentRoleResource does not implement resource.ResourceWithConfigure
```

Also covers the two edge cases the boilerplate handled: nil `ProviderData` (the framework calls `Configure` before the provider is configured — must be a no-op) and unexpected `ProviderData`.

## Verification

`go build`, `go vet`, `golangci-lint run ./...` (0 issues), `go test ./...` all pass. 41/41 subtests pass.

## Note for review

This is the largest diff of the set, but it's mechanical — the only behavioural change is the diagnostic text, which now names the right type. Worth a skim of `configure.go` and then trusting the test.

---

Part of a set of independent PRs from a codebase scan. It touches the struct definition and import block of nearly every provider file, so it will conflict with the others textually. I'd suggest merging it **last**, or first and rebasing the rest — happy to rebase whichever order you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor with regression tests; runtime behavior is unchanged aside from clearer error text when provider data is wrong.
> 
> **Overview**
> Introduces shared **`configure.go`** with `providerConfig`, embedded **`resourceConfigurer`** / **`dataSourceConfigurer`**, and test helpers **`withClient`** / **`withClientDataSource`**. Every resource and data source **drops its duplicated `Configure` method** and replaces explicit `client` (and related) fields with the embed, so promoted fields like **`r.client`** keep working unchanged.
> 
> Adds **`configure_test.go`**, including **`TestEveryResourceIsConfigurable`**, which walks all registered resources and data sources to ensure they still implement configure and receive the API client. Modify-plan and data-source unit tests that construct types directly now wire the client through **`withClient`** instead of setting `client` on the struct.
> 
> The only intentional behavior change is **unified configure diagnostics** (wrong provider data now consistently references `*IncidentProviderData` instead of the old, incorrect `*client.Client` message on many types).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c8aa93f97e8c3b5227727b952e43e5f3c145475. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->