### PR TITLE
Apply the beta schedule and escalation path resources in tests

### DIFF
--- a/internal/provider/escalation_path_beta_acceptance_test.go
+++ b/internal/provider/escalation_path_beta_acceptance_test.go
@@ -1,0 +1,224 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+)
+
+// TestAccEscalationPathBeta covers an escalation path written as sequences,
+// against the API: create, read back unchanged, import, and update.
+//
+// This resource had no acceptance test before now, and it is the shape v7 makes
+// the only one. What it exercises is what the flat shape brought and the nested
+// one couldn't: a branch naming the sequences to continue down, and a loop
+// naming the node to go back to. Both are converted to and from the API's nested
+// path on every read and write, which is the part most worth applying for real.
+func TestAccEscalationPathBeta(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEscalationPathBetaConfig(),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("incident_escalation_path_beta.test", "name", StableSuffix("acc-escalation-path")),
+					resource.TestCheckResourceAttr("incident_escalation_path_beta.test", "start", "main"),
+					resource.TestCheckResourceAttr("incident_escalation_path_beta.test", "sequences.%", "3"),
+					resource.TestCheckResourceAttr("incident_escalation_path_beta.test", "sequences.main.nodes.#", "1"),
+					resource.TestCheckResourceAttr("incident_escalation_path_beta.test", "sequences.main.nodes.0.branch.if.working_hours_active", "UK"),
+					resource.TestCheckResourceAttr("incident_escalation_path_beta.test", "sequences.main.nodes.0.branch.then", "in_hours"),
+					resource.TestCheckResourceAttr("incident_escalation_path_beta.test", "sequences.main.nodes.0.branch.else", "out_of_hours"),
+					resource.TestCheckResourceAttr("incident_escalation_path_beta.test", "sequences.in_hours.nodes.1.loop.back_to", "start"),
+					resource.TestCheckResourceAttr("incident_escalation_path_beta.test", "sequences.in_hours.nodes.1.loop.times", "2"),
+					resource.TestCheckResourceAttrSet("incident_escalation_path_beta.test", "id"),
+				),
+			},
+			// The sequence names are ours to choose, and the API stores a nested
+			// path that doesn't carry them: a read keeps the names already in
+			// state, and an import has no state to keep them from, so the names
+			// it comes back with are derived. Everything else has to round-trip.
+			{
+				ResourceName:            "incident_escalation_path_beta.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"start", "sequences"},
+			},
+			// Dropping the loop and slowing the acknowledgement window: an
+			// update that rewrites the path rather than adding to it, which is
+			// where a conversion bug in either direction would show.
+			{
+				Config: testAccEscalationPathBetaConfigWithoutLoop(),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("incident_escalation_path_beta.test", "sequences.in_hours.nodes.#", "1"),
+					resource.TestCheckResourceAttr("incident_escalation_path_beta.test", "sequences.in_hours.nodes.0.level.time_to_ack_seconds", "600"),
+				),
+			},
+		},
+	})
+}
+
+// The schedule the path pages. A target needs no schedule_mode unless it names a
+// rotation, so this is the simplest thing an escalation can point at.
+const escalationPathBetaAcceptanceTarget = `
+resource "incident_schedule_beta" "target" {
+  name     = {{ stableSuffix "acc-path-schedule" | quote }}
+  timezone = "Europe/London"
+}
+`
+
+func testAccEscalationPathBetaConfig() string {
+	return testRunTemplate("escalation_path_beta_acc", escalationPathBetaAcceptanceTarget+`
+resource "incident_escalation_path_beta" "test" {
+  name  = {{ stableSuffix "acc-escalation-path" | quote }}
+  start = "main"
+
+  sequences = {
+    main = {
+      nodes = [
+        {
+          # Named so the loop below can point back here.
+          id = "start"
+          branch = {
+            if = {
+              working_hours_active = "UK"
+            }
+            then = "in_hours"
+            else = "out_of_hours"
+          }
+        }
+      ]
+    }
+
+    in_hours = {
+      nodes = [
+        {
+          level = {
+            targets = [{
+              type    = "schedule"
+              id      = incident_schedule_beta.target.id
+              urgency = "high"
+            }]
+            time_to_ack_seconds = 300
+          }
+        },
+        {
+          loop = {
+            back_to = "start"
+            times   = 2
+          }
+        }
+      ]
+    }
+
+    out_of_hours = {
+      nodes = [
+        {
+          level = {
+            targets = [{
+              type    = "schedule"
+              id      = incident_schedule_beta.target.id
+              urgency = "low"
+            }]
+            time_to_ack_seconds = 300
+          }
+        }
+      ]
+    }
+  }
+
+  working_hours = [
+    {
+      id       = "UK"
+      name     = "UK"
+      timezone = "Europe/London"
+      weekday_intervals = [
+        {
+          weekday    = "monday"
+          start_time = "09:00"
+          end_time   = "17:00"
+        }
+      ]
+    }
+  ]
+}
+`, nil)
+}
+
+func testAccEscalationPathBetaConfigWithoutLoop() string {
+	return testRunTemplate("escalation_path_beta_acc_no_loop", escalationPathBetaAcceptanceTarget+`
+resource "incident_escalation_path_beta" "test" {
+  name  = {{ stableSuffix "acc-escalation-path" | quote }}
+  start = "main"
+
+  sequences = {
+    main = {
+      nodes = [
+        {
+          id = "start"
+          branch = {
+            if = {
+              working_hours_active = "UK"
+            }
+            then = "in_hours"
+            else = "out_of_hours"
+          }
+        }
+      ]
+    }
+
+    in_hours = {
+      nodes = [
+        {
+          level = {
+            targets = [{
+              type    = "schedule"
+              id      = incident_schedule_beta.target.id
+              urgency = "high"
+            }]
+            time_to_ack_seconds = 600
+          }
+        }
+      ]
+    }
+
+    out_of_hours = {
+      nodes = [
+        {
+          level = {
+            targets = [{
+              type    = "schedule"
+              id      = incident_schedule_beta.target.id
+              urgency = "low"
+            }]
+            time_to_ack_seconds = 300
+          }
+        }
+      ]
+    }
+  }
+
+  working_hours = [
+    {
+      id       = "UK"
+      name     = "UK"
+      timezone = "Europe/London"
+      weekday_intervals = [
+        {
+          weekday    = "monday"
+          start_time = "09:00"
+          end_time   = "17:00"
+        }
+      ]
+    }
+  ]
+}
+`, nil)
+}

--- a/internal/provider/escalation_path_beta_acceptance_test.go
+++ b/internal/provider/escalation_path_beta_acceptance_test.go
@@ -80,6 +80,11 @@ resource "incident_escalation_path_beta" "test" {
   name  = {{ stableSuffix "acc-escalation-path" | quote }}
   start = "main"
 
+  # The test account has an escalation paths attribute on its Teams, which makes
+  # team_ids required: the API rejects a path that omits it, and an empty list is
+  # how a path says it belongs to no team.
+  team_ids = []
+
   sequences = {
     main = {
       nodes = [
@@ -157,6 +162,8 @@ func testAccEscalationPathBetaConfigWithoutLoop() string {
 resource "incident_escalation_path_beta" "test" {
   name  = {{ stableSuffix "acc-escalation-path" | quote }}
   start = "main"
+
+  team_ids = []
 
   sequences = {
     main = {

--- a/internal/provider/incident_schedule_beta_acceptance_test.go
+++ b/internal/provider/incident_schedule_beta_acceptance_test.go
@@ -1,0 +1,98 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+)
+
+// TestAccIncidentScheduleBeta covers the lifecycle of a schedule on its own:
+// create, read back unchanged, import, and update.
+//
+// Nothing had applied this resource against the API before now - its other
+// tests all work on the model and the schema - and v7 makes it the only way to
+// manage a schedule. The empty-plan check after each apply is the part that
+// earns its keep: it catches a field the API returns in a shape the resource
+// can't store, which is how every "provider produced inconsistent result" bug
+// on this resource's neighbours has started.
+func TestAccIncidentScheduleBeta(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIncidentScheduleBetaConfig("acc-schedule", `["GB"]`),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("incident_schedule_beta.test", "name", StableSuffix("acc-schedule")),
+					resource.TestCheckResourceAttr("incident_schedule_beta.test", "timezone", "Europe/London"),
+					resource.TestCheckResourceAttr("incident_schedule_beta.test", "holidays_public_config.country_codes.#", "1"),
+					resource.TestCheckResourceAttr("incident_schedule_beta.test", "holidays_public_config.country_codes.0", "GB"),
+					resource.TestCheckResourceAttrSet("incident_schedule_beta.test", "id"),
+				),
+			},
+			{
+				ResourceName:      "incident_schedule_beta.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccIncidentScheduleBetaConfig("acc-schedule-renamed", `["GB", "FR"]`),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("incident_schedule_beta.test", "name", StableSuffix("acc-schedule-renamed")),
+					resource.TestCheckResourceAttr("incident_schedule_beta.test", "holidays_public_config.country_codes.#", "2"),
+				),
+			},
+			// Omitting the block is how a schedule says it shows no public
+			// holidays, so removing it has to clear the two set above rather
+			// than leave them in place.
+			{
+				Config: testAccIncidentScheduleBetaWithoutHolidays("acc-schedule-renamed"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("incident_schedule_beta.test", "holidays_public_config.country_codes.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccIncidentScheduleBetaConfig(name, countryCodes string) string {
+	return testRunTemplate("incident_schedule_beta_acc", `
+resource "incident_schedule_beta" "test" {
+  name     = {{ quote .Name }}
+  timezone = "Europe/London"
+
+  holidays_public_config = {
+    country_codes = {{ .CountryCodes }}
+  }
+}
+`, struct {
+		Name         string
+		CountryCodes string
+	}{
+		Name:         StableSuffix(name),
+		CountryCodes: countryCodes,
+	})
+}
+
+func testAccIncidentScheduleBetaWithoutHolidays(name string) string {
+	return testRunTemplate("incident_schedule_beta_acc_no_holidays", `
+resource "incident_schedule_beta" "test" {
+  name     = {{ quote .Name }}
+  timezone = "Europe/London"
+}
+`, struct {
+		Name string
+	}{
+		Name: StableSuffix(name),
+	})
+}

--- a/internal/provider/incident_schedule_rotation_beta_acceptance_test.go
+++ b/internal/provider/incident_schedule_rotation_beta_acceptance_test.go
@@ -46,11 +46,17 @@ func TestAccIncidentScheduleRotationBeta(t *testing.T) {
 			},
 			// A rotation is nested under its schedule in the API, so it imports
 			// by both IDs rather than by its own.
+			//
+			// rank is Optional and not Computed, so it is only tracked when the
+			// config asks for it, and an import has no config to ask: the
+			// rotation comes back unordered rather than adopting the position it
+			// happens to hold, which is the point of not computing it.
 			{
-				ResourceName:      "incident_schedule_rotation_beta.test",
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateIdFunc: importScheduleRotationBetaStateIDFunc("incident_schedule_rotation_beta.test"),
+				ResourceName:            "incident_schedule_rotation_beta.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"rank"},
+				ImportStateIdFunc:       importScheduleRotationBetaStateIDFunc("incident_schedule_rotation_beta.test"),
 			},
 			// The controls the inline shape had no way to express: two people on
 			// call at once, restricted to weekday working hours, allocated in a

--- a/internal/provider/incident_schedule_rotation_beta_acceptance_test.go
+++ b/internal/provider/incident_schedule_rotation_beta_acceptance_test.go
@@ -1,0 +1,154 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+// TestAccIncidentScheduleRotationBeta covers a rotation's lifecycle against the
+// API: create, read back unchanged, import by its compound ID, and update.
+//
+// The rotation is the resource that made splitting schedules worth doing, and
+// the controls it brought - concurrent_shifts, working_intervals, rank,
+// scheduling_mode - are the ones the inline shape had no way to express, so they
+// are what this exercises. Like the schedule, it had no acceptance test before
+// now.
+//
+// The line-up is the NOBODY sentinel throughout: it needs no account-specific
+// user IDs, and a rotation nobody is in still schedules its shifts.
+func TestAccIncidentScheduleRotationBeta(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIncidentScheduleRotationBetaConfig(),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("incident_schedule_rotation_beta.test", "name", "Primary"),
+					resource.TestCheckResourceAttr("incident_schedule_rotation_beta.test", "users.#", "1"),
+					resource.TestCheckResourceAttr("incident_schedule_rotation_beta.test", "users.0", "NOBODY"),
+					resource.TestCheckResourceAttr("incident_schedule_rotation_beta.test", "handovers.#", "1"),
+					resource.TestCheckResourceAttr("incident_schedule_rotation_beta.test", "handovers.0.interval_type", "weekly"),
+					resource.TestCheckResourceAttr("incident_schedule_rotation_beta.test", "rank", "1"),
+					resource.TestCheckResourceAttrPair(
+						"incident_schedule_rotation_beta.test", "schedule_id",
+						"incident_schedule_beta.test", "id",
+					),
+					resource.TestCheckResourceAttrSet("incident_schedule_rotation_beta.test", "id"),
+				),
+			},
+			// A rotation is nested under its schedule in the API, so it imports
+			// by both IDs rather than by its own.
+			{
+				ResourceName:      "incident_schedule_rotation_beta.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: importScheduleRotationBetaStateIDFunc("incident_schedule_rotation_beta.test"),
+			},
+			// The controls the inline shape had no way to express: two people on
+			// call at once, restricted to weekday working hours, allocated in a
+			// running order obvious to the people in it.
+			{
+				Config: testAccIncidentScheduleRotationBetaConfigWithWorkingIntervals(),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("incident_schedule_rotation_beta.test", "concurrent_shifts", "2"),
+					resource.TestCheckResourceAttr("incident_schedule_rotation_beta.test", "scheduling_mode", "sequential"),
+					resource.TestCheckResourceAttr("incident_schedule_rotation_beta.test", "working_intervals.#", "2"),
+					resource.TestCheckResourceAttr("incident_schedule_rotation_beta.test", "working_intervals.0.weekday", "monday"),
+					resource.TestCheckResourceAttr("incident_schedule_rotation_beta.test", "users.#", "3"),
+					resource.TestCheckResourceAttr("incident_schedule_rotation_beta.test", "handovers.0.interval_type", "daily"),
+				),
+			},
+			// Omitting working_intervals puts the rotation back on call around
+			// the clock, which an empty list is explicitly not a way to say.
+			{
+				Config: testAccIncidentScheduleRotationBetaConfig(),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("incident_schedule_rotation_beta.test", "working_intervals.#"),
+					resource.TestCheckResourceAttr("incident_schedule_rotation_beta.test", "users.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+// importScheduleRotationBetaStateIDFunc builds the <schedule_id>:<rotation_id>
+// an import takes, out of the state the previous step left.
+func importScheduleRotationBetaStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("%s is not in state", resourceName)
+		}
+
+		return rs.Primary.Attributes["schedule_id"] + ":" + rs.Primary.Attributes["id"], nil
+	}
+}
+
+const scheduleRotationBetaAcceptanceSchedule = `
+resource "incident_schedule_beta" "test" {
+  name     = {{ stableSuffix "acc-rotation-schedule" | quote }}
+  timezone = "Europe/London"
+}
+`
+
+// rank is set rather than left out so that the configuration and what the API
+// reports agree: it is Optional and not Computed, so a rotation that has never
+// been ordered reads back unset, and the two only match if the config says
+// which it is.
+func testAccIncidentScheduleRotationBetaConfig() string {
+	return testRunTemplate("incident_schedule_rotation_beta_acc", scheduleRotationBetaAcceptanceSchedule+`
+resource "incident_schedule_rotation_beta" "test" {
+  schedule_id = incident_schedule_beta.test.id
+  name        = "Primary"
+  rank        = 1
+
+  users = ["NOBODY"]
+
+  first_interval_starts_at = "2024-01-08T09:00:00Z"
+  handovers = [{
+    interval      = 1
+    interval_type = "weekly"
+  }]
+}
+`, nil)
+}
+
+func testAccIncidentScheduleRotationBetaConfigWithWorkingIntervals() string {
+	return testRunTemplate("incident_schedule_rotation_beta_acc_intervals", scheduleRotationBetaAcceptanceSchedule+`
+resource "incident_schedule_rotation_beta" "test" {
+  schedule_id = incident_schedule_beta.test.id
+  name        = "Primary"
+  rank        = 1
+
+  users = ["NOBODY", "NOBODY", "NOBODY"]
+
+  first_interval_starts_at = "2024-01-08T09:00:00Z"
+  handovers = [{
+    interval      = 1
+    interval_type = "daily"
+  }]
+
+  concurrent_shifts = 2
+  scheduling_mode   = "sequential"
+
+  working_intervals = [
+    { weekday = "monday", start_time = "09:00", end_time = "17:00" },
+    { weekday = "tuesday", start_time = "09:00", end_time = "17:00" },
+  ]
+}
+`, nil)
+}


### PR DESCRIPTION
`incident_schedule_beta`, `incident_schedule_rotation_beta` and `incident_escalation_path_beta` had no acceptance tests. Their existing tests all work on the model and the schema, so nothing had ever created, updated, imported or deleted one against the API — and the plan is for these to become the only way to manage schedules and escalation paths.

Each test runs the same shape: create, import, update, with an `ExpectEmptyPlan` check after every apply. That last check is what earns its keep here: every "provider produced inconsistent result" bug on these resources' neighbours has come from a field the API returns in a shape the resource can't store, and it only shows up on a real apply.

What each covers beyond the basics:

- **Schedule** — clearing public holidays by removing the block, which is the only way to say a schedule shows none.
- **Rotation** — the controls the inline shape couldn't express (`concurrent_shifts`, `working_intervals`, `scheduling_mode`, `rank`), and import by the `<schedule_id>:<rotation_id>` it is identified by.
- **Escalation path** — a `branch` naming the sequences to continue down and a `loop` naming the node to go back to, both of which convert to and from the API's nested path on every read and write.

## Two positions the tests take

Rotations are staffed with the `NOBODY` sentinel, so no account-specific user IDs are needed. And `rank` is set explicitly rather than left out, because it is Optional and not Computed: a rotation that has never been ordered reads back unset, so config and API only agree if the config says which it is.

The escalation path's import ignores `start` and `sequences`. Sequence names are ours to choose and the API stores a nested path that doesn't carry them, so a read keeps the names already in state and an import, having no state to keep them from, derives its own. Everything else round-trips and is verified. That limitation is worth documenting for anyone importing a path.

## Worth knowing when reviewing

**I have not run these.** There's no API key in my environment, so CI is the first real execution. I'd expect a round of fixes rather than green first time — the likeliest candidates are `NOBODY` as a rotation's whole line-up, `rank` on import, and whether the escalation path import needs more than `start` and `sequences` ignored. If any of those fail, the failure is this PR's assumption rather than the resource.

These add three tests of four steps each, run per CLI leg. `make testacc` already runs with `-timeout 18m` inside a 20 minute step, so if the suite starts brushing that limit, this is part of why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only additions with no runtime provider behavior changes; main impact is longer CI acceptance runs and possible first-time API assumption failures.
> 
> **Overview**
> Adds **acceptance tests** for `incident_schedule_beta`, `incident_schedule_rotation_beta`, and `incident_escalation_path_beta` so those resources are exercised against the live API (create, import, update) for the first time.
> 
> Each test follows the existing provider pattern: multi-step `resource.Test` flows with **`ExpectEmptyPlan` after every apply** to catch API/state drift. Coverage highlights include schedule **public holidays cleared by omitting** `holidays_public_config`; rotation **compound import** (`schedule_id:rotation_id`), `NOBODY` users, and fields like `concurrent_shifts` / `working_intervals`; escalation path **branch/loop sequence shape** with import verify ignoring `start` and `sequences` (names are not round-tripped from the API).
> 
> No provider or schema code changes—only new `*_acceptance_test.go` files, which will extend `make testacc` runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c97849e07aee96a44549c330dc189cadb8e20d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->