### PR TITLE
Increase acceptance test timeout to 20 minutes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,7 @@ jobs:
     name: Acceptance Tests (${{ matrix.cli }} ${{ matrix.version }})
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     # Keyed by CLI so the legs run alongside each other, while the same leg still
     # queues across runs. Test resources are named per run, so concurrent runs no
     # longer collide on names.
@@ -130,4 +130,4 @@ jobs:
       - env:
           INCIDENT_API_KEY: ${{ secrets.INCIDENT_API_KEY }}
         run: make testacc
-        timeout-minutes: 10
+        timeout-minutes: 20


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Acceptance tests on #543 are failing because `make testacc` hits the 10-minute step timeout (`The action 'Run make testacc' has timed out after 10 minutes`).

This raises:
- the `make testacc` step timeout from 10 to **20 minutes**
- the Acceptance Tests job timeout from 15 to **25 minutes**, so checkout/setup overhead does not cancel the step first

Once this lands, #543 can rebase and the suite should have enough time to finish.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7223d92-ac0f-4e8f-9b81-c79712af49ab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7223d92-ac0f-4e8f-9b81-c79712af49ab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

