### PR TITLE
Document how to set an alert source's priority

### DIFF
--- a/docs/resources/alert_source.md
+++ b/docs/resources/alert_source.md
@@ -6,6 +6,79 @@ description: |-
   Configure your alert sources in incident.io.
   Alert sources are the systems that send alerts to incident.io, which can then be routed to the right people and teams.
   We'd generally recommend building alert sources in our web dashboard https://app.incident.io/~/alerts/configuration, and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing alert source and copy the resulting Terraform without persisting it.
+  Setting an alert's priority
+  This resource has no priority field. An alert's priority is set the same way as any other
+  attribute: as an entry in template.attributes bound to the built-in Priority alert attribute,
+  which you look up by name.
+  data "incident_alert_attribute" "priority" {
+    name = "Priority"
+  }
+  
+  # ...then, in template.attributes
+  {
+    alert_attribute_id = data.incident_alert_attribute.priority.id
+    binding            = { value = { reference = "expressions[\"my-priority\"]" } }
+  }
+  
+  A priority binding takes no merge_strategy: an alert's priority is always overwritten when the
+  alert fires again.
+  Two mistakes here are worth knowing about, because both end with every alert on your default
+  alert priority and neither says anything.
+  The first is writing the expression and leaving out the binding. Nothing rejects it — the API
+  stores an expression nothing references and never evaluates it — so the config applies and reads
+  back unchanged, having done nothing. If you exported this source from the dashboard the binding
+  is already there; it's a hand-written or hand-trimmed config that tends to lose it.
+  The second is parsing a payload value straight into a CatalogEntry["AlertPriority"]. That
+  resolves by matching the value against a priority's name, alias or external ID exactly, so a
+  payload saying CRITICAL matches no priority called Urgent, resolves to nothing, and falls back
+  to your default priority — for every alert, which reads exactly like a hardcoded priority.
+  Mapping a payload value onto a priority takes two expressions. The payload is opaque JSON: an
+  expression reaches into it with a parse operation, and a condition can only ask whether
+  payload as a whole is set, so subject = "payload.severity" resolves to nothing. Parse the
+  value out first, then branch on the result:
+  expressions = [
+    {
+      label          = "Severity"
+      reference      = "severity"
+      root_reference = "payload"
+      operations = [{
+        operation_type = "parse"
+        parse = {
+          source  = "$['severity']"
+          returns = { type = "String", array = false }
+        }
+      }]
+    },
+    {
+      label          = "Priority"
+      reference      = "priority"
+      root_reference = "."
+      operations = [{
+        operation_type = "branches"
+        branches = {
+          returns = { type = "CatalogEntry[\"AlertPriority\"]", array = false }
+          branches = [{
+            condition_groups = [{
+              conditions = [{
+                subject        = "expressions[\"severity\"]"
+                operation      = "one_of"
+                param_bindings = [{ values = ["CRITICAL", "critical"] }]
+              }]
+            }]
+            result = { value_literal = data.incident_catalog_entry.urgent_priority.id }
+          }]
+        }
+      }]
+      else_branch = {
+        result = { value_literal = data.incident_catalog_entry.low_priority.id }
+      }
+    },
+  ]
+  
+  A branches operation reads the whole scope, so it needs root_reference = "." and has to be the
+  only operation in its expression.
+  incident_alert_source_beta binds priority directly, as priority = { expression_ref = ... }, and
+  splits each attribute into its own resource.
 ---
 
 # incident_alert_source (Resource)
@@ -15,6 +88,88 @@ Configure your alert sources in incident.io.
 Alert sources are the systems that send alerts to incident.io, which can then be routed to the right people and teams.
 
 We'd generally recommend building alert sources in our [web dashboard](https://app.incident.io/~/alerts/configuration), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing alert source and copy the resulting Terraform without persisting it.
+
+## Setting an alert's priority
+
+This resource has no `priority` field. An alert's priority is set the same way as any other
+attribute: as an entry in `template.attributes` bound to the built-in `Priority` alert attribute,
+which you look up by name.
+
+    data "incident_alert_attribute" "priority" {
+      name = "Priority"
+    }
+
+    # ...then, in template.attributes
+    {
+      alert_attribute_id = data.incident_alert_attribute.priority.id
+      binding            = { value = { reference = "expressions[\"my-priority\"]" } }
+    }
+
+A priority binding takes no `merge_strategy`: an alert's priority is always overwritten when the
+alert fires again.
+
+Two mistakes here are worth knowing about, because both end with every alert on your default
+alert priority and neither says anything.
+
+The first is writing the expression and leaving out the binding. Nothing rejects it — the API
+stores an expression nothing references and never evaluates it — so the config applies and reads
+back unchanged, having done nothing. If you exported this source from the dashboard the binding
+is already there; it's a hand-written or hand-trimmed config that tends to lose it.
+
+The second is parsing a payload value straight into a `CatalogEntry["AlertPriority"]`. That
+resolves by matching the value against a priority's name, alias or external ID exactly, so a
+payload saying `CRITICAL` matches no priority called `Urgent`, resolves to nothing, and falls back
+to your default priority — for every alert, which reads exactly like a hardcoded priority.
+
+Mapping a payload value onto a priority takes two expressions. The payload is opaque JSON: an
+expression reaches into it with a `parse` operation, and a condition can only ask whether
+`payload` as a whole is set, so `subject = "payload.severity"` resolves to nothing. Parse the
+value out first, then branch on the result:
+
+    expressions = [
+      {
+        label          = "Severity"
+        reference      = "severity"
+        root_reference = "payload"
+        operations = [{
+          operation_type = "parse"
+          parse = {
+            source  = "$['severity']"
+            returns = { type = "String", array = false }
+          }
+        }]
+      },
+      {
+        label          = "Priority"
+        reference      = "priority"
+        root_reference = "."
+        operations = [{
+          operation_type = "branches"
+          branches = {
+            returns = { type = "CatalogEntry[\"AlertPriority\"]", array = false }
+            branches = [{
+              condition_groups = [{
+                conditions = [{
+                  subject        = "expressions[\"severity\"]"
+                  operation      = "one_of"
+                  param_bindings = [{ values = ["CRITICAL", "critical"] }]
+                }]
+              }]
+              result = { value_literal = data.incident_catalog_entry.urgent_priority.id }
+            }]
+          }
+        }]
+        else_branch = {
+          result = { value_literal = data.incident_catalog_entry.low_priority.id }
+        }
+      },
+    ]
+
+A `branches` operation reads the whole scope, so it needs `root_reference = "."` and has to be the
+only operation in its expression.
+
+`incident_alert_source_beta` binds priority directly, as `priority = { expression_ref = ... }`, and
+splits each attribute into its own resource.
 
 ## Example Usage
 
@@ -80,6 +235,22 @@ resource "incident_alert_source" "cloudwatch" {
           merge_strategy = "first_wins"
         }
       },
+
+      ## An alert's priority is set here, as a binding on the built-in `Priority` Alert
+      ## Attribute: this resource has no `priority` field of its own. An expression that
+      ## returns an AlertPriority and is bound to nothing has no effect, so this entry is
+      ## what makes the `cloudwatch-priority` expression below do anything at all.
+      ##
+      ## A priority binding takes no `merge_strategy`: an alert's priority is always
+      ## overwritten when the alert fires again.
+      {
+        alert_attribute_id = data.incident_alert_attribute.priority.id
+        binding = {
+          value = {
+            reference = "expressions[\"cloudwatch-priority\"]"
+          }
+        }
+      },
     ]
 
     ## Query the `team` value from the endpoint referenced in the SNS Topic Subscription
@@ -101,6 +272,76 @@ resource "incident_alert_source" "cloudwatch" {
         reference      = "cloudwatch-team"
         root_reference = "payload"
       },
+
+      ## Mapping the payload's severity onto an AlertPriority takes two expressions.
+      ##
+      ## The payload is opaque JSON: an expression reaches into it with a `parse`
+      ## operation, and a condition can only ask whether `payload` as a whole is set. So
+      ## `subject = "payload.severity"` resolves to nothing — pull the value out first.
+      ##
+      ## Step one: parse the severity out of the payload as a plain string.
+      {
+        label = "Severity"
+        operations = [
+          {
+            operation_type = "parse"
+            parse = {
+              returns = {
+                array = false
+                type  = "String"
+              }
+              source = "$['severity']"
+            }
+        }]
+        reference      = "cloudwatch-severity"
+        root_reference = "payload"
+      },
+
+      ## Step two: map that string onto a priority.
+      ##
+      ## Parsing the severity straight into a CatalogEntry["AlertPriority"] instead would
+      ## be shorter, but it resolves by matching the value against a priority's name, alias
+      ## or external ID exactly. A payload saying "CRITICAL" matches no priority called
+      ## "Urgent", so it resolves to nothing and every alert lands on the else_branch.
+      ## Branching on the value says what you mean.
+      {
+        label = "Priority"
+        operations = [
+          {
+            operation_type = "branches"
+            branches = {
+              returns = {
+                array = false
+                type  = "CatalogEntry[\"AlertPriority\"]"
+              }
+              branches = [
+                {
+                  condition_groups = [
+                    {
+                      conditions = [
+                        {
+                          subject   = "expressions[\"cloudwatch-severity\"]"
+                          operation = "one_of"
+                          param_bindings = [
+                            { values = ["CRITICAL", "critical"] },
+                          ]
+                        },
+                      ]
+                    },
+                  ]
+                  result = { value_literal = data.incident_catalog_entry.urgent_priority.id }
+                },
+              ]
+            }
+        }]
+        reference = "cloudwatch-priority"
+        ## A branches operation reads the whole scope, so root_reference must be "."
+        root_reference = "."
+        ## What the priority is when no branch matched
+        else_branch = {
+          result = { value_literal = data.incident_catalog_entry.low_priority.id }
+        }
+      },
     ]
   }
 }
@@ -109,6 +350,29 @@ resource "incident_alert_source" "cloudwatch" {
 
 data "incident_alert_attribute" "team" {
   name = "Team"
+}
+
+## `Priority` is a built-in Alert Attribute that every account already has, so it's looked
+## up rather than declared: `incident_alert_attribute` rejects the name.
+
+data "incident_alert_attribute" "priority" {
+  name = "Priority"
+}
+
+## The priorities themselves are Catalog Entries, looked up by name
+
+data "incident_catalog_type" "alert_priority" {
+  type_name = "AlertPriority"
+}
+
+data "incident_catalog_entry" "urgent_priority" {
+  catalog_type_id = data.incident_catalog_type.alert_priority.id
+  identifier      = "Urgent"
+}
+
+data "incident_catalog_entry" "low_priority" {
+  catalog_type_id = data.incident_catalog_type.alert_priority.id
+  identifier      = "Low"
 }
 
 ## AWS Resources

--- a/docs/resources/alert_source.md
+++ b/docs/resources/alert_source.md
@@ -20,8 +20,10 @@ description: |-
     binding            = { value = { reference = "expressions[\"my-priority\"]" } }
   }
   
-  A priority binding takes no merge_strategy: an alert's priority is always overwritten when the
-  alert fires again.
+  A priority binding's merge_strategy can only be last_wins: an alert's priority is always
+  overwritten when the alert fires again, so no other strategy would mean anything. Leave it out and
+  the API fills it in — it reads back as last_wins either way, so there is no diff to manage.
+  Setting any other value is rejected.
   Two mistakes here are worth knowing about, because both end with every alert on your default
   alert priority and neither says anything.
   The first is writing the expression and leaving out the binding. Nothing rejects it — the API
@@ -105,8 +107,10 @@ which you look up by name.
       binding            = { value = { reference = "expressions[\"my-priority\"]" } }
     }
 
-A priority binding takes no `merge_strategy`: an alert's priority is always overwritten when the
-alert fires again.
+A priority binding's `merge_strategy` can only be `last_wins`: an alert's priority is always
+overwritten when the alert fires again, so no other strategy would mean anything. Leave it out and
+the API fills it in — it reads back as `last_wins` either way, so there is no diff to manage.
+Setting any other value is rejected.
 
 Two mistakes here are worth knowing about, because both end with every alert on your default
 alert priority and neither says anything.
@@ -241,8 +245,9 @@ resource "incident_alert_source" "cloudwatch" {
       ## returns an AlertPriority and is bound to nothing has no effect, so this entry is
       ## what makes the `cloudwatch-priority` expression below do anything at all.
       ##
-      ## A priority binding takes no `merge_strategy`: an alert's priority is always
-      ## overwritten when the alert fires again.
+      ## A priority binding's `merge_strategy` can only be `last_wins`: an alert's
+      ## priority is always overwritten when the alert fires again. Left out here
+      ## because the API fills it in, and it reads back as `last_wins` either way.
       {
         alert_attribute_id = data.incident_alert_attribute.priority.id
         binding = {

--- a/docs/resources/alert_source.md
+++ b/docs/resources/alert_source.md
@@ -20,10 +20,9 @@ description: |-
     binding            = { value = { reference = "expressions[\"my-priority\"]" } }
   }
   
-  A priority binding's merge_strategy can only be last_wins: an alert's priority is always
-  overwritten when the alert fires again, so no other strategy would mean anything. Leave it out and
-  the API fills it in — it reads back as last_wins either way, so there is no diff to manage.
-  Setting any other value is rejected.
+  A priority binding's merge_strategy can only be last_wins. Leave it out and the API fills
+  it in — it reads back as last_wins either way, so there is no diff to manage. Setting any other
+  value is rejected.
   Two mistakes here are worth knowing about, because both end with every alert on your default
   alert priority and neither says anything.
   The first is writing the expression and leaving out the binding. Nothing rejects it — the API
@@ -107,10 +106,9 @@ which you look up by name.
       binding            = { value = { reference = "expressions[\"my-priority\"]" } }
     }
 
-A priority binding's `merge_strategy` can only be `last_wins`: an alert's priority is always
-overwritten when the alert fires again, so no other strategy would mean anything. Leave it out and
-the API fills it in — it reads back as `last_wins` either way, so there is no diff to manage.
-Setting any other value is rejected.
+A priority binding's `merge_strategy` can only be `last_wins`. Leave it out and the API fills
+it in — it reads back as `last_wins` either way, so there is no diff to manage. Setting any other
+value is rejected.
 
 Two mistakes here are worth knowing about, because both end with every alert on your default
 alert priority and neither says anything.
@@ -245,9 +243,9 @@ resource "incident_alert_source" "cloudwatch" {
       ## returns an AlertPriority and is bound to nothing has no effect, so this entry is
       ## what makes the `cloudwatch-priority` expression below do anything at all.
       ##
-      ## A priority binding's `merge_strategy` can only be `last_wins`: an alert's
-      ## priority is always overwritten when the alert fires again. Left out here
-      ## because the API fills it in, and it reads back as `last_wins` either way.
+      ## A priority binding's `merge_strategy` can only be `last_wins`. Left out
+      ## here because the API fills it in, and it reads back as `last_wins`
+      ## either way; setting any other value is rejected.
       {
         alert_attribute_id = data.incident_alert_attribute.priority.id
         binding = {

--- a/examples/resources/incident_alert_source/resource.tf
+++ b/examples/resources/incident_alert_source/resource.tf
@@ -59,6 +59,22 @@ resource "incident_alert_source" "cloudwatch" {
           merge_strategy = "first_wins"
         }
       },
+
+      ## An alert's priority is set here, as a binding on the built-in `Priority` Alert
+      ## Attribute: this resource has no `priority` field of its own. An expression that
+      ## returns an AlertPriority and is bound to nothing has no effect, so this entry is
+      ## what makes the `cloudwatch-priority` expression below do anything at all.
+      ##
+      ## A priority binding takes no `merge_strategy`: an alert's priority is always
+      ## overwritten when the alert fires again.
+      {
+        alert_attribute_id = data.incident_alert_attribute.priority.id
+        binding = {
+          value = {
+            reference = "expressions[\"cloudwatch-priority\"]"
+          }
+        }
+      },
     ]
 
     ## Query the `team` value from the endpoint referenced in the SNS Topic Subscription
@@ -80,6 +96,76 @@ resource "incident_alert_source" "cloudwatch" {
         reference      = "cloudwatch-team"
         root_reference = "payload"
       },
+
+      ## Mapping the payload's severity onto an AlertPriority takes two expressions.
+      ##
+      ## The payload is opaque JSON: an expression reaches into it with a `parse`
+      ## operation, and a condition can only ask whether `payload` as a whole is set. So
+      ## `subject = "payload.severity"` resolves to nothing — pull the value out first.
+      ##
+      ## Step one: parse the severity out of the payload as a plain string.
+      {
+        label = "Severity"
+        operations = [
+          {
+            operation_type = "parse"
+            parse = {
+              returns = {
+                array = false
+                type  = "String"
+              }
+              source = "$['severity']"
+            }
+        }]
+        reference      = "cloudwatch-severity"
+        root_reference = "payload"
+      },
+
+      ## Step two: map that string onto a priority.
+      ##
+      ## Parsing the severity straight into a CatalogEntry["AlertPriority"] instead would
+      ## be shorter, but it resolves by matching the value against a priority's name, alias
+      ## or external ID exactly. A payload saying "CRITICAL" matches no priority called
+      ## "Urgent", so it resolves to nothing and every alert lands on the else_branch.
+      ## Branching on the value says what you mean.
+      {
+        label = "Priority"
+        operations = [
+          {
+            operation_type = "branches"
+            branches = {
+              returns = {
+                array = false
+                type  = "CatalogEntry[\"AlertPriority\"]"
+              }
+              branches = [
+                {
+                  condition_groups = [
+                    {
+                      conditions = [
+                        {
+                          subject   = "expressions[\"cloudwatch-severity\"]"
+                          operation = "one_of"
+                          param_bindings = [
+                            { values = ["CRITICAL", "critical"] },
+                          ]
+                        },
+                      ]
+                    },
+                  ]
+                  result = { value_literal = data.incident_catalog_entry.urgent_priority.id }
+                },
+              ]
+            }
+        }]
+        reference = "cloudwatch-priority"
+        ## A branches operation reads the whole scope, so root_reference must be "."
+        root_reference = "."
+        ## What the priority is when no branch matched
+        else_branch = {
+          result = { value_literal = data.incident_catalog_entry.low_priority.id }
+        }
+      },
     ]
   }
 }
@@ -88,6 +174,29 @@ resource "incident_alert_source" "cloudwatch" {
 
 data "incident_alert_attribute" "team" {
   name = "Team"
+}
+
+## `Priority` is a built-in Alert Attribute that every account already has, so it's looked
+## up rather than declared: `incident_alert_attribute` rejects the name.
+
+data "incident_alert_attribute" "priority" {
+  name = "Priority"
+}
+
+## The priorities themselves are Catalog Entries, looked up by name
+
+data "incident_catalog_type" "alert_priority" {
+  type_name = "AlertPriority"
+}
+
+data "incident_catalog_entry" "urgent_priority" {
+  catalog_type_id = data.incident_catalog_type.alert_priority.id
+  identifier      = "Urgent"
+}
+
+data "incident_catalog_entry" "low_priority" {
+  catalog_type_id = data.incident_catalog_type.alert_priority.id
+  identifier      = "Low"
 }
 
 ## AWS Resources

--- a/examples/resources/incident_alert_source/resource.tf
+++ b/examples/resources/incident_alert_source/resource.tf
@@ -65,8 +65,9 @@ resource "incident_alert_source" "cloudwatch" {
       ## returns an AlertPriority and is bound to nothing has no effect, so this entry is
       ## what makes the `cloudwatch-priority` expression below do anything at all.
       ##
-      ## A priority binding takes no `merge_strategy`: an alert's priority is always
-      ## overwritten when the alert fires again.
+      ## A priority binding's `merge_strategy` can only be `last_wins`: an alert's
+      ## priority is always overwritten when the alert fires again. Left out here
+      ## because the API fills it in, and it reads back as `last_wins` either way.
       {
         alert_attribute_id = data.incident_alert_attribute.priority.id
         binding = {

--- a/examples/resources/incident_alert_source/resource.tf
+++ b/examples/resources/incident_alert_source/resource.tf
@@ -65,9 +65,9 @@ resource "incident_alert_source" "cloudwatch" {
       ## returns an AlertPriority and is bound to nothing has no effect, so this entry is
       ## what makes the `cloudwatch-priority` expression below do anything at all.
       ##
-      ## A priority binding's `merge_strategy` can only be `last_wins`: an alert's
-      ## priority is always overwritten when the alert fires again. Left out here
-      ## because the API fills it in, and it reads back as `last_wins` either way.
+      ## A priority binding's `merge_strategy` can only be `last_wins`. Left out
+      ## here because the API fills it in, and it reads back as `last_wins`
+      ## either way; setting any other value is rejected.
       {
         alert_attribute_id = data.incident_alert_attribute.priority.id
         binding = {

--- a/internal/provider/incident_alert_source_resource.go
+++ b/internal/provider/incident_alert_source_resource.go
@@ -426,8 +426,10 @@ which you look up by name.
       binding            = { value = { reference = "expressions[\"my-priority\"]" } }
     }
 
-A priority binding takes no `+"`merge_strategy`"+`: an alert's priority is always overwritten when the
-alert fires again.
+A priority binding's `+"`merge_strategy`"+` can only be `+"`last_wins`"+`: an alert's priority is always
+overwritten when the alert fires again, so no other strategy would mean anything. Leave it out and
+the API fills it in — it reads back as `+"`last_wins`"+` either way, so there is no diff to manage.
+Setting any other value is rejected.
 
 Two mistakes here are worth knowing about, because both end with every alert on your default
 alert priority and neither says anything.

--- a/internal/provider/incident_alert_source_resource.go
+++ b/internal/provider/incident_alert_source_resource.go
@@ -408,7 +408,89 @@ func (r *IncidentAlertSourceResource) Metadata(ctx context.Context, req resource
 
 func (r *IncidentAlertSourceResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: fmt.Sprintf("%s\n\n%s", apischema.TagDocstring("Alert Sources V2"), `We'd generally recommend building alert sources in our [web dashboard](https://app.incident.io/~/alerts/configuration), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing alert source and copy the resulting Terraform without persisting it.`),
+		MarkdownDescription: fmt.Sprintf("%s\n\n%s", apischema.TagDocstring("Alert Sources V2"), `We'd generally recommend building alert sources in our [web dashboard](https://app.incident.io/~/alerts/configuration), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing alert source and copy the resulting Terraform without persisting it.
+
+## Setting an alert's priority
+
+This resource has no `+"`priority`"+` field. An alert's priority is set the same way as any other
+attribute: as an entry in `+"`template.attributes`"+` bound to the built-in `+"`Priority`"+` alert attribute,
+which you look up by name.
+
+    data "incident_alert_attribute" "priority" {
+      name = "Priority"
+    }
+
+    # ...then, in template.attributes
+    {
+      alert_attribute_id = data.incident_alert_attribute.priority.id
+      binding            = { value = { reference = "expressions[\"my-priority\"]" } }
+    }
+
+A priority binding takes no `+"`merge_strategy`"+`: an alert's priority is always overwritten when the
+alert fires again.
+
+Two mistakes here are worth knowing about, because both end with every alert on your default
+alert priority and neither says anything.
+
+The first is writing the expression and leaving out the binding. Nothing rejects it — the API
+stores an expression nothing references and never evaluates it — so the config applies and reads
+back unchanged, having done nothing. If you exported this source from the dashboard the binding
+is already there; it's a hand-written or hand-trimmed config that tends to lose it.
+
+The second is parsing a payload value straight into a `+"`CatalogEntry[\"AlertPriority\"]`"+`. That
+resolves by matching the value against a priority's name, alias or external ID exactly, so a
+payload saying `+"`CRITICAL`"+` matches no priority called `+"`Urgent`"+`, resolves to nothing, and falls back
+to your default priority — for every alert, which reads exactly like a hardcoded priority.
+
+Mapping a payload value onto a priority takes two expressions. The payload is opaque JSON: an
+expression reaches into it with a `+"`parse`"+` operation, and a condition can only ask whether
+`+"`payload`"+` as a whole is set, so `+"`subject = \"payload.severity\"`"+` resolves to nothing. Parse the
+value out first, then branch on the result:
+
+    expressions = [
+      {
+        label          = "Severity"
+        reference      = "severity"
+        root_reference = "payload"
+        operations = [{
+          operation_type = "parse"
+          parse = {
+            source  = "$['severity']"
+            returns = { type = "String", array = false }
+          }
+        }]
+      },
+      {
+        label          = "Priority"
+        reference      = "priority"
+        root_reference = "."
+        operations = [{
+          operation_type = "branches"
+          branches = {
+            returns = { type = "CatalogEntry[\"AlertPriority\"]", array = false }
+            branches = [{
+              condition_groups = [{
+                conditions = [{
+                  subject        = "expressions[\"severity\"]"
+                  operation      = "one_of"
+                  param_bindings = [{ values = ["CRITICAL", "critical"] }]
+                }]
+              }]
+              result = { value_literal = data.incident_catalog_entry.urgent_priority.id }
+            }]
+          }
+        }]
+        else_branch = {
+          result = { value_literal = data.incident_catalog_entry.low_priority.id }
+        }
+      },
+    ]
+
+A `+"`branches`"+` operation reads the whole scope, so it needs `+"`root_reference = \".\"`"+` and has to be the
+only operation in its expression.
+
+`+"`incident_alert_source_beta`"+` binds priority directly, as `+"`priority = { expression_ref = ... }`"+`, and
+splits each attribute into its own resource.`),
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed: true,

--- a/internal/provider/incident_alert_source_resource.go
+++ b/internal/provider/incident_alert_source_resource.go
@@ -426,10 +426,9 @@ which you look up by name.
       binding            = { value = { reference = "expressions[\"my-priority\"]" } }
     }
 
-A priority binding's `+"`merge_strategy`"+` can only be `+"`last_wins`"+`: an alert's priority is always
-overwritten when the alert fires again, so no other strategy would mean anything. Leave it out and
-the API fills it in — it reads back as `+"`last_wins`"+` either way, so there is no diff to manage.
-Setting any other value is rejected.
+A priority binding's `+"`merge_strategy`"+` can only be `+"`last_wins`"+`. Leave it out and the API fills
+it in — it reads back as `+"`last_wins`"+` either way, so there is no diff to manage. Setting any other
+value is rejected.
 
 Two mistakes here are worth knowing about, because both end with every alert on your default
 alert priority and neither says anything.


### PR DESCRIPTION
Closes #527 on the provider side.

Split into three PRs: this one documents the priority binding, #533 fixes the broken beta examples the same investigation turned up, and #534 adds the acceptance tests.

## Why

`incident_alert_source` has no `priority` field. The V2 API carries an alert's priority as a binding on the built-in `Priority` alert attribute, under a synthetic attribute ID — core's own V3 design file says so:

> `priority` is a real field. V2 smuggles it through `attributes[]` under a synthetic attribute ID, which means a client cannot tell it apart from a real attribute.

That was completely undocumented: zero mentions of priority in `docs/resources/alert_source.md` or the example. The only place the pattern existed was `TestAccAlertSourceResource_Issue342_SpuriousMergeStrategy`, a regression test for an unrelated bug.

## What this documents

The binding itself — a `template.attributes` entry bound to the `Priority` alert attribute, looked up with the `incident_alert_attribute` data source, and taking no `merge_strategy` — plus the two ways setting a priority silently does nothing. Both end on the org's default alert priority (`evaluate_attributes.go:288` in core), which is why this reads to a user as "priority is hardcoded":

- **Expression, no binding.** The API stores an expression nothing references and never evaluates it, so the config applies and reads back unchanged, having done nothing.
- **Parsing straight into `CatalogEntry["AlertPriority"]`.** This resolves by matching the value against a priority's name, alias or external ID *exactly* (`resource_catalog_entry.go`, `identifiers @> ARRAY[value]`). A payload saying `CRITICAL` matches no priority called `Urgent`, resolves to nothing, and the `else_branch` wins every time.

The second is what happened in #527.

The `incident_alert_source` example now shows the working shape: `parse` the severity out of the payload, `branch` that onto an `AlertPriority` catalog entry, and bind the result.

No changelog entry, as this is docs and examples only.

## Not in scope

Two findings from the same investigation that belong in core, not here:

- The silent fallback at `evaluate_attributes.go:288` logs at info and substitutes the default priority, making "never resolves" indistinguishable from "not configured". `sourceconfigs/template_reference_warnings.go` is the natural home for a warning, and it'd cover the dashboard too.
- The Terraform exporter writes the priority binding's `alert_attribute_id` as a raw org-specific ULID (`generate.go:253`), where every sibling attribute goes through `writeAlertAttributeIDReference` and comes out as a data source lookup.

Both verified correct and *not* the bug: the V2 and V3 APIs round-trip priority properly, and the exporter does emit the priority binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example-only changes with no provider runtime or API behavior changes.
> 
> **Overview**
> Documents how to set alert priority on **`incident_alert_source`**, which has no top-level **`priority`** field. Priority is configured through **`template.attributes`** bound to the built-in **`Priority`** alert attribute (via **`incident_alert_attribute`**), including **`merge_strategy`** rules (**`last_wins`** only).
> 
> Adds guidance on two silent failure modes (expression without binding; parsing directly to **`CatalogEntry["AlertPriority"]`**) and the recommended **`parse` + `branches`** pattern for mapping payload severity to catalog priorities.
> 
> The CloudWatch example in **`docs/resources/alert_source.md`** and **`examples/resources/incident_alert_source/resource.tf`** is extended with priority bindings, expressions, and catalog data sources. The same prose is wired into the resource schema **`MarkdownDescription`** in **`incident_alert_source_resource.go`** so generated registry docs stay in sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a67c9a942074a40d5c1e222f9f0f9d73f62277c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->