### PR TITLE
Fix the API key team pairing test's expected error

### DIFF
--- a/internal/provider/incident_api_key_resource_test.go
+++ b/internal/provider/incident_api_key_resource_test.go
@@ -181,6 +181,11 @@ func TestAccIncidentAPIKeyResourceTeamScoped(t *testing.T) {
 // TestAccIncidentAPIKeyResourceTeamPairing checks the plan-time errors for team scoping,
 // which the API requires to be set as a pair: teams with no roles to grant for them, or
 // roles with no teams to grant them for, are both rejected before an apply is attempted.
+//
+// The patterns match against Terraform's rendered diagnostic, which it hard-wraps, so any
+// space in an expected phrase may be a line break by the time ExpectError sees it. Hence
+// `\s+` rather than a literal space: without it a pattern matches or not depending on
+// where the wrap happens to fall.
 func TestAccIncidentAPIKeyResourceTeamPairing(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -193,7 +198,7 @@ resource "incident_api_key" "test" {
   team_ids = ["01G0J1EXE7AXZ2C93K61WBPYEH"]
 }
 `, nil),
-				ExpectError: regexp.MustCompile(`needs at least one team role`),
+				ExpectError: regexp.MustCompile(`needs at least one\s+team role`),
 			},
 			{
 				Config: testRunTemplate("incident_api_key_team_roles_only", `
@@ -202,7 +207,7 @@ resource "incident_api_key" "test" {
   team_role_names = ["schedules_editor"]
 }
 `, nil),
-				ExpectError: regexp.MustCompile(`it needs team_ids saying which`),
+				ExpectError: regexp.MustCompile(`it needs team_ids\s+saying which`),
 			},
 		},
 	})


### PR DESCRIPTION
`TestAccIncidentAPIKeyResourceTeamPairing` fails on every run, so master's acceptance jobs are red.

The expected pattern is word-for-word what the validator produces — but `ExpectError` matches against Terraform's *rendered* diagnostic, and Terraform hard-wraps it. The wrap lands inside the phrase:

```
team_role_names grants roles for particular teams, so it needs team_ids
saying which. Set team_ids, or move the roles to role_names to grant them
```

so `it needs team_ids saying which` can never match: there's a newline where its space is. Both patterns now allow a line break where they expect a space. The first one passes today only because of where the wrap happens to fall, so it gets the same treatment.

Reproduced locally in both directions: the literal space fails, `\s+` passes. No provider or behaviour change, so no changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only regex and comment updates; no runtime or API behavior is affected.
> 
> **Overview**
> Fixes **`TestAccIncidentAPIKeyResourceTeamPairing`**, which was failing because `ExpectError` matches Terraform’s **rendered** diagnostics, where hard-wrapping can insert a newline inside phrases that the test expected as a single space.
> 
> Both expected regexes now use **`\s+`** between words that might be split by wrapping (`needs at least one\s+team role` and `it needs team_ids\s+saying which`). A short comment above the test documents that behavior. **No provider or validation logic changes**—acceptance tests only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3188cb0fc93ae71b77d2acbdc5cbaef8cfbe64a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->