### PR TITLE
Add an example for every policy type, and require a due date where the API does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- `due_date_config` is now required on an `incident_policy`'s `follow_up`, `debrief` and `post_mortem` blocks. These are the policy types that carry a due date, and the API rejects an update to one without it - so a config that omitted the block created a policy successfully and then failed on its next apply. The plan now says so instead. If you have such a config, add a `due_date_config`; the policy it created was already un-editable through the API.
+
 ## v6.11.0
 
 - Add the `incident_incident_template` resource, which manages an incident template. Incident templates determine how an incident is created from an alert, and have been split out of alert routes, where they lived previously.

--- a/docs/resources/policy.md
+++ b/docs/resources/policy.md
@@ -94,6 +94,165 @@ resource "incident_policy" "postmortems" {
 }
 ```
 
+## Example - Action follow-ups within 30 days
+
+```terraform
+# Who to chase when a follow-up is overdue.
+data "incident_user" "followups_owner" {
+  email = "engineering-manager@example.com"
+}
+
+data "incident_incident_timestamp" "followups_closed" {
+  name = "Closed at"
+}
+
+# A follow-up policy: the follow-ups left behind by an incident have to be dealt
+# with, rather than sitting open indefinitely.
+resource "incident_policy" "follow_ups" {
+  name        = "Follow-ups actioned within 30 days"
+  description = "Follow-ups from an incident shouldn't be left open once it closes."
+
+  # Empty, so the policy applies to every incident.
+  condition_groups = []
+
+  # Offsets are in whole days, so use multiples of 24 hours: a nudge the day
+  # before, and a chase the day after.
+  assignment_rules = {
+    bindings                       = [{ value_literal = data.incident_user.followups_owner.id }]
+    reminder_due_date_offset_hours = [-24, 24]
+  }
+
+  follow_up = {
+    # A follow-up is compliant once it's out of the open state — completed, or
+    # deliberately dropped.
+    requirements = [
+      {
+        conditions = [
+          {
+            subject        = "follow_up.status"
+            operation      = "not_one_of"
+            param_bindings = [{ values = ["open"] }]
+          }
+        ]
+      }
+    ]
+
+    # Required for follow-up, debrief and post-mortem policies: these types are
+    # the ones that carry a due date, and the API rejects an update without one.
+    due_date_config = {
+      incident_timestamp_id = data.incident_incident_timestamp.followups_closed.id
+      days                  = { value_literal = "30" }
+      calculation_type      = "seven_days"
+    }
+  }
+}
+```
+
+## Example - Book a debrief for major incidents
+
+```terraform
+data "incident_user" "debriefs_owner" {
+  email = "incident-manager@example.com"
+}
+
+data "incident_incident_timestamp" "debriefs_closed" {
+  name = "Closed at"
+}
+
+# A debrief policy: major incidents need a debrief booked in, not just promised.
+#
+# This one scopes itself with condition_groups rather than applying to every
+# incident, so only the incidents that warrant a debrief are held to it.
+resource "incident_policy" "debriefs" {
+  name        = "Debriefs booked for major incidents"
+  description = "Anything at major severity or above needs a debrief in the calendar."
+
+  condition_groups = [
+    {
+      conditions = [
+        {
+          subject   = "incident.severity"
+          operation = "gte"
+          # The ID of the severity to compare against, which is a literal rather
+          # than a reference.
+          param_bindings = [{ value_literal = "01FCNDV6P870EA6S7TK1DSYD5H" }]
+        }
+      ]
+    }
+  ]
+
+  assignment_rules = {
+    bindings                       = [{ value_literal = data.incident_user.debriefs_owner.id }]
+    reminder_due_date_offset_hours = [-24]
+  }
+
+  debrief = {
+    # `is_set` takes no parameters, so its bindings list is empty — but the key
+    # is still required.
+    requirements = [
+      {
+        conditions = [
+          {
+            subject        = "debrief.is_scheduled"
+            operation      = "is_set"
+            param_bindings = []
+          }
+        ]
+      }
+    ]
+
+    due_date_config = {
+      incident_timestamp_id = data.incident_incident_timestamp.debriefs_closed.id
+      days                  = { value_literal = "5" }
+      calculation_type      = "weekdays"
+    }
+  }
+}
+```
+
+## Example - Find gaps in on-call coverage
+
+```terraform
+data "incident_user" "schedule_owner" {
+  email = "on-call-manager@example.com"
+}
+
+# A schedule policy, which finds gaps in on-call coverage.
+#
+# Unlike follow-up, debrief and post-mortem policies this one takes no
+# due_date_config: a coverage gap is a violation the moment it's spotted, so
+# there is no due date to count from. It's the one type that instead supports
+# reminders measured from when the gap was detected.
+resource "incident_policy" "schedule_coverage" {
+  name        = "On-call schedules have no gaps"
+  description = "Every rotation should have someone on call at all times."
+
+  # Empty, so the policy applies to every schedule.
+  condition_groups = []
+
+  assignment_rules = {
+    bindings = [{ value_literal = data.incident_user.schedule_owner.id }]
+
+    # No due date to measure from, so this stays empty and the reminders below
+    # do the work instead.
+    reminder_due_date_offset_hours = []
+
+    # Whole days from when the gap was found: straight away, then again after
+    # two days if it's still there.
+    reminder_detected_date_offset_hours = [0, 48]
+  }
+
+  schedule = {
+    # Check that cover is contiguous, with no uncovered stretches.
+    requirement_type = "contiguous"
+
+    # Judge each rotation separately rather than the schedule as a whole, so one
+    # rotation covering for another doesn't hide a gap. Defaults to "schedule".
+    evaluation_level = "rotation"
+  }
+}
+```
+
 ## Example - Check that on-call responders can be reached
 
 ```terraform

--- a/docs/resources/policy.md
+++ b/docs/resources/policy.md
@@ -428,12 +428,58 @@ Optional:
 
 Required:
 
+- `due_date_config` (Attributes) (see [below for nested schema](#nestedatt--debrief--due_date_config))
 - `requirements` (Attributes List) Groups of prerequisite conditions. All conditions in at least one group must be satisfied (see [below for nested schema](#nestedatt--debrief--requirements))
 
 Optional:
 
-- `due_date_config` (Attributes) (see [below for nested schema](#nestedatt--debrief--due_date_config))
 - `run_on_private_incidents` (Boolean) Requires the policies.run_on_private scope
+
+<a id="nestedatt--debrief--due_date_config"></a>
+### Nested Schema for `debrief.due_date_config`
+
+Required:
+
+- `calculation_type` (String) Whether to count all days or only weekdays. Possible values are: `seven_days`, `weekdays`.
+- `days` (Attributes) (see [below for nested schema](#nestedatt--debrief--due_date_config--days))
+- `incident_timestamp_id` (String) Timestamp the due date counts from
+
+Optional:
+
+- `applies_from` (String) If set, the policy only applies to resources from this timestamp onwards
+- `calculation_timezone` (String) Timezone the due date is calculated in. Only meaningful when calculation_type is weekdays.
+
+<a id="nestedatt--debrief--due_date_config--days"></a>
+### Nested Schema for `debrief.due_date_config.days`
+
+Optional:
+
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--debrief--due_date_config--days--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--debrief--due_date_config--days--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
+
+<a id="nestedatt--debrief--due_date_config--days--array_value"></a>
+### Nested Schema for `debrief.due_date_config.days.array_value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--debrief--due_date_config--days--value"></a>
+### Nested Schema for `debrief.due_date_config.days.value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
 
 <a id="nestedatt--debrief--requirements"></a>
 ### Nested Schema for `debrief.requirements`
@@ -480,52 +526,6 @@ Optional:
 - `literal` (String) If set, this is the literal value of the step parameter
 - `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
 
-
-
-
-
-<a id="nestedatt--debrief--due_date_config"></a>
-### Nested Schema for `debrief.due_date_config`
-
-Required:
-
-- `calculation_type` (String) Whether to count all days or only weekdays. Possible values are: `seven_days`, `weekdays`.
-- `days` (Attributes) (see [below for nested schema](#nestedatt--debrief--due_date_config--days))
-- `incident_timestamp_id` (String) Timestamp the due date counts from
-
-Optional:
-
-- `applies_from` (String) If set, the policy only applies to resources from this timestamp onwards
-- `calculation_timezone` (String) Timezone the due date is calculated in. Only meaningful when calculation_type is weekdays.
-
-<a id="nestedatt--debrief--due_date_config--days"></a>
-### Nested Schema for `debrief.due_date_config.days`
-
-Optional:
-
-- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--debrief--due_date_config--days--array_value))
-- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
-- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--debrief--due_date_config--days--value))
-- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
-- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
-- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
-
-<a id="nestedatt--debrief--due_date_config--days--array_value"></a>
-### Nested Schema for `debrief.due_date_config.days.array_value`
-
-Optional:
-
-- `literal` (String) If set, this is the literal value of the step parameter
-- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
-
-
-<a id="nestedatt--debrief--due_date_config--days--value"></a>
-### Nested Schema for `debrief.due_date_config.days.value`
-
-Optional:
-
-- `literal` (String) If set, this is the literal value of the step parameter
-- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
 
 
 
@@ -822,12 +822,58 @@ Optional:
 
 Required:
 
+- `due_date_config` (Attributes) (see [below for nested schema](#nestedatt--follow_up--due_date_config))
 - `requirements` (Attributes List) Groups of prerequisite conditions. All conditions in at least one group must be satisfied (see [below for nested schema](#nestedatt--follow_up--requirements))
 
 Optional:
 
-- `due_date_config` (Attributes) (see [below for nested schema](#nestedatt--follow_up--due_date_config))
 - `run_on_private_incidents` (Boolean) Requires the policies.run_on_private scope
+
+<a id="nestedatt--follow_up--due_date_config"></a>
+### Nested Schema for `follow_up.due_date_config`
+
+Required:
+
+- `calculation_type` (String) Whether to count all days or only weekdays. Possible values are: `seven_days`, `weekdays`.
+- `days` (Attributes) (see [below for nested schema](#nestedatt--follow_up--due_date_config--days))
+- `incident_timestamp_id` (String) Timestamp the due date counts from
+
+Optional:
+
+- `applies_from` (String) If set, the policy only applies to resources from this timestamp onwards
+- `calculation_timezone` (String) Timezone the due date is calculated in. Only meaningful when calculation_type is weekdays.
+
+<a id="nestedatt--follow_up--due_date_config--days"></a>
+### Nested Schema for `follow_up.due_date_config.days`
+
+Optional:
+
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--follow_up--due_date_config--days--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--follow_up--due_date_config--days--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
+
+<a id="nestedatt--follow_up--due_date_config--days--array_value"></a>
+### Nested Schema for `follow_up.due_date_config.days.array_value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--follow_up--due_date_config--days--value"></a>
+### Nested Schema for `follow_up.due_date_config.days.value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
 
 <a id="nestedatt--follow_up--requirements"></a>
 ### Nested Schema for `follow_up.requirements`
@@ -878,52 +924,6 @@ Optional:
 
 
 
-<a id="nestedatt--follow_up--due_date_config"></a>
-### Nested Schema for `follow_up.due_date_config`
-
-Required:
-
-- `calculation_type` (String) Whether to count all days or only weekdays. Possible values are: `seven_days`, `weekdays`.
-- `days` (Attributes) (see [below for nested schema](#nestedatt--follow_up--due_date_config--days))
-- `incident_timestamp_id` (String) Timestamp the due date counts from
-
-Optional:
-
-- `applies_from` (String) If set, the policy only applies to resources from this timestamp onwards
-- `calculation_timezone` (String) Timezone the due date is calculated in. Only meaningful when calculation_type is weekdays.
-
-<a id="nestedatt--follow_up--due_date_config--days"></a>
-### Nested Schema for `follow_up.due_date_config.days`
-
-Optional:
-
-- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--follow_up--due_date_config--days--array_value))
-- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
-- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--follow_up--due_date_config--days--value))
-- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
-- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
-- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
-
-<a id="nestedatt--follow_up--due_date_config--days--array_value"></a>
-### Nested Schema for `follow_up.due_date_config.days.array_value`
-
-Optional:
-
-- `literal` (String) If set, this is the literal value of the step parameter
-- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
-
-
-<a id="nestedatt--follow_up--due_date_config--days--value"></a>
-### Nested Schema for `follow_up.due_date_config.days.value`
-
-Optional:
-
-- `literal` (String) If set, this is the literal value of the step parameter
-- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
-
-
-
-
 
 <a id="nestedatt--on_call_readiness"></a>
 ### Nested Schema for `on_call_readiness`
@@ -964,12 +964,58 @@ Optional:
 
 Required:
 
+- `due_date_config` (Attributes) (see [below for nested schema](#nestedatt--post_mortem--due_date_config))
 - `requirements` (Attributes List) Groups of prerequisite conditions. All conditions in at least one group must be satisfied (see [below for nested schema](#nestedatt--post_mortem--requirements))
 
 Optional:
 
-- `due_date_config` (Attributes) (see [below for nested schema](#nestedatt--post_mortem--due_date_config))
 - `run_on_private_incidents` (Boolean) Requires the policies.run_on_private scope
+
+<a id="nestedatt--post_mortem--due_date_config"></a>
+### Nested Schema for `post_mortem.due_date_config`
+
+Required:
+
+- `calculation_type` (String) Whether to count all days or only weekdays. Possible values are: `seven_days`, `weekdays`.
+- `days` (Attributes) (see [below for nested schema](#nestedatt--post_mortem--due_date_config--days))
+- `incident_timestamp_id` (String) Timestamp the due date counts from
+
+Optional:
+
+- `applies_from` (String) If set, the policy only applies to resources from this timestamp onwards
+- `calculation_timezone` (String) Timezone the due date is calculated in. Only meaningful when calculation_type is weekdays.
+
+<a id="nestedatt--post_mortem--due_date_config--days"></a>
+### Nested Schema for `post_mortem.due_date_config.days`
+
+Optional:
+
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--post_mortem--due_date_config--days--array_value))
+- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--post_mortem--due_date_config--days--value))
+- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
+- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
+- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
+
+<a id="nestedatt--post_mortem--due_date_config--days--array_value"></a>
+### Nested Schema for `post_mortem.due_date_config.days.array_value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--post_mortem--due_date_config--days--value"></a>
+### Nested Schema for `post_mortem.due_date_config.days.value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
 
 <a id="nestedatt--post_mortem--requirements"></a>
 ### Nested Schema for `post_mortem.requirements`
@@ -1016,52 +1062,6 @@ Optional:
 - `literal` (String) If set, this is the literal value of the step parameter
 - `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
 
-
-
-
-
-<a id="nestedatt--post_mortem--due_date_config"></a>
-### Nested Schema for `post_mortem.due_date_config`
-
-Required:
-
-- `calculation_type` (String) Whether to count all days or only weekdays. Possible values are: `seven_days`, `weekdays`.
-- `days` (Attributes) (see [below for nested schema](#nestedatt--post_mortem--due_date_config--days))
-- `incident_timestamp_id` (String) Timestamp the due date counts from
-
-Optional:
-
-- `applies_from` (String) If set, the policy only applies to resources from this timestamp onwards
-- `calculation_timezone` (String) Timezone the due date is calculated in. Only meaningful when calculation_type is weekdays.
-
-<a id="nestedatt--post_mortem--due_date_config--days"></a>
-### Nested Schema for `post_mortem.due_date_config.days`
-
-Optional:
-
-- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--post_mortem--due_date_config--days--array_value))
-- `expression_ref` (String) The name of an expression on this resource, whose result becomes the value. Shorthand for referencing `expressions["name"]`.
-- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--post_mortem--due_date_config--days--value))
-- `value_literal` (String) A fixed value, shorthand for `value = { literal = ... }`. A catalog entry ID is a literal, not a reference.
-- `value_reference` (String) A reference into the scope, shorthand for `value = { reference = ... }`.
-- `values` (List of String) Several fixed values, shorthand for an `array_value` of literals. For a mix of literals and references, use `array_value`.
-
-<a id="nestedatt--post_mortem--due_date_config--days--array_value"></a>
-### Nested Schema for `post_mortem.due_date_config.days.array_value`
-
-Optional:
-
-- `literal` (String) If set, this is the literal value of the step parameter
-- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
-
-
-<a id="nestedatt--post_mortem--due_date_config--days--value"></a>
-### Nested Schema for `post_mortem.due_date_config.days.value`
-
-Optional:
-
-- `literal` (String) If set, this is the literal value of the step parameter
-- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
 
 
 

--- a/examples/resources/incident_policy/resource-debriefs.tf
+++ b/examples/resources/incident_policy/resource-debriefs.tf
@@ -1,0 +1,57 @@
+data "incident_user" "debriefs_owner" {
+  email = "incident-manager@example.com"
+}
+
+data "incident_incident_timestamp" "debriefs_closed" {
+  name = "Closed at"
+}
+
+# A debrief policy: major incidents need a debrief booked in, not just promised.
+#
+# This one scopes itself with condition_groups rather than applying to every
+# incident, so only the incidents that warrant a debrief are held to it.
+resource "incident_policy" "debriefs" {
+  name        = "Debriefs booked for major incidents"
+  description = "Anything at major severity or above needs a debrief in the calendar."
+
+  condition_groups = [
+    {
+      conditions = [
+        {
+          subject   = "incident.severity"
+          operation = "gte"
+          # The ID of the severity to compare against, which is a literal rather
+          # than a reference.
+          param_bindings = [{ value_literal = "01FCNDV6P870EA6S7TK1DSYD5H" }]
+        }
+      ]
+    }
+  ]
+
+  assignment_rules = {
+    bindings                       = [{ value_literal = data.incident_user.debriefs_owner.id }]
+    reminder_due_date_offset_hours = [-24]
+  }
+
+  debrief = {
+    # `is_set` takes no parameters, so its bindings list is empty — but the key
+    # is still required.
+    requirements = [
+      {
+        conditions = [
+          {
+            subject        = "debrief.is_scheduled"
+            operation      = "is_set"
+            param_bindings = []
+          }
+        ]
+      }
+    ]
+
+    due_date_config = {
+      incident_timestamp_id = data.incident_incident_timestamp.debriefs_closed.id
+      days                  = { value_literal = "5" }
+      calculation_type      = "weekdays"
+    }
+  }
+}

--- a/examples/resources/incident_policy/resource-follow-ups.tf
+++ b/examples/resources/incident_policy/resource-follow-ups.tf
@@ -1,0 +1,49 @@
+# Who to chase when a follow-up is overdue.
+data "incident_user" "followups_owner" {
+  email = "engineering-manager@example.com"
+}
+
+data "incident_incident_timestamp" "followups_closed" {
+  name = "Closed at"
+}
+
+# A follow-up policy: the follow-ups left behind by an incident have to be dealt
+# with, rather than sitting open indefinitely.
+resource "incident_policy" "follow_ups" {
+  name        = "Follow-ups actioned within 30 days"
+  description = "Follow-ups from an incident shouldn't be left open once it closes."
+
+  # Empty, so the policy applies to every incident.
+  condition_groups = []
+
+  # Offsets are in whole days, so use multiples of 24 hours: a nudge the day
+  # before, and a chase the day after.
+  assignment_rules = {
+    bindings                       = [{ value_literal = data.incident_user.followups_owner.id }]
+    reminder_due_date_offset_hours = [-24, 24]
+  }
+
+  follow_up = {
+    # A follow-up is compliant once it's out of the open state — completed, or
+    # deliberately dropped.
+    requirements = [
+      {
+        conditions = [
+          {
+            subject        = "follow_up.status"
+            operation      = "not_one_of"
+            param_bindings = [{ values = ["open"] }]
+          }
+        ]
+      }
+    ]
+
+    # Required for follow-up, debrief and post-mortem policies: these types are
+    # the ones that carry a due date, and the API rejects an update without one.
+    due_date_config = {
+      incident_timestamp_id = data.incident_incident_timestamp.followups_closed.id
+      days                  = { value_literal = "30" }
+      calculation_type      = "seven_days"
+    }
+  }
+}

--- a/examples/resources/incident_policy/resource-schedule-coverage.tf
+++ b/examples/resources/incident_policy/resource-schedule-coverage.tf
@@ -1,0 +1,38 @@
+data "incident_user" "schedule_owner" {
+  email = "on-call-manager@example.com"
+}
+
+# A schedule policy, which finds gaps in on-call coverage.
+#
+# Unlike follow-up, debrief and post-mortem policies this one takes no
+# due_date_config: a coverage gap is a violation the moment it's spotted, so
+# there is no due date to count from. It's the one type that instead supports
+# reminders measured from when the gap was detected.
+resource "incident_policy" "schedule_coverage" {
+  name        = "On-call schedules have no gaps"
+  description = "Every rotation should have someone on call at all times."
+
+  # Empty, so the policy applies to every schedule.
+  condition_groups = []
+
+  assignment_rules = {
+    bindings = [{ value_literal = data.incident_user.schedule_owner.id }]
+
+    # No due date to measure from, so this stays empty and the reminders below
+    # do the work instead.
+    reminder_due_date_offset_hours = []
+
+    # Whole days from when the gap was found: straight away, then again after
+    # two days if it's still there.
+    reminder_detected_date_offset_hours = [0, 48]
+  }
+
+  schedule = {
+    # Check that cover is contiguous, with no uncovered stretches.
+    requirement_type = "contiguous"
+
+    # Judge each rotation separately rather than the schedule as a whole, so one
+    # rotation covering for another doesn't hide a gap. Defaults to "schedule".
+    evaluation_level = "rotation"
+  }
+}

--- a/internal/provider/policy_resource.go
+++ b/internal/provider/policy_resource.go
@@ -315,9 +315,13 @@ func policyIncidentConfigAttribute(name, definition string) schema.SingleNestedA
 		PlanModifiers:       []planmodifier.Object{policyBlockRequiresReplace()},
 		Attributes: map[string]schema.Attribute{
 			"requirements": requirements,
+			// Required, because these are the three types that carry a due date and the
+			// API rejects an update to one without it. Leaving it optional let a config
+			// create a policy that then failed on its next apply, which is a worse place
+			// to find out.
 			"due_date_config": schema.SingleNestedAttribute{
 				MarkdownDescription: apischema.Docstring(definition, "due_date_config"),
-				Optional:            true,
+				Required:            true,
 				Attributes: map[string]schema.Attribute{
 					"incident_timestamp_id": schema.StringAttribute{
 						MarkdownDescription: apischema.Docstring("PolicyDueDateConfigV2", "incident_timestamp_id"),

--- a/internal/provider/policy_validate_test.go
+++ b/internal/provider/policy_validate_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/samber/lo"
@@ -278,5 +279,40 @@ func TestPolicyTypesWithForcedAssigneeAreRealTypes(t *testing.T) {
 		if !slices.Contains(fromAPI, policyType) {
 			t.Errorf("%q is not a policy type: %v", policyType, fromAPI)
 		}
+	}
+}
+
+// TestPolicyDueDateConfigRequired pins the rule for the three types that carry a due date.
+// The API rejects an update to one without a due_date_config, so a config that omits it
+// creates a policy and then fails on its next apply.
+func TestPolicyDueDateConfigRequired(t *testing.T) {
+	attributes := policySchema(t).Schema.Attributes
+
+	for _, block := range []string{"follow_up", "debrief", "post_mortem"} {
+		t.Run(block, func(t *testing.T) {
+			nested, ok := attributes[block].(schema.SingleNestedAttribute)
+			if !ok {
+				t.Fatalf("%s is not a single nested attribute", block)
+			}
+
+			if !nested.Attributes["due_date_config"].IsRequired() {
+				t.Error("due_date_config is not required")
+			}
+		})
+	}
+
+	// The other three don't carry a due date at all, and the API rejects one. Their
+	// blocks have no due_date_config attribute to require.
+	for _, block := range []string{"schedule", "on_call_readiness", "vacation_conflict"} {
+		t.Run(block, func(t *testing.T) {
+			nested, ok := attributes[block].(schema.SingleNestedAttribute)
+			if !ok {
+				t.Fatalf("%s is not a single nested attribute", block)
+			}
+
+			if _, found := nested.Attributes["due_date_config"]; found {
+				t.Error("due_date_config should not exist on a type without a due date")
+			}
+		})
 	}
 }

--- a/templates/resources/policy.md.tmpl
+++ b/templates/resources/policy.md.tmpl
@@ -24,6 +24,18 @@ description: |-
 
 {{ tffile "examples/resources/incident_policy/resource-post-mortems.tf" }}
 
+## Example - Action follow-ups within 30 days
+
+{{ tffile "examples/resources/incident_policy/resource-follow-ups.tf" }}
+
+## Example - Book a debrief for major incidents
+
+{{ tffile "examples/resources/incident_policy/resource-debriefs.tf" }}
+
+## Example - Find gaps in on-call coverage
+
+{{ tffile "examples/resources/incident_policy/resource-schedule-coverage.tf" }}
+
 ## Example - Check that on-call responders can be reached
 
 {{ tffile "examples/resources/incident_policy/resource-on-call-readiness.tf" }}


### PR DESCRIPTION
Three of the six policy types had no example. The three missing ones are also the ones with rules a config can't guess, and writing them turned up a gap in the schema.

`due_date_config` is now required on `follow_up`, `debrief` and `post_mortem`. The API rejects an update to one of those without it but accepts a create, so a config that omitted it applied once and then failed on its next apply. `schedule`, `on_call_readiness` and `vacation_conflict` don't take one at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Schema change can break existing Terraform configs that omitted `due_date_config` on follow-up, debrief, or post-mortem policies until they add the block; behavior aligns with API constraints rather than changing runtime logic.
> 
> **Overview**
> **`due_date_config` is now required** on `incident_policy` blocks `follow_up`, `debrief`, and `post_mortem`, matching API behavior where updates without it fail even though create could succeed. Plans that omit it fail early instead of breaking on the next apply.
> 
> **Documentation** adds Terraform examples for the three previously undocumented policy types (follow-ups, debriefs, schedule coverage), wired through the policy docs template and reflected in generated schema docs (`due_date_config` listed under Required for those nested blocks).
> 
> **Tests** add `TestPolicyDueDateConfigRequired` to assert required vs absent `due_date_config` across all six policy blocks. **CHANGELOG** documents the unreleased breaking schema tightening and migration note for configs that omitted `due_date_config`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 872047adf3862ed71885461bbb0929574f02fc05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->