### PR TITLE
Say that an escalation path's first plan is an update

### DIFF
--- a/docs/guides/migrating-to-v7.md
+++ b/docs/guides/migrating-to-v7.md
@@ -286,8 +286,9 @@ limit on branching is gone. A path too deep to write before can be written now.
 - A `repeat` node becomes a `loop`, which names the node to go `back_to`.
 - `working_hours`, `repeat_config` and `team_ids` are unchanged.
 
-Two things to expect in the first plan, both of which the example below is
-written to avoid.
+Three things to expect in the first plan. Two you can avoid, as the example below
+does; the third you cannot, and it is the one case in this guide where the first
+plan after an upgrade is not empty.
 
 The API does not store sequence names, so the refresh names them: the sequence
 the path starts with is `main`, and the sequences a branch leads to are
@@ -295,12 +296,23 @@ the path starts with is `main`, and the sequences a branch leads to are
 configuration that calls them something else plans a change - harmless, but
 noise you can do without on the plan you are reading carefully.
 
-And `ack_mode` on a level now defaults to `first` where the v6 resource defaulted
-it to `all`. A default applies wherever the configuration is silent, so a level
-that never set `ack_mode` plans a change from `all` to `first`, and applying it
+`ack_mode` on a level now defaults to `first` where the v6 resource defaulted it
+to `all`. A default applies wherever the configuration is silent, so a level that
+never set `ack_mode` plans a change from `all` to `first`, and applying it
 changes how the level pages: with `first`, the first person to acknowledge
 cancels everyone else's escalation on that level. Write `ack_mode = "all"` on
 every level whose behaviour you mean to keep.
+
+~> **Expect an update on the path itself, and read it before applying.** A node
+id is now derived from the node's position, and only ids in that form are treated
+as derived when the path is read back. v6 minted a random id for every node your
+configuration did not name, and those are what your escalation path holds, so
+they read back as ids you wrote against a configuration that never wrote one -
+and the plan proposes rewriting them. It changes nothing about how the path
+escalates: the levels, targets, conditions and working hours are untouched, and
+the nodes you *did* name keep their names, so a `loop` still finds what it loops
+back to. Apply it once and it settles. What to check before you do is that the
+plan touches ids and nothing else.
 
 ```terraform
 # Before: a branch holds the nodes that follow it, nested under then_path and
@@ -395,13 +407,20 @@ resource "incident_escalation_path" "urgent_support" {
   # are written to match, so the names are not something the first plan has to
   # reconcile. Rename them afterwards if you would rather they read better -
   # that is an update to your own state, not a change to the path.
+  #
+  # The first plan will still propose an update, for the node ids v6 minted for
+  # the nodes it wasn't told the names of. That one can't be written around: apply
+  # it once and it settles. See the guide.
   start = "main"
 
   sequences = {
     main = {
       nodes = [
         {
-          # Keep an id on the nodes something loops back to, and leave it off the rest.
+          # Keep an id on the nodes something loops back to, and leave it off the
+          # rest: an unnamed node gets one derived from its position, which is
+          # stable across applies. A node your v6 config named keeps its name, so
+          # this is the id a loop can still rely on after the upgrade.
           id = "start"
           branch = {
             # The raw engine condition becomes one attribute per thing an
@@ -720,6 +739,19 @@ happening at the same time.
 once, on an alert source: the API returns its own spelling of the document. Apply
 it and it settles. A plan that asks again after applying is a bug - please report
 it.
+
+**A plan asking to rewrite an escalation path's node ids.** Expected once, and
+covered above: v6 minted those ids, and they are not the form this resource
+derives. Applying it changes no behaviour.
+
+**`Failed to marshal state to json: unsupported attribute "path"`**, or the same
+for `rotations` or `template`. `terraform show -json` renders state against the
+provider's current schema, and until the first apply rewrites it your state still
+holds the attribute the old schema had. `terraform plan` and `terraform apply`
+are unaffected - it is only the JSON rendering that fails - so the fix is to
+apply the migration. It is worth knowing about if your pipeline reads plans as
+JSON, because that is the step that breaks between upgrading the provider and
+applying.
 
 ## Rolling back
 

--- a/examples/guides/migrating-to-v7/escalation-path-after.tf
+++ b/examples/guides/migrating-to-v7/escalation-path-after.tf
@@ -17,13 +17,20 @@ resource "incident_escalation_path" "urgent_support" {
   # are written to match, so the names are not something the first plan has to
   # reconcile. Rename them afterwards if you would rather they read better -
   # that is an update to your own state, not a change to the path.
+  #
+  # The first plan will still propose an update, for the node ids v6 minted for
+  # the nodes it wasn't told the names of. That one can't be written around: apply
+  # it once and it settles. See the guide.
   start = "main"
 
   sequences = {
     main = {
       nodes = [
         {
-          # Keep an id on the nodes something loops back to, and leave it off the rest.
+          # Keep an id on the nodes something loops back to, and leave it off the
+          # rest: an unnamed node gets one derived from its position, which is
+          # stable across applies. A node your v6 config named keeps its name, so
+          # this is the id a loop can still rely on after the upgrade.
           id = "start"
           branch = {
             # The raw engine condition becomes one attribute per thing an

--- a/templates/guides/migrating-to-v7.md.tmpl
+++ b/templates/guides/migrating-to-v7.md.tmpl
@@ -171,8 +171,9 @@ limit on branching is gone. A path too deep to write before can be written now.
 - A `repeat` node becomes a `loop`, which names the node to go `back_to`.
 - `working_hours`, `repeat_config` and `team_ids` are unchanged.
 
-Two things to expect in the first plan, both of which the example below is
-written to avoid.
+Three things to expect in the first plan. Two you can avoid, as the example below
+does; the third you cannot, and it is the one case in this guide where the first
+plan after an upgrade is not empty.
 
 The API does not store sequence names, so the refresh names them: the sequence
 the path starts with is `main`, and the sequences a branch leads to are
@@ -180,12 +181,23 @@ the path starts with is `main`, and the sequences a branch leads to are
 configuration that calls them something else plans a change - harmless, but
 noise you can do without on the plan you are reading carefully.
 
-And `ack_mode` on a level now defaults to `first` where the v6 resource defaulted
-it to `all`. A default applies wherever the configuration is silent, so a level
-that never set `ack_mode` plans a change from `all` to `first`, and applying it
+`ack_mode` on a level now defaults to `first` where the v6 resource defaulted it
+to `all`. A default applies wherever the configuration is silent, so a level that
+never set `ack_mode` plans a change from `all` to `first`, and applying it
 changes how the level pages: with `first`, the first person to acknowledge
 cancels everyone else's escalation on that level. Write `ack_mode = "all"` on
 every level whose behaviour you mean to keep.
+
+~> **Expect an update on the path itself, and read it before applying.** A node
+id is now derived from the node's position, and only ids in that form are treated
+as derived when the path is read back. v6 minted a random id for every node your
+configuration did not name, and those are what your escalation path holds, so
+they read back as ids you wrote against a configuration that never wrote one -
+and the plan proposes rewriting them. It changes nothing about how the path
+escalates: the levels, targets, conditions and working hours are untouched, and
+the nodes you *did* name keep their names, so a `loop` still finds what it loops
+back to. Apply it once and it settles. What to check before you do is that the
+plan touches ids and nothing else.
 
 {{ codefile "terraform" "examples/guides/migrating-to-v7/escalation-path-before.tf" }}
 
@@ -315,6 +327,19 @@ happening at the same time.
 once, on an alert source: the API returns its own spelling of the document. Apply
 it and it settles. A plan that asks again after applying is a bug - please report
 it.
+
+**A plan asking to rewrite an escalation path's node ids.** Expected once, and
+covered above: v6 minted those ids, and they are not the form this resource
+derives. Applying it changes no behaviour.
+
+**`Failed to marshal state to json: unsupported attribute "path"`**, or the same
+for `rotations` or `template`. `terraform show -json` renders state against the
+provider's current schema, and until the first apply rewrites it your state still
+holds the attribute the old schema had. `terraform plan` and `terraform apply`
+are unaffected - it is only the JSON rendering that fails - so the fix is to
+apply the migration. It is worth knowing about if your pipeline reads plans as
+JSON, because that is the step that breaks between upgrading the provider and
+applying.
 
 ## Rolling back
 


### PR DESCRIPTION
Correction to the guide merged in #573. Found by the acceptance test in #584 — which is the test doing its job on its first real run.

## The guide was wrong

It told people the first plan after rewriting a `path` as `sequences` would be empty, as long as they matched the sequence names and wrote out `ack_mode`. It isn't, and no configuration can make it be:

```
'incident_escalation_path.upgrading' - expected NoOp, got action(s): [update]
```

A node id is derived from the node's position in v7, and `sequenceKeyFromNodeID` only treats an id read back from the API as derived when it contains the separator we derive with. **v6 minted a random ULID for every node a configuration did not name** — `toPathPayload` filled an empty id with `ulid.Make()` — and those are what the escalation path holds. A ULID has no separator in it, so it reads back as an id the author wrote, against a configuration that never wrote one. Null in the plan, a ULID in state, an update.

It changes nothing about how the path escalates: levels, targets, conditions and working hours are untouched, and a node the old configuration *did* name keeps its name, so a `loop` still finds what it loops back to. One apply settles it.

The guide now says all of that, says what to check in that plan before applying it (that it touches ids and nothing else), and the example says which ids survive and which get rewritten.

## Second thing the same run turned up

`terraform show -json` renders state against the provider's current schema, so state that still holds a v6-only attribute cannot be rendered until the first apply rewrites it:

```
Failed to marshal state to json: unsupported attribute "path"
```

`plan` and `apply` are unaffected, which is why nothing noticed — but a pipeline that reads plans as JSON breaks in the window between upgrading the provider and applying. Now a troubleshooting entry rather than a surprise. I observed this for `path`; the mechanism is identical for `rotations` and `template`.

## Why this is a follow-up rather than a fix to #573

#573 merged while I was still diagnosing the CI failure on #584. No harm — the guide is right about everything else, and this is the one claim that needed retracting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example comments only; no provider or runtime behavior changes.
> 
> **Overview**
> Fixes the **Migrating to v7** guide after acceptance tests showed the first plan is not empty when rewriting `path` as `sequences`, even if sequence names and `ack_mode` match the examples.
> 
> The guide now lists **three** expected first-plan surprises (not two) and adds a callout that **unnamed node ids** from v6 (random ULIDs) must be rewritten to v7’s position-derived ids—behaviorally harmless, one apply to settle, with guidance to confirm the plan only touches ids. The after-example and template pick up matching comments on which ids survive and that the id update cannot be avoided.
> 
> **Troubleshooting** gains entries for escalation path node-id updates and for **`terraform show -json`** failing with `unsupported attribute "path"` (or `rotations` / `template`) until the first migration apply, while `plan`/`apply` still work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a589b5595ecdece0cb1800a90329c4ff85ca3ca9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->