### PR TITLE
Claim API keys and secrets for Terraform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- `incident_api_key` and `incident_secret` now claim the key or secret they manage, the way every other managed resource does. Neither did before, so a key or secret Terraform created still looked dashboard-managed: the dashboard offered to edit it, and the next apply put its own configuration back over the change. Both now send the `incident.io/terraform/version` annotation, so the dashboard shows the resource as synced, refuses to edit it, and offers to disconnect one you want to hand back. The claim happens on create, on update, and on import - the last subject to `mark_imported_resources_as_managed`, like every other resource. It needs a version of incident.io that knows `api_key` and `secret` as managed-resource types; against an older one the claim is rejected and the apply reports it.
+
 ## v6.12.0
 
 - Add `rank` to `incident_status`, which says where a status sits within its category, lowest rank first. Statuses could not express their order before: each landed after the last one created, so several in a single apply raced for the same rank and the apply failed with `Can't have more than one status with the same rank`. Ranks must be unique within a category but needn't be consecutive, so leaving gaps (10, 20, 30) means a status can be inserted between two others later without renumbering them. The attribute is optional and not computed, so a config that leaves it out doesn't manage the order and a reorder made in the dashboard survives the next apply.

--- a/internal/provider/incident_api_key_resource.go
+++ b/internal/provider/incident_api_key_resource.go
@@ -376,6 +376,9 @@ func (r *IncidentAPIKeyResource) Create(ctx context.Context, req resource.Create
 		return
 	}
 
+	claimResource(ctx, r.client, result.JSON201.ApiKey.Id, &resp.Diagnostics,
+		client.ManagedResourcesCreateManagedResourcePayloadV2ResourceTypeApiKey, r.terraformVersion)
+
 	tflog.Trace(ctx, fmt.Sprintf("created an API key with id=%s", result.JSON201.ApiKey.Id))
 
 	// This response carries the only copy of the token there will ever be.
@@ -451,6 +454,9 @@ func (r *IncidentAPIKeyResource) Update(ctx context.Context, req resource.Update
 		return
 	}
 
+	claimResource(ctx, r.client, result.JSON200.ApiKey.Id, &resp.Diagnostics,
+		client.ManagedResourcesCreateManagedResourcePayloadV2ResourceTypeApiKey, r.terraformVersion)
+
 	var (
 		key   = result.JSON200.ApiKey
 		token = state.Token
@@ -501,6 +507,10 @@ func (r *IncidentAPIKeyResource) Delete(ctx context.Context, req resource.Delete
 }
 
 func (r *IncidentAPIKeyResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	claimResourceOnImport(ctx, r.client, req.ID, &resp.Diagnostics,
+		client.ManagedResourcesCreateManagedResourcePayloadV2ResourceTypeApiKey, r.terraformVersion,
+		r.markImportedAsManaged)
+
 	result, err := r.client.APIKeysV1ShowWithResponse(ctx, req.ID)
 	if err != nil {
 		httpErr := client.HTTPError{}

--- a/internal/provider/incident_secret_resource.go
+++ b/internal/provider/incident_secret_resource.go
@@ -217,6 +217,9 @@ func (r *IncidentSecretResource) Create(ctx context.Context, req resource.Create
 		return
 	}
 
+	claimResource(ctx, r.client, result.JSON201.Secret.Id, &resp.Diagnostics,
+		client.ManagedResourcesCreateManagedResourcePayloadV2ResourceTypeSecret, r.terraformVersion)
+
 	tflog.Trace(ctx, fmt.Sprintf("created a secret with id=%s", result.JSON201.Secret.Id))
 
 	state := models.SecretModel{}.FromAPI(result.JSON201.Secret, data.ValueWOVersion)
@@ -274,6 +277,9 @@ func (r *IncidentSecretResource) Update(ctx context.Context, req resource.Update
 		return
 	}
 
+	claimResource(ctx, r.client, secret.Id, &resp.Diagnostics,
+		client.ManagedResourcesCreateManagedResourcePayloadV2ResourceTypeSecret, r.terraformVersion)
+
 	// The value itself is invisible to Terraform, so a change to value_wo_version is the
 	// only thing that can ask for a rotation. Dropping it is not such a change: a config
 	// that removes both value attributes is handing the value back rather than asking for
@@ -324,6 +330,10 @@ func (r *IncidentSecretResource) Delete(ctx context.Context, req resource.Delete
 }
 
 func (r *IncidentSecretResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	claimResourceOnImport(ctx, r.client, req.ID, &resp.Diagnostics,
+		client.ManagedResourcesCreateManagedResourcePayloadV2ResourceTypeSecret, r.terraformVersion,
+		r.markImportedAsManaged)
+
 	result, err := r.client.SecretsV2ShowWithResponse(ctx, req.ID)
 	if err != nil {
 		httpErr := client.HTTPError{}

--- a/internal/provider/managed_resources_test.go
+++ b/internal/provider/managed_resources_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/provider"
@@ -139,6 +140,89 @@ func TestProviderMarkImportedResourcesAsManaged(t *testing.T) {
 
 			if data.MarkImportedAsManaged != tc.want {
 				t.Errorf("MarkImportedAsManaged = %v, want %v", data.MarkImportedAsManaged, tc.want)
+			}
+		})
+	}
+}
+
+// TestImportStateClaimsCorrectResourceType pins the resource type each resource claims
+// itself as. The plumbing is shared, so the realistic bug is a resource passing the wrong
+// constant, which no other test would catch.
+//
+// The fake serves only the claim endpoint, so each import claims and then fails to read
+// the resource back. The claim happens before the read, so it is recorded either way.
+func TestImportStateClaimsCorrectResourceType(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		newResource      func() resource.Resource
+		importID         string
+		wantResourceType string
+		wantErrSummary   string
+	}{
+		{
+			name:             "api key",
+			newResource:      NewIncidentAPIKeyResource,
+			importID:         "01APIKEY",
+			wantResourceType: `"resource_type":"api_key"`,
+			wantErrSummary:   "API Key Not Found",
+		},
+		{
+			name:             "secret",
+			newResource:      NewIncidentSecretResource,
+			importID:         "01SECRET",
+			wantResourceType: `"resource_type":"secret"`,
+			wantErrSummary:   "Secret Not Found",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := t.Context()
+			api := &fakeManagedResourcesAPI{}
+
+			r := tc.newResource()
+			configurable, ok := r.(resource.ResourceWithConfigure)
+			if !ok {
+				t.Fatalf("%T does not implement ResourceWithConfigure", r)
+			}
+			configureResp := &resource.ConfigureResponse{}
+			configurable.Configure(ctx, resource.ConfigureRequest{
+				ProviderData: &IncidentProviderData{
+					Client:                api.start(t),
+					TerraformVersion:      "1.14.0",
+					MarkImportedAsManaged: true,
+				},
+			}, configureResp)
+			if configureResp.Diagnostics.HasError() {
+				t.Fatalf("configuring resource: %v", configureResp.Diagnostics)
+			}
+
+			importable, ok := r.(resource.ResourceWithImportState)
+			if !ok {
+				t.Fatalf("%T does not implement ResourceWithImportState", r)
+			}
+
+			schemaResp := &resource.SchemaResponse{}
+			r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+
+			importResp := &resource.ImportStateResponse{
+				State: tfsdk.State{
+					Schema: schemaResp.Schema,
+					Raw:    tftypes.NewValue(schemaResp.Schema.Type().TerraformType(ctx), nil),
+				},
+			}
+			importable.ImportState(ctx, resource.ImportStateRequest{ID: tc.importID}, importResp)
+
+			if api.requests != 1 {
+				t.Fatalf("managed resource requests = %d, want 1", api.requests)
+			}
+			if got := string(api.received); !strings.Contains(got, tc.wantResourceType) {
+				t.Errorf("claim payload = %s, want it to contain %s", got, tc.wantResourceType)
+			}
+			errs := importResp.Diagnostics.Errors()
+			if len(errs) == 0 {
+				t.Fatalf("expected the import to fail against a fake that serves no %s", tc.name)
+			}
+			if summary := errs[0].Summary(); !strings.Contains(summary, tc.wantErrSummary) {
+				t.Errorf("diagnostic summary = %q, want it to mention %q", summary, tc.wantErrSummary)
 			}
 		})
 	}


### PR DESCRIPTION
**Stacked on #567** (the schema and client refresh), which it needs for the two new managed-resource-type constants. Review and merge that one first — this PR's diff is just the claim change.

Provider half of incident-io/core#73187, which added `api_key` and `secret` as managed-resource types.

## What this fixes

`incident_api_key` and `incident_secret` never claimed the resource they manage, so a key or secret Terraform created still looked dashboard-managed: the dashboard offered to edit it, and the next apply put its own configuration back over the change.

Both now claim the way every other managed resource does — on create, on update, and on import subject to `mark_imported_resources_as_managed`. With core#73187 deployed, the dashboard shows them as synced, refuses to edit them, and offers to disconnect one you want to hand back.

Two details worth a look in review:

- **The update claims off the update response**, before the rotation that may follow, so a failed rotation still leaves the resource claimed.
- **The new test pins which resource type each resource claims itself as.** The plumbing is shared and already covered by `TestImportStateMarkImportedAsManaged`, so the bug worth catching is a resource passing the wrong constant — which would badge the wrong thing, or nothing. I checked the test fails when the constant is wrong before keeping it.

## Ordering

Needs core#73187 deployed. Against an older API the claim is rejected and the apply reports it, so this shouldn't be released before that has shipped.

## Testing

- `make test` — green (the new subtests are in `internal/provider`)
- `go build ./...`, `go vet ./internal/...`, `gofmt -l internal/` — clean
- `make generate` — no docs diff
- Acceptance tests not run; they need API credentials and hit a real account

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes managed-resource claiming for API keys and secrets (credential resources) and depends on a matching incident.io release; applies fail if the API does not accept the new resource types.
> 
> **Overview**
> **`incident_api_key` and `incident_secret` now register as Terraform-managed resources** on create, update, and import (imports still respect `mark_imported_resources_as_managed`), matching other resources in the provider.
> 
> Claims go through the existing `claimResource` / `claimResourceOnImport` helpers with `api_key` and `secret` managed-resource types and the `incident.io/terraform/version` annotation, so the dashboard should show them as synced and block edits that would fight the next apply. **Updates claim immediately after a successful metadata update** (before optional token/value rotation), so a failed rotation still leaves the resource claimed.
> 
> The unreleased **CHANGELOG** entry documents the behavior and notes that **incident.io must support these managed-resource types**; older APIs reject the claim and the apply fails.
> 
> **`TestImportStateClaimsCorrectResourceType`** asserts import claims send `"resource_type":"api_key"` or `"secret"` so a wrong constant cannot slip through shared plumbing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf329c57b611906998139f6bc242cb428d96dad5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->