### PR TITLE
Handle team-scoped escalation path managed-resource claims

### DIFF
--- a/internal/provider/managed_resources.go
+++ b/internal/provider/managed_resources.go
@@ -1,7 +1,9 @@
 package provider
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -55,8 +57,29 @@ func claimResource(
 	}
 
 	_, err := apiClient.ManagedResourcesV2CreateManagedResourceWithResponse(ctx, payload)
-	if err != nil {
-		diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create managed resource, got error: %s", err))
+	if err == nil {
 		return
 	}
+
+	// The managed-resources endpoint checks escalation_paths.update without
+	// taking the escalation path's teams into account. A team-scoped key can
+	// therefore create or update an escalation path successfully, then receive
+	// this 403 while adding the secondary "managed by Terraform" metadata.
+	//
+	// Do not fail the Terraform operation after the escalation path itself has
+	// already been created, updated, or imported. Other claim failures remain
+	// errors so they are not hidden.
+	var httpErr client.HTTPError
+	if resourceType == client.ManagedResourcesCreateManagedResourcePayloadV2ResourceTypeEscalationPath &&
+		errors.As(err, &httpErr) &&
+		httpErr.StatusCode == 403 &&
+		bytes.Contains(httpErr.Body, []byte("missing_required_scope")) {
+		diagnostics.AddWarning(
+			"Unable to mark escalation path as managed by Terraform",
+			fmt.Sprintf("The escalation path operation succeeded, but incident.io could not mark it as managed by Terraform because the API key's escalation_paths.update scope may be team-scoped. The resource will remain editable in the dashboard. Got error: %s", err),
+		)
+		return
+	}
+
+	diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create managed resource, got error: %s", err))
 }

--- a/internal/provider/managed_resources_test.go
+++ b/internal/provider/managed_resources_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -17,8 +18,10 @@ import (
 // fakeManagedResourcesAPI counts claims, which is how these tests tell an import that
 // claimed the resource apart from one that left the account untouched.
 type fakeManagedResourcesAPI struct {
-	requests int
-	received []byte
+	requests     int
+	received     []byte
+	status       int
+	responseBody string
 }
 
 func (f *fakeManagedResourcesAPI) start(t *testing.T) *client.ClientWithResponses {
@@ -30,7 +33,14 @@ func (f *fakeManagedResourcesAPI) start(t *testing.T) *client.ClientWithResponse
 		f.received, _ = io.ReadAll(r.Body)
 
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"managed_resource":{"id":"01MANAGED","resource_type":"workflow","resource_id":"01WORKFLOW","annotations":{}}}`))
+		if f.status != 0 {
+			w.WriteHeader(f.status)
+		}
+		body := f.responseBody
+		if body == "" {
+			body = `{"managed_resource":{"id":"01MANAGED","resource_type":"workflow","resource_id":"01WORKFLOW","annotations":{}}}`
+		}
+		_, _ = w.Write([]byte(body))
 	})
 
 	server := httptest.NewServer(mux)
@@ -42,6 +52,60 @@ func (f *fakeManagedResourcesAPI) start(t *testing.T) *client.ClientWithResponse
 	}
 
 	return api
+}
+
+func TestClaimResourceTeamScopedEscalationPathPermission(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		resourceType client.ManagedResourcesCreateManagedResourcePayloadV2ResourceType
+		status       int
+		body         string
+		wantErrors   int
+		wantWarnings int
+	}{
+		{
+			name:         "warns for a team-scoped escalation path permission",
+			resourceType: client.ManagedResourcesCreateManagedResourcePayloadV2ResourceTypeEscalationPath,
+			status:       http.StatusForbidden,
+			body:         `{"type":"missing_required_scope","message":"Missing required scope escalation_paths.update"}`,
+			wantWarnings: 1,
+		},
+		{
+			name:         "fails for another escalation path permission error",
+			resourceType: client.ManagedResourcesCreateManagedResourcePayloadV2ResourceTypeEscalationPath,
+			status:       http.StatusForbidden,
+			body:         `{"type":"resource_forbidden"}`,
+			wantErrors:   1,
+		},
+		{
+			name:         "fails for another resource type",
+			resourceType: client.ManagedResourcesCreateManagedResourcePayloadV2ResourceTypeSchedule,
+			status:       http.StatusForbidden,
+			body:         `{"type":"missing_required_scope"}`,
+			wantErrors:   1,
+		},
+		{
+			name:         "fails for an unrelated server error",
+			resourceType: client.ManagedResourcesCreateManagedResourcePayloadV2ResourceTypeEscalationPath,
+			status:       http.StatusInternalServerError,
+			body:         `{"type":"internal_error"}`,
+			wantErrors:   1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			api := &fakeManagedResourcesAPI{status: tc.status, responseBody: tc.body}
+			var diagnostics diag.Diagnostics
+
+			claimResource(t.Context(), api.start(t), "01ESCALATIONPATH", &diagnostics, tc.resourceType, "1.14.0")
+
+			if got := diagnostics.ErrorsCount(); got != tc.wantErrors {
+				t.Errorf("errors = %d, want %d: %v", got, tc.wantErrors, diagnostics)
+			}
+			if got := diagnostics.WarningsCount(); got != tc.wantWarnings {
+				t.Errorf("warnings = %d, want %d: %v", got, tc.wantWarnings, diagnostics)
+			}
+		})
+	}
 }
 
 // TestImportStateMarkImportedAsManaged covers the plumbing end to end: an import with


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- treat the known escalation-path managed-resource 403 `missing_required_scope` as a warning
- allow Terraform to retain state after the escalation path API operation succeeds
- keep unrelated managed-resource claim failures as errors
- cover the scoped and non-scoped error cases with unit tests

## Testing
- `go test ./internal/provider -count=1`
- `go test ./internal/client -count=1`
- `go vet ./internal/provider ./internal/client`

## Issue
Resolves PR-83.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [PR-83](https://linear.app/incident-io/issue/PR-83/terraform-ep-create-fails-with-403-when-the-api-keys-scope-is-team)

<div><a href="https://cursor.com/agents/bc-7c5d67d7-640c-4126-af89-18c09da3f535?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c5d67d7-640c-4126-af89-18c09da3f535&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

