### PR TITLE
Changelog for v7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## v7.0.0
 
 - **Breaking**: the beta resources lose their `_beta` suffix. `incident_alert_source`, `incident_alert_source_attribute`, `incident_escalation_path`, `incident_schedule` and `incident_schedule_rotation` are now what the `_beta` resources were, and the v6 resources of those names are removed.
 - The `_beta` names still work, so upgrading changes nothing if you were using them. They warn on every plan and go in v8; rename one with a `moved` block whenever you like.


### PR DESCRIPTION
The v7 entries are all in, so the section they sit under is no longer unreleased. This renames `## Unreleased` to `## v7.0.0` and nothing else — the same one-line cut [#582](https://github.com/incident-io/terraform-provider-incident/pull/582) did for v6.13.0.

Stacked on #587, so the base is `v7-drop-plural-data-sources`. That PR adds the last of the v7 entries (removing the plural data sources); merge it first and this one retargets to `master` on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only header rename with no provider or behavioral changes.
> 
> **Overview**
> **Releases the v7 changelog** by renaming the top-level section from `## Unreleased` to `## v7.0.0` in `CHANGELOG.md`.
> 
> No bullet text or other files change in this PR—the v7.0.0 notes were already under Unreleased; this is the same cut used for prior releases (e.g. v6.13.0).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89e0f83e65c6a5f8396f60bf81e815dafb0f157b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->