### PR TITLE
Fail on an unparseable success response instead of dereferencing nil

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -2,10 +2,12 @@
 package client
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
@@ -56,6 +58,10 @@ func New(ctx context.Context, apiKey, apiEndpoint, version string, opts ...Clien
 			}
 		}
 
+		if err := requireJSONBody(resp); err != nil {
+			return nil, err
+		}
+
 		return resp, err
 	})
 
@@ -75,6 +81,59 @@ func New(ctx context.Context, apiKey, apiEndpoint, version string, opts ...Clien
 	}
 
 	return client, nil
+}
+
+// requireJSONBody rejects a success response carrying a body the generated client won't
+// parse, which is any body that isn't JSON.
+//
+// The generated Parse functions only populate the typed body (JSON200, JSON201...) when the
+// status matches and the content type contains "json". Otherwise they return the response
+// with every typed field nil and no error, and every caller dereferences that field — so the
+// provider panics and the plugin crashes, rather than reporting anything useful.
+//
+// The API schema only ever describes JSON response bodies, so a non-JSON body on a 2xx means
+// something between us and the API rewrote the response: a proxy's HTML error or sign-in
+// page is the usual culprit. Surfacing that beats a nil dereference.
+//
+// An empty body is left alone: the schema has 44 success responses that declare no body at
+// all, all of them 204s from a delete, and those callers don't touch the typed field.
+func requireJSONBody(resp *http.Response) error {
+	if isJSONContentType(resp.Header.Get("Content-Type")) {
+		return nil
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		return fmt.Errorf("status %d: reading response body: %w", resp.StatusCode, err)
+	}
+
+	// Put the body back for the caller, which still has to parse it.
+	resp.Body = io.NopCloser(bytes.NewReader(data))
+
+	if len(bytes.TrimSpace(data)) == 0 {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"status %d: expected a JSON response body but the content type was %q, so the response could not be read. This usually means something between you and the incident.io API rewrote the response, such as a proxy returning an error page. Body: %s",
+		resp.StatusCode, resp.Header.Get("Content-Type"), truncateForError(data))
+}
+
+// isJSONContentType matches the test the generated client uses to decide whether to parse a
+// body, so the two can't disagree about what counts as JSON.
+func isJSONContentType(contentType string) bool {
+	return strings.Contains(contentType, "json")
+}
+
+// truncateForError keeps an unexpected body short enough to put in a diagnostic.
+func truncateForError(data []byte) string {
+	const limit = 512
+	if len(data) <= limit {
+		return string(data)
+	}
+
+	return string(data[:limit]) + "... (truncated)"
 }
 
 const (

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1,0 +1,114 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A 2xx the generated client can't parse leaves the typed body (JSON200, JSON201...) nil
+// while returning no error. Every caller dereferences that field, so without this the
+// provider panics and the plugin crashes.
+func TestRequireJSONBody(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		status      int
+		contentType string
+		body        string
+		wantErr     string
+	}{
+		{
+			name:        "JSON body is parsed as usual",
+			status:      http.StatusOK,
+			contentType: "application/json",
+			body:        `{"catalog_type":{"id":"01ABC"}}`,
+		},
+		{
+			// What a proxy or sign-in portal does to an intercepted request.
+			name:        "HTML body on a 200 is an error, not a nil dereference",
+			status:      http.StatusOK,
+			contentType: "text/html; charset=utf-8",
+			body:        "<html><body>Authentication required</body></html>",
+			wantErr:     "expected a JSON response body",
+		},
+		{
+			name:        "plain text body on a 201 is an error",
+			status:      http.StatusCreated,
+			contentType: "text/plain",
+			body:        "created",
+			wantErr:     "expected a JSON response body",
+		},
+		{
+			// The schema has 44 success responses that declare no body, all 204s from a
+			// delete. Those callers never touch the typed field, so they must keep working.
+			name:   "empty body with no content type is fine",
+			status: http.StatusNoContent,
+			body:   "",
+		},
+		{
+			name:        "whitespace-only body is treated as empty",
+			status:      http.StatusNoContent,
+			contentType: "text/plain",
+			body:        "  \n",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tc.contentType != "" {
+					w.Header().Set("Content-Type", tc.contentType)
+				}
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			c, err := New(context.Background(), "inc_test_key", srv.URL, "test")
+			require.NoError(t, err)
+
+			// Any endpoint will do: we're exercising the transport, not the operation.
+			_, err = c.CatalogV3ListTypesWithResponse(context.Background())
+
+			if tc.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+			// The body has to reach the user, or there's nothing to debug from.
+			assert.Contains(t, err.Error(), strings.TrimSpace(tc.body))
+			assert.Contains(t, err.Error(), tc.contentType)
+		})
+	}
+}
+
+// The body is consumed to inspect it, so it has to be put back for the caller to parse.
+func TestRequireJSONBodyLeavesTheBodyReadable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"catalog_types":[],"pagination_meta":{"page_size":25}}`))
+	}))
+	defer srv.Close()
+
+	c, err := New(context.Background(), "inc_test_key", srv.URL, "test")
+	require.NoError(t, err)
+
+	result, err := c.CatalogV3ListTypesWithResponse(context.Background())
+
+	require.NoError(t, err)
+	require.NotNil(t, result.JSON200, "the typed body should be populated")
+	assert.Empty(t, result.JSON200.CatalogTypes)
+}
+
+func TestIsJSONContentType(t *testing.T) {
+	assert.True(t, isJSONContentType("application/json"))
+	assert.True(t, isJSONContentType("application/json; charset=utf-8"))
+	assert.True(t, isJSONContentType("application/problem+json"))
+	assert.False(t, isJSONContentType("text/html"))
+	assert.False(t, isJSONContentType(""))
+}


### PR DESCRIPTION
## Problem

There are **122 `.JSON200.` and 43 `.JSON201.` dereferences** in the provider, against only 42 nil guards. They look safe, because the transport turns anything over 299 into an error. They aren't.

The generated `ParseXxxResponse` functions populate the typed body only when the status matches **exactly** and the content type contains `"json"`:

```go
switch {
case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
	...
	response.JSON200 = &dest
}
return response, nil   // <- otherwise: every typed field nil, err == nil
```

So the caller dereferences nil: the provider panics, the plugin crashes, and the user gets a Go stack trace instead of a diagnostic.

The realistic way in is a proxy or sign-in portal rewriting a response — answering `200` with an HTML error page. That's environment-specific, so it hits users rather than CI.

## Change

One guard in the transport middleware, ~10 lines plus comment. **This fixes all 165 dereference sites from one place**, rather than adding 120 hand-written nil checks.

The rule is: *a success response carrying a body must have a JSON content type.* I checked that against the schema before writing it:

- **211** declared response bodies, and every single one is `application/json` — there is no non-JSON body anywhere in the API.
- **44** success responses declare no body at all. All of them are `204`s from deletes, whose callers never touch a typed field.

So the rule is exactly right, and an empty body is deliberately left alone — a blanket content-type check would have broken every delete, since the generated delete parsers have no `switch` at all.

Before:
```
panic: runtime error: invalid memory address or nil pointer dereference
Error: The terraform-provider-incident plugin crashed!
```

After:
```
status 200: expected a JSON response body but the content type was "text/html", so the
response could not be read. This usually means something between you and the incident.io
API rewrote the response, such as a proxy returning an error page. Body: <html>proxy</html>
```

## Retries

The middleware wraps the **outside** of retryablehttp's round-tripper (`base.Transport = Wrap(base.Transport, ...)` where `base` is `retryClient.StandardClient()`), so this returns once, after retries have finished. It doesn't cause ten more attempts — same as the existing `> 299` branch.

## Tests

New `internal/client/client_test.go` — first tests in this package. Covers JSON passing through, HTML-on-200 and text-on-201 erroring with the body and content type included, `204` with an empty body still working, whitespace-only bodies treated as empty, and that the body is still readable by the caller after being inspected.

## What this does *not* cover

The other way a typed body can be nil: a 2xx whose status the schema doesn't declare for that operation — the API answering `200` where the client expects `201`. That can't be detected centrally, because the transport doesn't know which status the operation expects.

I judged it much lower priority: it's a schema-versus-server disagreement, so it breaks that endpoint for *everyone* and fails the acceptance tests on the first run, rather than silently affecting only the users behind a particular proxy. If you'd rather close it off completely, the mechanical follow-up is a generic `expectBody(result, result.JSON200, ...)` helper threaded through all 165 call sites — happy to do that as a separate PR, but it's a large diff for a failure mode CI catches immediately.

---

Part of a set of independent PRs from a codebase scan. This one touches only `internal/client/`, so it won't conflict with any of the others.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Central guard on the HTTP client only; behavior change is stricter validation of unexpected 2xx bodies, with tests and no change to normal JSON or empty 204 responses.
> 
> **Overview**
> Adds **transport-level validation** so successful API responses with a non-empty, non-JSON body fail with a clear error instead of letting the oapi-codegen client return `nil` typed bodies and crash the Terraform plugin on dereference.
> 
> After existing `>299` handling, **`requireJSONBody`** checks `Content-Type` the same way the generated parsers do; empty or whitespace-only bodies (e.g. `204` deletes) still pass, and the body is re-wrapped so JSON responses parse normally. Errors include status, content type, and a truncated body snippet (typical proxy/HTML case).
> 
> New **`internal/client/client_test.go`** covers JSON success, HTML/text on 2xx, empty bodies, and body readability after inspection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21ab1ff5254f4391fb9541793f71c4b86f90bf44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->