### PR TITLE
Document that alert attributes are account-wide, not per source

### DIFF
--- a/docs/resources/alert_attribute.md
+++ b/docs/resources/alert_attribute.md
@@ -5,6 +5,36 @@ subcategory: ""
 description: |-
   View and manage alert attributes.
   Alert attributes are used to parse structured data from alerts coming in via alert sources.
+  An attribute is account-wide; what fills it in is per source
+  An alert attribute is the column, not the rule that populates it. It belongs to your whole
+  incident.io organization: its name has to be unique across the account, and every alert
+  source draws on the same set of attributes. That is deliberate — one attribute means the same
+  thing whichever source fired the alert, so an alert route spanning several sources can match
+  on it.
+  What varies per source is the binding: the rule parsing a value for this attribute out of an
+  incoming event. A source binds a given attribute at most once, and two sources can fill the
+  same attribute from completely different parts of their payloads. Write bindings either as
+  template.attributes on incident_alert_source, which declares a source and everything it
+  populates together, or as one incident_alert_source_attribute_beta resource per binding
+  against an incident_alert_source_beta source.
+  So a GCP service attribute is declared once, then bound separately by each source that sets it.
+  Declaring one attribute from several workspaces
+  If your Terraform is split across workspaces — one per environment, say — only one of them
+  should declare an attribute as a resource. The others should read it with the
+  incident_alert_attribute data source, which looks an attribute up by name:
+  data "incident_alert_attribute" "gcp_service" {
+    name = "GCP service"
+  }
+  
+  Declaring the same name in two workspaces plans cleanly in both, then fails when the second
+  applies: the attribute it means to create already exists. To bring an attribute that already
+  exists under a workspace's management instead, import it.
+  Per-environment differences belong on the binding rather than the attribute, so both
+  environments share one attribute and each parses it from its own source.
+  Reserved names
+  Title, Description and Priority collide with properties every alert already has, and are
+  rejected regardless of casing. Priority does exist as an attribute you can bind and filter on,
+  but it is read-only through the API: read it with the data source rather than declaring it.
 ---
 
 # incident_alert_attribute (Resource)
@@ -12,6 +42,46 @@ description: |-
 View and manage alert attributes.
 
 Alert attributes are used to parse structured data from alerts coming in via alert sources.
+
+## An attribute is account-wide; what fills it in is per source
+
+An alert attribute is the column, not the rule that populates it. It belongs to your whole
+incident.io organization: its `name` has to be unique across the account, and every alert
+source draws on the same set of attributes. That is deliberate — one attribute means the same
+thing whichever source fired the alert, so an alert route spanning several sources can match
+on it.
+
+What varies per source is the *binding*: the rule parsing a value for this attribute out of an
+incoming event. A source binds a given attribute at most once, and two sources can fill the
+same attribute from completely different parts of their payloads. Write bindings either as
+`template.attributes` on `incident_alert_source`, which declares a source and everything it
+populates together, or as one `incident_alert_source_attribute_beta` resource per binding
+against an `incident_alert_source_beta` source.
+
+So a `GCP service` attribute is declared once, then bound separately by each source that sets it.
+
+## Declaring one attribute from several workspaces
+
+If your Terraform is split across workspaces — one per environment, say — only one of them
+should declare an attribute as a resource. The others should read it with the
+`incident_alert_attribute` data source, which looks an attribute up by name:
+
+    data "incident_alert_attribute" "gcp_service" {
+      name = "GCP service"
+    }
+
+Declaring the same `name` in two workspaces plans cleanly in both, then fails when the second
+applies: the attribute it means to create already exists. To bring an attribute that already
+exists under a workspace's management instead, `import` it.
+
+Per-environment differences belong on the binding rather than the attribute, so both
+environments share one attribute and each parses it from its own source.
+
+## Reserved names
+
+`Title`, `Description` and `Priority` collide with properties every alert already has, and are
+rejected regardless of casing. `Priority` does exist as an attribute you can bind and filter on,
+but it is read-only through the API: read it with the data source rather than declaring it.
 
 ## Example Usage
 
@@ -31,6 +101,44 @@ resource "incident_alert_attribute" "severity" {
   array    = false
   required = false
   emoji    = "warning"
+}
+
+# An attribute is account-wide, so declare it once. What differs between environments is the
+# binding that fills it in, which belongs to an alert source.
+resource "incident_alert_attribute" "gcp_service" {
+  name  = "GCP service"
+  type  = "String"
+  array = false
+}
+
+# Staging and production each parse the same attribute out of their own source, so both
+# environments' alerts are labelled with one attribute that routes can match on.
+resource "incident_alert_source_attribute_beta" "gcp_service_staging" {
+  alert_source_id    = incident_alert_source_beta.gcp_staging.id
+  alert_attribute_id = incident_alert_attribute.gcp_service.id
+
+  value_reference = "payload.resource.labels.service_name"
+}
+
+resource "incident_alert_source_attribute_beta" "gcp_service_production" {
+  alert_source_id    = incident_alert_source_beta.gcp_production.id
+  alert_attribute_id = incident_alert_attribute.gcp_service.id
+
+  value_reference = "payload.resource.labels.service_name"
+}
+
+# Where a source lives in a different workspace to the attribute it binds, read the attribute
+# by name rather than declaring it again. Two workspaces declaring the same name will both plan
+# cleanly, and then the second one to apply will fail.
+data "incident_alert_attribute" "existing_gcp_service" {
+  name = "GCP service"
+}
+
+resource "incident_alert_source_attribute_beta" "gcp_service_other_workspace" {
+  alert_source_id    = incident_alert_source_beta.gcp_other.id
+  alert_attribute_id = data.incident_alert_attribute.existing_gcp_service.id
+
+  value_reference = "payload.resource.labels.service_name"
 }
 ```
 

--- a/docs/resources/alert_source.md
+++ b/docs/resources/alert_source.md
@@ -107,7 +107,7 @@ resource "incident_alert_source" "cloudwatch" {
 
 ## The `team` Alert Attribute we've configured to label Alerts and route alerts to schedules
 
-data "incident_alert_attribute" "squad" {
+data "incident_alert_attribute" "team" {
   name = "Team"
 }
 

--- a/examples/resources/incident_alert_attribute/resource.tf
+++ b/examples/resources/incident_alert_attribute/resource.tf
@@ -14,3 +14,41 @@ resource "incident_alert_attribute" "severity" {
   required = false
   emoji    = "warning"
 }
+
+# An attribute is account-wide, so declare it once. What differs between environments is the
+# binding that fills it in, which belongs to an alert source.
+resource "incident_alert_attribute" "gcp_service" {
+  name  = "GCP service"
+  type  = "String"
+  array = false
+}
+
+# Staging and production each parse the same attribute out of their own source, so both
+# environments' alerts are labelled with one attribute that routes can match on.
+resource "incident_alert_source_attribute_beta" "gcp_service_staging" {
+  alert_source_id    = incident_alert_source_beta.gcp_staging.id
+  alert_attribute_id = incident_alert_attribute.gcp_service.id
+
+  value_reference = "payload.resource.labels.service_name"
+}
+
+resource "incident_alert_source_attribute_beta" "gcp_service_production" {
+  alert_source_id    = incident_alert_source_beta.gcp_production.id
+  alert_attribute_id = incident_alert_attribute.gcp_service.id
+
+  value_reference = "payload.resource.labels.service_name"
+}
+
+# Where a source lives in a different workspace to the attribute it binds, read the attribute
+# by name rather than declaring it again. Two workspaces declaring the same name will both plan
+# cleanly, and then the second one to apply will fail.
+data "incident_alert_attribute" "existing_gcp_service" {
+  name = "GCP service"
+}
+
+resource "incident_alert_source_attribute_beta" "gcp_service_other_workspace" {
+  alert_source_id    = incident_alert_source_beta.gcp_other.id
+  alert_attribute_id = data.incident_alert_attribute.existing_gcp_service.id
+
+  value_reference = "payload.resource.labels.service_name"
+}

--- a/examples/resources/incident_alert_source/resource.tf
+++ b/examples/resources/incident_alert_source/resource.tf
@@ -86,7 +86,7 @@ resource "incident_alert_source" "cloudwatch" {
 
 ## The `team` Alert Attribute we've configured to label Alerts and route alerts to schedules
 
-data "incident_alert_attribute" "squad" {
+data "incident_alert_attribute" "team" {
   name = "Team"
 }
 

--- a/internal/provider/incident_alert_attribute_resource.go
+++ b/internal/provider/incident_alert_attribute_resource.go
@@ -47,7 +47,45 @@ func (r *IncidentAlertAttributeResource) Metadata(ctx context.Context, req resou
 
 func (r *IncidentAlertAttributeResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: apischema.TagDocstring("Alert Attributes V2"),
+		MarkdownDescription: fmt.Sprintf("%s\n\n%s", apischema.TagDocstring("Alert Attributes V2"), `## An attribute is account-wide; what fills it in is per source
+
+An alert attribute is the column, not the rule that populates it. It belongs to your whole
+incident.io organization: its `+"`name`"+` has to be unique across the account, and every alert
+source draws on the same set of attributes. That is deliberate — one attribute means the same
+thing whichever source fired the alert, so an alert route spanning several sources can match
+on it.
+
+What varies per source is the *binding*: the rule parsing a value for this attribute out of an
+incoming event. A source binds a given attribute at most once, and two sources can fill the
+same attribute from completely different parts of their payloads. Write bindings either as
+`+"`template.attributes`"+` on `+"`incident_alert_source`"+`, which declares a source and everything it
+populates together, or as one `+"`incident_alert_source_attribute_beta`"+` resource per binding
+against an `+"`incident_alert_source_beta`"+` source.
+
+So a `+"`GCP service`"+` attribute is declared once, then bound separately by each source that sets it.
+
+## Declaring one attribute from several workspaces
+
+If your Terraform is split across workspaces — one per environment, say — only one of them
+should declare an attribute as a resource. The others should read it with the
+`+"`incident_alert_attribute`"+` data source, which looks an attribute up by name:
+
+    data "incident_alert_attribute" "gcp_service" {
+      name = "GCP service"
+    }
+
+Declaring the same `+"`name`"+` in two workspaces plans cleanly in both, then fails when the second
+applies: the attribute it means to create already exists. To bring an attribute that already
+exists under a workspace's management instead, `+"`import`"+` it.
+
+Per-environment differences belong on the binding rather than the attribute, so both
+environments share one attribute and each parses it from its own source.
+
+## Reserved names
+
+`+"`Title`"+`, `+"`Description`"+` and `+"`Priority`"+` collide with properties every alert already has, and are
+rejected regardless of casing. `+"`Priority`"+` does exist as an attribute you can bind and filter on,
+but it is read-only through the API: read it with the data source rather than declaring it.`),
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:            true,


### PR DESCRIPTION
Closes #520.

An alert attribute and an alert source attribute are easy to confuse, and the docs didn't distinguish them. The reporter managed staging and production in separate workspaces, reasonably read the attribute as source-scoped, declared it in both, and got two clean plans followed by a failing apply.

The distinction, confirmed against core:

|  | Alert attribute | Alert source attribute |
| --- | --- | --- |
| Terraform | `incident_alert_attribute` | `incident_alert_source_attribute_beta`, or `template.attributes` |
| What it is | The column: name, type, array, required | The rule filling that column for one source |
| Scope | Per organisation | Per alert source |
| Uniqueness | Name unique across the account | One binding per (source, attribute) |

So the per-source scoping the reporter wanted already exists — it's the binding, not the attribute. Nothing in the docs said the attribute name was account-wide, and nothing pointed at the `incident_alert_attribute` data source that reads an attribute another workspace owns.

### Changes

- **`incident_alert_attribute` description** — three sections: the attribute-vs-binding split and why the attribute is shared (one attribute means the same thing whichever source fired, so a route spanning sources can match on it); declaring one attribute from several workspaces, pointing at the data source and `import`; and reserved names, since `Title`, `Description` and `Priority` fail the same plans-clean-then-breaks way.
- **`incident_alert_attribute` example** — one attribute declared once and bound separately by each environment's source, plus the data source where the source lives in another workspace.
- **`incident_alert_source` example** — bound an attribute from `data.incident_alert_attribute.team` while declaring that data source as `squad`. That example is the reference for wiring an attribute to a source, and as written it didn't work.
- **`docs/`** — regenerated.

### Notes

- Docs and examples only, no behaviour change.
- Ran `tfplugindocs` directly rather than `go generate ./...`, so the OpenAPI client isn't regenerated and the diff stays to these five files.
- `go build`, `go vet` and the full unit suite pass. Acceptance tests need `TF_ACC=1` and a live token; there's no behaviour here to cover.
- No changelog entry, per instruction.

### Follow-up worth considering, not in this PR

The clash could be caught at `plan` rather than `apply`. `AlertAttributesV2List` is one cheap call, and there's precedent for plan-time API checks in `IncidentAlertSourceResource.ModifyPlan`. A `ModifyPlan` erroring on create when the name is taken — naming the data source and `import` as the fixes — would turn this into a plan error, which is what the reporter actually asked for. Worth its own discussion: it costs a request per plan, and two workspaces legitimately wanting the same attribute should be importing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example-only changes with no changes to create/update/delete logic or API calls beyond existing schema docstrings.
> 
> **Overview**
> Closes confusion between **alert attributes** (org-wide column definitions) and **bindings** (per-source rules that populate them). The `incident_alert_attribute` resource docs, generated `docs/resources/alert_attribute.md`, and the resource schema `MarkdownDescription` in `incident_alert_attribute_resource.go` now explain that attribute `name` is unique per organization, how to use the `incident_alert_attribute` data source or `import` when Terraform is split across workspaces, and that `Title`, `Description`, and `Priority` are reserved (with `Priority` read-only via the data source).
> 
> **Examples** add a `GCP service` attribute declared once with separate `incident_alert_source_attribute_beta` bindings for staging/production and a cross-workspace data-source pattern. The `incident_alert_source` example fixes a broken reference: the data source block is renamed from `squad` to `team` so it matches `data.incident_alert_attribute.team` used in `template.attributes`.
> 
> No provider API or runtime behavior changes—documentation and examples only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc95ec1282dab5c72488e7ae94344a2aeff1360c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->