### PR TITLE
Fix the beta alert source examples' branches conditions

### DIFF
--- a/docs/resources/alert_source_attribute_beta.md
+++ b/docs/resources/alert_source_attribute_beta.md
@@ -117,11 +117,26 @@ resource "incident_alert_source_attribute_beta" "severity" {
 
   expression_ref = "severity_lookup"
 
+  # The payload is opaque JSON: an expression reaches into it with a parse operation, and a
+  # condition can only ask whether payload as a whole is set. So a lookup on a payload value
+  # takes two expressions — parse the value out, then branch on the result.
+  named_expression {
+    name       = "severity"
+    start_from = "payload"
+
+    operation {
+      parse {
+        function = "$.labels.severity"
+        as       = "String"
+      }
+    }
+  }
+
   named_expression {
     name = "severity_lookup"
 
     # A branches-only expression starts from the whole scope, so its conditions reference
-    # absolute paths.
+    # absolute paths — including other expressions' results.
     start_from = "."
 
     operation {
@@ -130,7 +145,7 @@ resource "incident_alert_source_attribute_beta" "severity" {
 
         if {
           conditions = [{
-            subject   = "payload.labels.severity"
+            subject   = "expressions[\"severity\"]"
             operation = "one_of"
             params    = [{ values = ["critical", "page"] }]
           }]
@@ -139,7 +154,7 @@ resource "incident_alert_source_attribute_beta" "severity" {
 
         else_if {
           conditions = [{
-            subject   = "payload.labels.severity"
+            subject   = "expressions[\"severity\"]"
             operation = "one_of"
             params    = [{ values = ["warning"] }]
           }]

--- a/docs/resources/alert_source_beta.md
+++ b/docs/resources/alert_source_beta.md
@@ -67,38 +67,74 @@ resource "incident_alert_source_beta" "prometheus" {
     literal = data.incident_rich_text.prometheus_alert.json
   }
 
-  # An expression this source owns, addressed by name.
+  # Expressions this source owns, addressed by name. One can reference another.
+  #
+  # The payload is opaque JSON: an expression reaches into it with a parse operation,
+  # and a condition can only ask whether payload as a whole is set. So mapping a payload
+  # value onto something takes two expressions — parse the value out, then branch on it.
   named_expression {
-    name = "severity_lookup"
+    name       = "severity"
+    start_from = "payload"
 
-    # A branches-only expression starts from the whole scope, so its conditions
-    # reference absolute paths.
+    operation {
+      parse {
+        function = "$.labels.severity"
+        as       = "String"
+      }
+    }
+  }
+
+  # A branches-only expression starts from the whole scope, so its conditions reference
+  # absolute paths — including other expressions' results.
+  named_expression {
+    name       = "priority_lookup"
     start_from = "."
 
     operation {
       branches {
-        as = incident_alert_attribute.severity.type
+        # A priority is an AlertPriority catalog entry, so that is what every branch
+        # here has to return.
+        as = "CatalogEntry[\"AlertPriority\"]"
 
         if {
           conditions = [{
-            subject   = "payload.labels.severity"
+            subject   = "expressions[\"severity\"]"
             operation = "one_of"
             params    = [{ values = ["critical", "page"] }]
           }]
-          result = { value_literal = "high" }
+          result = { value_literal = data.incident_catalog_entry.urgent_priority.id }
         }
       }
     }
 
-    # What the expression produces when no branch matched.
+    # What the expression produces when no branch matched. Without it, an unmatched
+    # severity resolves to nothing and the alert falls back to your default priority.
     fallback {
-      result = { value_literal = "low" }
+      result = { value_literal = data.incident_catalog_entry.low_priority.id }
     }
   }
 
+  # Unlike incident_alert_source, priority is a field here rather than a binding on the
+  # built-in Priority alert attribute.
   priority = {
-    expression_ref = "severity_lookup"
+    expression_ref = "priority_lookup"
   }
+}
+
+# The priorities themselves are AlertPriority catalog entries, looked up by name.
+
+data "incident_catalog_type" "alert_priority" {
+  type_name = "AlertPriority"
+}
+
+data "incident_catalog_entry" "urgent_priority" {
+  catalog_type_id = data.incident_catalog_type.alert_priority.id
+  identifier      = "Urgent"
+}
+
+data "incident_catalog_entry" "low_priority" {
+  catalog_type_id = data.incident_catalog_type.alert_priority.id
+  identifier      = "Low"
 }
 
 data "incident_rich_text" "prometheus_alert" {

--- a/examples/resources/incident_alert_source_attribute_beta/resource.tf
+++ b/examples/resources/incident_alert_source_attribute_beta/resource.tf
@@ -67,11 +67,26 @@ resource "incident_alert_source_attribute_beta" "severity" {
 
   expression_ref = "severity_lookup"
 
+  # The payload is opaque JSON: an expression reaches into it with a parse operation, and a
+  # condition can only ask whether payload as a whole is set. So a lookup on a payload value
+  # takes two expressions — parse the value out, then branch on the result.
+  named_expression {
+    name       = "severity"
+    start_from = "payload"
+
+    operation {
+      parse {
+        function = "$.labels.severity"
+        as       = "String"
+      }
+    }
+  }
+
   named_expression {
     name = "severity_lookup"
 
     # A branches-only expression starts from the whole scope, so its conditions reference
-    # absolute paths.
+    # absolute paths — including other expressions' results.
     start_from = "."
 
     operation {
@@ -80,7 +95,7 @@ resource "incident_alert_source_attribute_beta" "severity" {
 
         if {
           conditions = [{
-            subject   = "payload.labels.severity"
+            subject   = "expressions[\"severity\"]"
             operation = "one_of"
             params    = [{ values = ["critical", "page"] }]
           }]
@@ -89,7 +104,7 @@ resource "incident_alert_source_attribute_beta" "severity" {
 
         else_if {
           conditions = [{
-            subject   = "payload.labels.severity"
+            subject   = "expressions[\"severity\"]"
             operation = "one_of"
             params    = [{ values = ["warning"] }]
           }]

--- a/examples/resources/incident_alert_source_beta/resource.tf
+++ b/examples/resources/incident_alert_source_beta/resource.tf
@@ -21,38 +21,74 @@ resource "incident_alert_source_beta" "prometheus" {
     literal = data.incident_rich_text.prometheus_alert.json
   }
 
-  # An expression this source owns, addressed by name.
+  # Expressions this source owns, addressed by name. One can reference another.
+  #
+  # The payload is opaque JSON: an expression reaches into it with a parse operation,
+  # and a condition can only ask whether payload as a whole is set. So mapping a payload
+  # value onto something takes two expressions — parse the value out, then branch on it.
   named_expression {
-    name = "severity_lookup"
+    name       = "severity"
+    start_from = "payload"
 
-    # A branches-only expression starts from the whole scope, so its conditions
-    # reference absolute paths.
+    operation {
+      parse {
+        function = "$.labels.severity"
+        as       = "String"
+      }
+    }
+  }
+
+  # A branches-only expression starts from the whole scope, so its conditions reference
+  # absolute paths — including other expressions' results.
+  named_expression {
+    name       = "priority_lookup"
     start_from = "."
 
     operation {
       branches {
-        as = incident_alert_attribute.severity.type
+        # A priority is an AlertPriority catalog entry, so that is what every branch
+        # here has to return.
+        as = "CatalogEntry[\"AlertPriority\"]"
 
         if {
           conditions = [{
-            subject   = "payload.labels.severity"
+            subject   = "expressions[\"severity\"]"
             operation = "one_of"
             params    = [{ values = ["critical", "page"] }]
           }]
-          result = { value_literal = "high" }
+          result = { value_literal = data.incident_catalog_entry.urgent_priority.id }
         }
       }
     }
 
-    # What the expression produces when no branch matched.
+    # What the expression produces when no branch matched. Without it, an unmatched
+    # severity resolves to nothing and the alert falls back to your default priority.
     fallback {
-      result = { value_literal = "low" }
+      result = { value_literal = data.incident_catalog_entry.low_priority.id }
     }
   }
 
+  # Unlike incident_alert_source, priority is a field here rather than a binding on the
+  # built-in Priority alert attribute.
   priority = {
-    expression_ref = "severity_lookup"
+    expression_ref = "priority_lookup"
   }
+}
+
+# The priorities themselves are AlertPriority catalog entries, looked up by name.
+
+data "incident_catalog_type" "alert_priority" {
+  type_name = "AlertPriority"
+}
+
+data "incident_catalog_entry" "urgent_priority" {
+  catalog_type_id = data.incident_catalog_type.alert_priority.id
+  identifier      = "Urgent"
+}
+
+data "incident_catalog_entry" "low_priority" {
+  catalog_type_id = data.incident_catalog_type.alert_priority.id
+  identifier      = "Low"
 }
 
 data "incident_rich_text" "prometheus_alert" {


### PR DESCRIPTION
Split out of #530.

## Why

Both beta alert source examples branched on a payload field directly:

```hcl
subject   = "payload.labels.severity"
```

An alert source's `payload` is a `ResourceJSON` (`app/oncall/alert/sources/source.go:539`). It offers `AsParseableInput()` plus `is_set`/`is_not_set`, and **no key navigation** — so those subjects resolve to nothing, no branch ever matches, and every alert takes the fallback. Core's own branches tests only ever use top-level subjects like `title`.

Anyone copying these examples got a source that silently never branched.

## What changed

Mapping a payload value onto anything takes two expressions: one `parse` to pull the value out, a second to `branch` on that result. Both `incident_alert_source_beta` and `incident_alert_source_attribute_beta` now show that.

The beta source example was additionally binding `priority` to an expression returning an alert attribute's type rather than a `CatalogEntry["AlertPriority"]`, with `"high"`/`"low"` string literals instead of priority IDs. It now returns catalog entries looked up by name.

Docs regenerated; no changelog entry, as this only touches examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)