### PR TITLE
Support moving state when a resource is renamed

### DIFF
--- a/internal/provider/state_mover.go
+++ b/internal/provider/state_mover.go
@@ -1,0 +1,91 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+)
+
+// renameStateMover moves state from a resource that has been renamed, where the
+// schema either side of the rename is the same one.
+//
+// Terraform asks the provider to move state whenever a `moved` block changes a
+// resource's type, because it cannot know whether the two schemas are
+// compatible - and getting that wrong loses somebody's state. A rename is the
+// case where they are identical, so the move is a copy: whatever the source
+// resource held is what the target should hold, and a `terraform plan` straight
+// afterwards reports no changes.
+//
+// The source type name is the name the resource used to go by, which is what a
+// practitioner writes in the `from` argument:
+//
+//	moved {
+//	  from = incident_schedule_beta.primary
+//	  to   = incident_schedule.primary
+//	}
+//
+// A mover that does not recognise the source returns no state and no
+// diagnostics, which the framework reads as "skipped": it tries the next mover
+// the resource offers, and if none of them take the move it reports an error
+// naming the source and target types. That is a better error than any we could
+// write here, so recognising the source is all this has to do.
+//
+// It is deliberately strict about the schema version. Writing state we do not
+// understand into the target resource is worse than refusing the move, because
+// a practitioner can undo a refusal.
+func renameStateMover(sourceTypeName string, sourceSchema schema.Schema) resource.StateMover {
+	return resource.StateMover{
+		// Setting this asks the framework to decode the source state for us, which for
+		// a rename it can always do, the schema being the target's own.
+		SourceSchema: &sourceSchema,
+		StateMover: func(ctx context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+			if req.SourceTypeName != sourceTypeName {
+				return // not a source we know: skip, and let the framework try the next mover
+			}
+
+			// Schemas are versioned separately from the provider, and this resource has
+			// only ever had the one version, so a source at another version is state we
+			// have never written and cannot vouch for.
+			if req.SourceSchemaVersion != sourceSchema.Version {
+				return
+			}
+
+			// The framework logs its decoding error at debug level and leaves this nil,
+			// so a nil here is the only sign we get that state we were meant to be able
+			// to read did not read. Refuse the move rather than write a partial value.
+			if req.SourceState == nil {
+				resp.Diagnostics.AddError(
+					"Unable to Move Resource State",
+					fmt.Sprintf(
+						"The state held by %s could not be read using the schema of the resource it is moving to, "+
+							"which is the same schema it was written with. This is always a problem with the "+
+							"provider: please report it to us, with the output of `terraform plan` run with "+
+							"TF_LOG=debug.\n\nSource resource type: %s\nSource schema version: %d",
+						sourceTypeName, req.SourceTypeName, req.SourceSchemaVersion,
+					),
+				)
+				return
+			}
+
+			resp.TargetState.Raw = req.SourceState.Raw
+
+			// Private state belongs to the resource rather than to the name it goes by,
+			// and a rename does not change what any of it means.
+			if req.SourcePrivate != nil {
+				resp.TargetPrivate = req.SourcePrivate
+			}
+		},
+	}
+}
+
+// declaredResourceSchema returns the schema a resource declares, for the places that
+// need it outside of the framework's own call to Schema - a state mover, which
+// has to describe the state it is moving from.
+func declaredResourceSchema(ctx context.Context, r resource.Resource) schema.Schema {
+	var resp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &resp)
+
+	return resp.Schema
+}

--- a/internal/provider/state_mover_test.go
+++ b/internal/provider/state_mover_test.go
@@ -1,0 +1,181 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// The schema either side of a rename is the same one, so these tests only need
+// a schema, not the resource it belongs to.
+func testRenameSchema() schema.Schema {
+	return schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id":   schema.StringAttribute{Computed: true},
+			"name": schema.StringAttribute{Required: true},
+		},
+	}
+}
+
+// testRenameState is the state a resource holds before the move.
+func testRenameState(ctx context.Context, t *testing.T, sourceSchema schema.Schema) tfsdk.State {
+	t.Helper()
+
+	return tfsdk.State{
+		Schema: sourceSchema,
+		Raw: tftypes.NewValue(sourceSchema.Type().TerraformType(ctx), map[string]tftypes.Value{
+			"id":   tftypes.NewValue(tftypes.String, "01SCHED"),
+			"name": tftypes.NewValue(tftypes.String, "Platform on-call"),
+		}),
+	}
+}
+
+// testMoveStateResponse is the response the framework hands a mover: the target
+// resource's schema, holding a null value until a mover sets one. The framework
+// reads a response still holding that null as the mover having skipped the
+// move, so these tests have to start from it to tell skipping apart from
+// moving.
+func testMoveStateResponse(ctx context.Context, targetSchema schema.Schema) resource.MoveStateResponse {
+	return resource.MoveStateResponse{
+		TargetState: tfsdk.State{
+			Schema: targetSchema,
+			Raw:    tftypes.NewValue(targetSchema.Type().TerraformType(ctx), nil),
+		},
+	}
+}
+
+// renamedInV7 is every rename v7 makes, which is what this mover exists for.
+// Each promotion wires up its own, so listing them here checks the mover
+// accepts each name before the resource that will claim it does.
+var renamedInV7 = map[string]string{
+	"incident_schedule_beta":               "incident_schedule",
+	"incident_schedule_rotation_beta":      "incident_schedule_rotation",
+	"incident_escalation_path_beta":        "incident_escalation_path",
+	"incident_alert_source_beta":           "incident_alert_source",
+	"incident_alert_source_attribute_beta": "incident_alert_source_attribute",
+}
+
+func TestRenameStateMover(t *testing.T) {
+	ctx := context.Background()
+	sourceSchema := testRenameSchema()
+	state := testRenameState(ctx, t, sourceSchema)
+
+	t.Run("moves the state of the name the resource used to go by", func(t *testing.T) {
+		for former, promoted := range renamedInV7 {
+			t.Run(former+" to "+promoted, func(t *testing.T) {
+				mover := renameStateMover(former, sourceSchema)
+				resp := testMoveStateResponse(ctx, sourceSchema)
+
+				mover.StateMover(ctx, resource.MoveStateRequest{
+					SourceTypeName: former,
+					SourceState:    &state,
+				}, &resp)
+
+				if resp.Diagnostics.HasError() {
+					t.Fatalf("expected the move to be accepted, got %+v", resp.Diagnostics)
+				}
+				if !resp.TargetState.Raw.Equal(state.Raw) {
+					t.Errorf("expected the target to hold the source state\n got: %s\nwant: %s", resp.TargetState.Raw, state.Raw)
+				}
+			})
+		}
+	})
+
+	// A resource can offer several movers and the framework tries them in turn,
+	// so a mover that doesn't recognise the source has to leave the response
+	// exactly as it found it. Returning an error here would fail a move another
+	// mover was going to take.
+	t.Run("skips a source resource type it does not know", func(t *testing.T) {
+		mover := renameStateMover("incident_schedule_beta", sourceSchema)
+		resp := testMoveStateResponse(ctx, sourceSchema)
+
+		mover.StateMover(ctx, resource.MoveStateRequest{
+			SourceTypeName: "incident_escalation_path_beta",
+			SourceState:    &state,
+		}, &resp)
+
+		if len(resp.Diagnostics) > 0 {
+			t.Errorf("expected no diagnostics, got %+v", resp.Diagnostics)
+		}
+		if !resp.TargetState.Raw.IsNull() {
+			t.Errorf("expected the target state to be left null, got %s", resp.TargetState.Raw)
+		}
+	})
+
+	t.Run("skips a source at a schema version it has never written", func(t *testing.T) {
+		mover := renameStateMover("incident_schedule_beta", sourceSchema)
+		resp := testMoveStateResponse(ctx, sourceSchema)
+
+		mover.StateMover(ctx, resource.MoveStateRequest{
+			SourceTypeName:      "incident_schedule_beta",
+			SourceSchemaVersion: 1, // the schema under test is version 0
+			SourceState:         &state,
+		}, &resp)
+
+		if len(resp.Diagnostics) > 0 {
+			t.Errorf("expected no diagnostics, got %+v", resp.Diagnostics)
+		}
+		if !resp.TargetState.Raw.IsNull() {
+			t.Errorf("expected the target state to be left null, got %s", resp.TargetState.Raw)
+		}
+	})
+
+	// The framework leaves SourceState nil when the state didn't decode against
+	// the schema we gave it, which for a rename should never happen: this is the
+	// case where it has, and the move must fail rather than half-happen.
+	t.Run("refuses a source whose state did not decode", func(t *testing.T) {
+		mover := renameStateMover("incident_schedule_beta", sourceSchema)
+		resp := testMoveStateResponse(ctx, sourceSchema)
+
+		mover.StateMover(ctx, resource.MoveStateRequest{
+			SourceTypeName: "incident_schedule_beta",
+			SourceState:    nil,
+		}, &resp)
+
+		if !resp.Diagnostics.HasError() {
+			t.Fatal("expected the move to be refused")
+		}
+		if !resp.TargetState.Raw.IsNull() {
+			t.Errorf("expected the target state to be left null, got %s", resp.TargetState.Raw)
+		}
+	})
+}
+
+// The mover describes the state it moves from with the schema it was given, so
+// that the framework decodes the source for it.
+func TestRenameStateMoverSourceSchema(t *testing.T) {
+	sourceSchema := testRenameSchema()
+	mover := renameStateMover("incident_schedule_beta", sourceSchema)
+
+	if mover.SourceSchema == nil {
+		t.Fatal("expected a source schema, so the framework populates SourceState")
+	}
+	if len(mover.SourceSchema.Attributes) != len(sourceSchema.Attributes) {
+		t.Errorf("expected the schema it was given, got %+v", mover.SourceSchema.Attributes)
+	}
+}
+
+// declaredResourceSchema is how a mover gets hold of the schema to describe itself
+// with, so it has to return the schema the resource actually declares.
+func TestDeclaredResourceSchema(t *testing.T) {
+	ctx := context.Background()
+
+	declared := declaredResourceSchema(ctx, NewIncidentScheduleBetaResource())
+
+	var direct resource.SchemaResponse
+	NewIncidentScheduleBetaResource().Schema(ctx, resource.SchemaRequest{}, &direct)
+
+	if len(declared.Attributes) == 0 {
+		t.Fatal("expected the resource's attributes")
+	}
+	if len(declared.Attributes) != len(direct.Schema.Attributes) {
+		t.Errorf("expected %d attributes, got %d", len(direct.Schema.Attributes), len(declared.Attributes))
+	}
+	if declared.Version != direct.Schema.Version {
+		t.Errorf("expected schema version %d, got %d", direct.Schema.Version, declared.Version)
+	}
+}


### PR DESCRIPTION
**1 of 6 in the v7 stack.** Opened as a draft: the release has two open questions on it, listed at the bottom.

v7 promotes the beta resources to the names they will keep, and a rename is a change of resource type as far as Terraform is concerned. Terraform will not move state across types on its own — it cannot know whether the two schemas are compatible, and guessing loses somebody's state — so it asks the provider through the `MoveResourceState` RPC, and errors out if the target resource has not implemented it.

This adds the mover every one of those renames wants. The schema either side of a rename is the same one, so the move is a copy: the target ends up holding exactly what the source held, and a plan run straight afterwards reports no changes. That turns each rename into a `moved` block in a pull request:

```hcl
moved {
  from = incident_schedule_beta.primary
  to   = incident_schedule.primary
}
```

rather than a `terraform state mv` per resource, which is the difference between a migration somebody can review and one they run by hand against production state.

A mover that does not recognise its source returns no state and no diagnostics, which the framework reads as "skipped": it tries the next mover, and if none take the move it reports an error naming both types. That is a better error than any we could write, so recognising the source is all this has to do. It is deliberately strict about the schema version — writing state we do not understand into the target is worse than refusing, because a practitioner can undo a refusal.

Nothing consumes this yet; the promotions that do are the rest of the stack. The table in the test lists all five renames so the mover is known to accept each name before the resource claiming it lands.

## Open questions for the release

1. **Do the old resources really go, or become `_legacy` for one major?** Reusing the plain names means anyone who upgrades before migrating has state under `incident_schedule` that v7 cannot read, refresh or forget — `terraform state rm` plus a fresh import is the only way out. The guide in PR 2 has a recovery section, but a `_legacy` name for one major would mean nobody hits it.
2. **`incident_schedule_replica` needs a layer ID the new rotation resource cannot give it.** Detail in the schedules PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)